### PR TITLE
Add offset parameter to bulk send.

### DIFF
--- a/Modules/input/Views/input_api.php
+++ b/Modules/input/Views/input_api.php
@@ -36,14 +36,19 @@
 
 <p><b><?php echo _('Bulk data'); ?></b>
 <table class="table">
-  <tr><td><?php echo _('You can provide data using bulk mode'); ?></td><td><a href="<?php echo $path; ?>input/bulk.json?data=[[0,10,250,100,20],[2,12,1437,3164],[10,10,252,80,21]]&offset=-60"><?php echo $path; ?>input/bulk.json?data=[[0,10,250,100,20],[2,12,1437,3164],[10,10,252,80,21]]&offset=-60</a></td></tr>
+  <tr><td><?php echo _('You can provide data using bulk mode'); ?></td><td><a href="<?php echo $path; ?>input/bulk.json?data=[[0,16,1137],[2,17,1437,3164],[4,19,1412,3077]]"><?php echo $path; ?>input/bulk.json?data=[[0,16,1137],[2,17,1437,3164],[4,19,1412,3077]]</a></td></tr>
 </table>
 <ul>
-  <li><?php echo _('The first number of each node is the time offset, so for the first node it is 0 which means the packet for the first node arrived at 0 seconds. The second node arrived at 2 seconds and 3rd 10 seconds.'); ?></li>
+  <li><?php echo _('The first number of each node is the time offset (see below).'); ?></li>
   <li><?php echo _('The second number is the node id, this is the unique identifer for the wireless node.'); ?></li>
-  <li><?php echo _('All the numbers after the first two are data values. The first node here (node 10) has three data values: 250,100 and 20.'); ?></li>  
-  <li><?php echo _('The optional offset=-60 parameter means that the last packet was received 60 seconds before the json command was sent.'); ?></li>  
+  <li><?php echo _('All the numbers after the first two are data values. The second node here (node 17) has two data values: 1437 and 3164.'); ?></li>
+  <li><?php echo _('Optional offset and time parameters allow the sender to set the time reference for the packets. If none is specified, it is assumed that the last packet just arrived. The time for the other packets is then calculated accordingly.'); ?></li>
 </ul>
+<table class="table">
+  <tr><td><?php echo _('Legacy default format (4 is now, 2 is -2 seconds and 0 is -4 seconds to now):'); ?></td><td><a href="<?php echo $path; ?>input/bulk.json?data=[[0,16,1137],[2,17,1437,3164],[4,19,1412,3077]]"><?php echo $path; ?>input/bulk.json?data=[[0,16,1137],[2,17,1437,3164],[4,19,1412,3077]]</a></td></tr>
+  <tr><td><?php echo _('Time offset format (-6 is -16 seconds to now):'); ?></td><td><a href="<?php echo $path; ?>input/bulk.json?data=[[-10,16,1137],[-8,17,1437,3164],[-6,19,1412,3077]]&offset=-10"><?php echo $path; ?>input/bulk.json?data=[[-10,16,1137],[-8,17,1437,3164],[-6,19,1412,3077]]<b>&offset=-10</b></a></td></tr>
+  <tr><td><?php echo _('Absolute time format (-6 is 1387730121 seconds since 1970-01-01 00:00:00 UTC))'); ?></td><td><a href="<?php echo $path; ?>input/bulk.json?data=[[-10,16,1137],[-8,17,1437,3164],[-6,19,1412,3077]]&time=1387730127"><?php echo $path; ?>input/bulk.json?data=[[-10,16,1137],[-8,17,1437,3164],[-6,19,1412,3077]]<b>&time=1387730127</b></a></td></tr>
+</table>
 
 <br>
 <p><b><?php echo _('Input actions'); ?></b>

--- a/Modules/input/input_controller.php
+++ b/Modules/input/input_controller.php
@@ -51,21 +51,35 @@ function input_controller()
   {
       /*
         
-        input/bulk.json?data=[[0,16,1137],[2,17,1437,3164],[4,19,1412,3077]]&offset=-60
+        input/bulk.json?data=[[0,16,1137],[2,17,1437,3164],[4,19,1412,3077]]
 
-        Parameters:
-
-        - data:	
-
-        The first number of each node is the time offset, so for the first node it is 0 which means the packet for the first node arrived at 0 seconds. The second node arrived at 2 seconds and 3rd 4 seconds. 
+        The first number of each node is the time offset (see below).
 
         The second number is the node id, this is the unique identifer for the wireless node. 
 
         All the numbers after the first two are data values. The first node here (node 16) has only one data value: 1137. 
 
-        - offset:
+        Optional offset and time parameters allow the sender to set the time 
+        reference for the packets. 
+        
+        If none is specified, it is assumed that the last packet just arrived.
+        The time for the other packets is then calculated accordingly.
 
-        The optional offset=-60 parameter means that the last packet was received 60 seconds before the json command was sent.        
+        offset=-10 means the time of each packet is relative to [now -10 s].
+        
+        time=1387730127 means the time of each packet is relative to 1387730127
+        (number of seconds since 1970-01-01 00:00:00 UTC)
+
+        Examples:
+        
+        // legacy mode: 4 is 0, 2 is -2 and 0 is -4 seconds to now.
+        input/bulk.json?data=[[0,16,1137],[2,17,1437,3164],[4,19,1412,3077]] 
+        
+        // offset mode: -6 is -16 seconds to now.
+        input/bulk.json?data=[[-10,16,1137],[-8,17,1437,3164],[-6,19,1412,3077]]&offset=-10
+        
+        // time mode: -6 is 1387730121
+        input/bulk.json?data=[[-10,16,1137],[-8,17,1437,3164],[-6,19,1412,3077]]&time=1387730127 
 
       */
 
@@ -89,12 +103,24 @@ function input_controller()
         {
           if (isset($data[$len-1][0])) 
           {
+	    
+            // Get optional time reference parameters
+            $offset = json_decode(get('offset'));
+            $time = json_decode(get('time'));
             
-	    $offset = json_decode(get('offset'));
-            if ($offset === NULL) { $offset = 0; }
+            // Offset mode: input/bulk.json?data=[[-10,16,1137],[-8,17,1437,3164],[-6,19,1412,3077]]&offset=-10
+            if ($offset !== NULL) {
+                $time_ref = time() + (int) $offset;
+            }
+            // Time mode: input/bulk.json?data=[[-10,16,1137],[-8,17,1437,3164],[-6,19,1412,3077]]&time=1387729425
+            elseif ($time !== NULL) {
+                $time_ref = (int) $time;
+            }
+            // Legacy mode: input/bulk.json?data=[[0,16,1137],[2,17,1437,3164],[4,19,1412,3077]]
+            else {
+                $time_ref = time() - (int) $data[$len-1][0];
+            }
 
-            $time_ref = time() - (int) $data[$len-1][0] + (int) $offset;
-     
             foreach ($data as $item)
             {
               if (count($item)>1)


### PR DESCRIPTION
Hi.

This adds an offset parameter to the bulk send command.

It allows an emonBase to send batches of data packets not just after receiving the last packet.

Use cases:
- Delay in the gateway software, for whatever reason, causing the json send to be delayed a few seconds.
- Data resent 10 seconds later after a http timeout.
- Sending data buffered during a network downtime. 

This offset parameter is optional so no existing setup should be broken.
