### PR TITLE
Update readme.md (install php5-json)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -122,6 +122,7 @@ When installing mysql and the blue dialog appears enter a password for root user
     $ sudo apt-get install php5 libapache2-mod-php5
     $ sudo apt-get install php5-mysql  
     $ sudo apt-get install php5-curl
+    $ sudo apt-get install php5-json
     
 ## 3) Enable mod rewrite
 


### PR DESCRIPTION
By default, json_encode() isn't available in Ubuntu 13.10's php5 package. You need to separately install `php5-json`.
