### PR TITLE
Switch /feed/get to only require read API key

### DIFF
--- a/Modules/feed/feed_controller.php
+++ b/Modules/feed/feed_controller.php
@@ -82,7 +82,7 @@
       }
     }
 
-    elseif ($action == 'get' && $session['write'])
+    elseif ($action == 'get' && $session['read'])
     {
       $feedid = intval($_GET['id']);
       if (feed_belongs_user($feedid,$session['userid']))


### PR DESCRIPTION
Currently /feed/get requires the write API key. This change makes the read API key suffice.
