### PR TITLE
Long rawdata visualization load times

### DIFF
--- a/Modules/feed/feed_model.php
+++ b/Modules/feed/feed_model.php
@@ -354,22 +354,20 @@ class Feed
     if (($end - $start) > (5000) && $dp>0) //why 5000?
     {
       $range = $end - $start;
-      $td = $range / $dp;
-
-      for ($i=0; $i<$dp; $i++)
-      {
-        $t = $start + $i*$td;
-        $tb = $start + ($i+1)*$td;
-        $result = $this->mysqli->query("SELECT * FROM $feedname WHERE `time` >$t AND `time` <$tb LIMIT 1");
-
-        if($result){
-          $row = $result->fetch_array();
-          $dataValue = $row['data'];               
+      $td = intval($range / $dp);
+      $result = $this->mysqli->query(
+        "SELECT FLOOR(time/$td) AS `time`, AVG(data) AS `data`".
+        " FROM $feedname".
+        " WHERE `time` > $start AND `time` < $end".
+        " GROUP BY 1");
+      if($result) {
+        while($row = $result->fetch_array()) {
+          $dataValue = $row['data'];
           if ($dataValue!=NULL) { // Remove this to show white space gaps in graph      
-            $time = $row['time'] * 1000;     
+            $time = $row['time'] * 1000 * $td;  
             $data[] = array($time , $dataValue); 
-          } 
-        }         
+          }
+        }
       }
     } else {
       $result = $this->mysqli->query("select * from $feedname WHERE time>$start AND time<$end order by time Desc");


### PR DESCRIPTION
My emoncms is on a machine that doesn't have mysql on it, on account of it being flash media that can't take the update frequency my plug monitors put out (once every 10 seconds per plug, 4 plugs so far). When adding a rawdata visualization, the browser spins for over _13 seconds_ to load the graph. Adding just a few graphs or a multigraph was making the page minutes to load.

I turned on some SQL tracing and saw that the Feed model was making 1,000 calls to the database to quantize the data, one for each datapoint. The data it was returning was also incorrect on account of it just pulls 1 random sample from each quantization with may massively misrepresent the value of the dataset.

What I've done is modified the class to push the work off onto the mysql server and have it return a dataset which averages the data for each interval. This reduced the load time from 13 seconds to 0.175s. This may not be viable for massive datasets but I don't have a database with millions of rows to test with.
