### PR TITLE
Enables negative numbers to display to correct decimal places in table

### DIFF
--- a/Lib/tablejs/custom-table-fields.js
+++ b/Lib/tablejs/custom-table-fields.js
@@ -199,8 +199,10 @@ function list_format_updated(time)
 // Format value dynamically 
 function list_format_value(value)
 {
-  if (value>10) value = (1*value).toFixed(1);
-  if (value>100) value = (1*value).toFixed(0);
+  if (value>=10) value = (1*value).toFixed(1);
+  if (value>=100) value = (1*value).toFixed(0);
   if (value<10) value = (1*value).toFixed(2);
+  if (value<=-10) value = (1*value).toFixed(1);
+  if (value<=-100) value = (1*value).toFixed(0);
   return value;
 }


### PR DESCRIPTION
1) More people are now using emoncms to log import AND export of power, which can involve negative power data as well as positive. This change enables 'negative value' data to display to the correct number of decimal places in the Feeds table, in pretty much the same way as 'positive' feed data is displayed.
2) Corrects number of decimal places if data is exactly 10 or 100.

Paul

Original code;
![original table screenprint](https://f.cloud.github.com/assets/973580/1141276/fdfad71e-1cb0-11e3-9f91-01a4665e3db4.png)
With this fix applied;
![with fix applied](https://f.cloud.github.com/assets/973580/1141277/fe16050c-1cb0-11e3-81da-0a615155898f.png)
