### PR TITLE
vague login error fix

### DIFF
--- a/Modules/user/user_model.php
+++ b/Modules/user/user_model.php
@@ -183,7 +183,7 @@ class User
 
         if ($hash != $userData->password) 
         {
-            return array('success'=>false, 'message'=>_("Incorrect password, if your sure its correct try clearing your browser cache"));
+            return array('success'=>false, 'message'=>_("Incorrect username or password. If you're sure it's correct, try clearing your browser's cache."));
         }
         else
         {


### PR DESCRIPTION
Tonight, I accidentally entered an incorrect password when logging into emoncms. I noticed the error message said that the password was incorrect.

In my reading on creating login systems, I've read it's good practice to provide a vague error message stating that the username or password is incorrect, for security purposes.

I've change the login error message and thought it might be useful to incorporate into the master branch. Feel free to change the message to another state of vagueness if you'd like. I just wanted to bring it to attention.
