### PR TITLE
New input process: signed to unsigned

### DIFF
--- a/Lib/tablejs/custom-table-fields.js
+++ b/Lib/tablejs/custom-table-fields.js
@@ -113,8 +113,16 @@ var customtablefields = {
                 key = '- inp'; type = 1; break;
               case 23:
                 key = 'kwhkwhd'; type = 2; break;
+              case 24:
+                key = '> 0'; type = 3; break;
+              case 25:
+                key = '< 0'; type = 3; break;
+              case 26:
+                key = 'unsign'; type = 3; break;
             }  
 
+            value = keyvalue[1];
+            
             switch(type)
             {
               case 0:
@@ -126,13 +134,16 @@ var customtablefields = {
               case 2:
                 type = 'feed: '; color = 'info';
                 break;
+              case 3:
+                type = ''; color = 'important';
+                value = '' // Argument type is NONE, we don't mind the value
+                break;
             }
 
-
             if (type == 'feed: ') { 
-              out += "<a href='"+path+"vis/auto?feedid="+keyvalue[1]+"'<span class='label label-"+color+"' title='"+type+keyvalue[1]+"' style='cursor:pointer'>"+key+"</span></a> "; 
+              out += "<a href='"+path+"vis/auto?feedid="+value+"'<span class='label label-"+color+"' title='"+type+value+"' style='cursor:pointer'>"+key+"</span></a> "; 
             } else {
-              out += "<span class='label label-"+color+"' title='"+type+keyvalue[1]+"' style='cursor:default'>"+key+"</span> ";
+              out += "<span class='label label-"+color+"' title='"+type+value+"' style='cursor:default'>"+key+"</span> ";
             }
           }
           

--- a/Modules/input/input_controller.php
+++ b/Modules/input/input_controller.php
@@ -16,6 +16,7 @@
     const VALUE = 0;
     const INPUTID = 1;
     const FEEDID = 2;
+    const NONE = 3;
   }
 
   class DataType {

--- a/Modules/input/input_model.php
+++ b/Modules/input/input_model.php
@@ -113,6 +113,10 @@ class Input
                     if ($result['success']==true) $arg = $result['feedid']; else return $result;
                 }
                 break;
+            case ProcessArg::NONE:                                           // If arg type none
+                $arg = 0;
+                $id = $arg;
+                break;
         }
 
         $list = $this->get_processlist($inputid);

--- a/Modules/input/process_model.php
+++ b/Modules/input/process_model.php
@@ -202,21 +202,29 @@ class Process
       );
 
       $list[24] = array(
-        "allow positive (set arg = 1)",
-        ProcessArg::VALUE,
+        "allow positive",
+        ProcessArg::NONE,
         "allowpositive",
         0,
         DataType::UNDEFINED
       );
 
       $list[25] = array(
-        "allow negative (set arg = 1)",
-        ProcessArg::VALUE,
+        "allow negative",
+        ProcessArg::NONE,
         "allownegative",
         0,
         DataType::UNDEFINED
       );
 
+      $list[26] = array(
+        "signed to unsigned",
+        ProcessArg::NONE,
+        "signed2unsigned",
+        0,
+        DataType::UNDEFINED
+      );
+      
       return $list;
     }
 
@@ -269,6 +277,12 @@ class Process
       return $value;
     }
 
+    public function signed2unsigned($arg, $time, $value)
+    {
+      if($value < 0) $value = $value + 65536;
+      return $value;
+    }
+    
     public function log_to_feed($id, $time, $value)
     {
       $this->feed->insert_data($id, $time, $time, $value);


### PR DESCRIPTION
Unsigns a value received as signed. This allows for the recombination
of longs transmitted as signed ints.

This commit creates arg type None, for input processes that don't need
any argument, like this one, or allow positive / negative.

I think this addresses this issue: http://openenergymonitor.org/emon/node/1964

Please review, at least the change in input_model.php. It seems to work here, but perhaps could it be simplified.
