### PR TITLE
Vague error message for wrong username

### DIFF
--- a/Modules/user/user_model.php
+++ b/Modules/user/user_model.php
@@ -176,14 +176,16 @@ class User
 
         $result = $this->mysqli->query("SELECT id,password,admin,salt,language FROM users WHERE username = '$username'");
 
-        if ($result->num_rows < 1) return array('success'=>false, 'message'=>_("Incorrect username or password. If you're sure it's correct, try clearing your browser's cache."));
+        $login_error_message = _("Incorrect username or password. If you're sure it's correct, try clearing your browser's cache.");
+
+        if ($result->num_rows < 1) return array('success'=>false, 'message'=>$login_error_message);
      
         $userData = $result->fetch_object();
         $hash = hash('sha256', $userData->salt . hash('sha256', $password));
 
         if ($hash != $userData->password) 
         {
-            return array('success'=>false, 'message'=>_("Incorrect username or password. If you're sure it's correct, try clearing your browser's cache."));
+            return array('success'=>false, 'message'=>$login_error_message);
         }
         else
         {


### PR DESCRIPTION
This is a complement to https://github.com/emoncms/emoncms/pull/51

The message needs to be vague for both password and username for it to be useful.

Anyway, any account with a public dashboard is a known username (perhaps this could be changed as well by adding the possibility to create custom path dashboards, but is this worth doing ?).
