### PR TITLE
Fixed dashboard height error + login label

### DIFF
--- a/Modules/dashboard/Views/dashboard_edit_view.php
+++ b/Modules/dashboard/Views/dashboard_edit_view.php
@@ -56,7 +56,6 @@ if (!$dashboard['height']) $dashboard['height'] = 400;
 <script type="application/javascript">
 
   var dashid = <?php echo $dashboard['id']; ?>;
-  var page_height = "<?php echo $dashboard['height']; ?>";
   var path = "<?php echo $path; ?>";
   var apikey = "";
   var feedlist = feed.list();
@@ -90,16 +89,22 @@ if (!$dashboard['height']) $dashboard['height'] = 400;
   setInterval(function() { update(); }, 10000);
   setInterval(function() { fast_update(); }, 30);
 
+  
   $("#save-dashboard").click(function (){
+    //recalculate the height so the page_height is shrunk to the minimum but still wrapping all components
+    //otherwise a user can drag a component far down then up again and a too high value will be stored to db.
+    designer.page_height = 0;
+    designer.scan(); 
     $.ajax({
       type: "POST",
       url :  path+"dashboard/setcontent.json",
-      data : "&id="+dashid+'&content='+encodeURIComponent($("#page").html())+'&height='+page_height,
+      data : "&id="+dashid+'&content='+encodeURIComponent($("#page").html())+'&height='+designer.page_height,
       dataType: 'json',
       success : function(data) { console.log(data); if (data.success==true) $("#save-dashboard").attr('class','btn btn-success').text('<?php echo _("Saved") ?>');
       } 
     });
   });
+  
 
   $(window).resize(function(){
     designer.draw();

--- a/Modules/user/login_block.php
+++ b/Modules/user/login_block.php
@@ -49,7 +49,7 @@ global $path, $allowusersregister, $enable_rememberme;
       <div id="error" class="alert alert-error" style="display:none;"></div>
 
       <p class="login-item">
-        <?php if ($enable_rememberme) { ?><input type="checkbox" tabindex="5" id="rememberme" value="1" name="rememberme"><?php echo '&nbsp;'._('Remember me'); ?><br><br><?php } ?>
+        <?php if ($enable_rememberme) { ?><label class="checkbox"><input type="checkbox" tabindex="5" id="rememberme" value="1" name="rememberme"><?php echo '&nbsp;'._('Remember me'); ?></label><br /><?php } ?>
         <button id="login" class="btn btn-primary" tabindex="6" type="button"><?php echo _('Login'); ?></button> 
         <?php if ($allowusersregister) { echo '&nbsp;'._('or').'&nbsp' ?><a id="register-link"  href="#"><?php echo _('register'); ?></a><?php } ?>
       </p>


### PR DESCRIPTION
The page_height variable was never changed, the designer.page_height
was, thus when saving a dashboard the designer.scan() => computed page
height was not passed to the save method since it only used the old
value again.

This bug was reported by Paul Reed over at the forums here (illustrated
with a large blue arrow): http://openenergymonitor.org/emon/node/2013

Changed so it uses the designer.page_height variable instead.

This fix also makes the "Remember me" text a label around the checkbox
according to ui/ux web standards the label should be clickable (alot easier on smart-phones to click the text and not having to target the checkbox with your too fat fingers :)). The
bootstrap default style was used for this. (see
http://twitter.github.io/bootstrap/base-css.html#forms)
