### PR TITLE
Small Fix for issue #42 Cannot create user

### DIFF
--- a/Modules/user/user_model.php
+++ b/Modules/user/user_model.php
@@ -148,8 +148,10 @@ class User
         $apikey_write = md5(uniqid(mt_rand(), true));
         $apikey_read = md5(uniqid(mt_rand(), true));
 
-        $this->mysqli->query("INSERT INTO users ( username, password, email, salt ,apikey_read, apikey_write ) VALUES ( '$username' , '$hash', '$email', '$salt', '$apikey_read', '$apikey_write' );");
-
+        if (!$this->mysqli->query("INSERT INTO users ( username, password, email, salt ,apikey_read, apikey_write, uphits, dnhits, admin ) VALUES ( '$username' , '$hash', '$email', '$salt', '$apikey_read', '$apikey_write', 0 , 0, 0 );")) {
+        	return array('success'=>false, 'message'=>_("Error creating user"));
+        }
+        
         // Make the first user an admin
         $userid = $this->mysqli->insert_id;
         if ($userid == 1) $this->mysqli->query("UPDATE users SET admin = 1 WHERE id = '1'");


### PR DESCRIPTION
 I figured out, the INSERT statement is wrong, because there are 3 missing fields in the dev branch.

uphits, dnhits, admin are "Not Null" database fields.

Hint:
Maybe in a existing installation, the update function does not the correct alter table, so the 
bug is only pressent on a new installation, but I am not sure.
