### PR TITLE
route path setting cleanup

### DIFF
--- a/default.settings.php
+++ b/default.settings.php
@@ -16,9 +16,6 @@
   Default router settings - in absence of stated path
 
   */
-  
-  //The sites application root if run in a sub directory e.g. domain.com/emoncms
-  define('APPLICATION_ROOT', str_replace($_SERVER['DOCUMENT_ROOT'], '', realpath(dirname(__FILE__))));
 
   // Default controller and action if none are specified and user is anonymous
   $default_controller = "user";

--- a/route.php
+++ b/route.php
@@ -30,7 +30,7 @@ class Route
     public function decode($q)
     {
         // filter out the applications root to prevent invalid route-parsing
-        $q = str_replace(APPLICATION_ROOT, '', $q);
+        $q = str_replace(dirname(server('SCRIPT_NAME')), '', $q);
         $q = trim($q, '/');
 	
         // filter out all except a-z and / .


### PR DESCRIPTION
Some users have problems because they don't notice that the default settings have changed, in a previous merge. This commit removes the APPLICATION_ROOT define in settings and uses a core function to extract sub-directory through $_SERVER['SCRIPT_NAME'] instead.

This also makes the code follow the projects code standard a bit more too.
