### PR TITLE
Option to set decimal places in feedvalue widget

### DIFF
--- a/Modules/dashboard/Views/js/widgets/feedvalue/feedvalue_render.js
+++ b/Modules/dashboard/Views/js/widgets/feedvalue/feedvalue_render.js
@@ -37,19 +37,19 @@ function feedvalue_widgetlist()
   };
 
   var decimalsDropBoxOptions = [        // Options for the type combobox. Each item is [typeID, "description"]
-         [-1,   "Automatic"],
-	 [0,    "0"],
-         [1,    "1"],
-         [2,    "2"],
-         [3,    "3"],
-         [4,    "4"],
-         [5,    "5"],
-         [6,    "6"]
-       ];
+		[-1,   "Automatic"],
+		[0,    "0"],
+		[1,    "1"],
+		[2,    "2"],
+		[3,    "3"],
+		[4,    "4"],
+		[5,    "5"],
+		[6,    "6"]
+	];
 
-  addOption(widgets["feedvalue"], "feedname",   "feed",    _Tr("Feed"),     _Tr("Feed value"),                                                            []);
-  addOption(widgets["feedvalue"], "units",      "value",   _Tr("Units"),    _Tr("Units to show"),                                                     []);
-  addOption(widgets["feedvalue"], "decimals",   "dropbox", _Tr("Decimals"), _Tr("Decimals to show"),                                                          decimalsDropBoxOptions);
+  addOption(widgets["feedvalue"], "feedname",   "feed",    _Tr("Feed"),     _Tr("Feed value"),		[]);
+  addOption(widgets["feedvalue"], "units",      "value",   _Tr("Units"),    _Tr("Units to show"),	[]);
+  addOption(widgets["feedvalue"], "decimals",   "dropbox", _Tr("Decimals"), _Tr("Decimals to show"),	decimalsDropBoxOptions);
 
   return widgets;
 }


### PR DESCRIPTION
Sometimes its handy to be able to control the number of decimal places in a feed value (ie. it is often unnecessary to display temperature with two decimal places, also when temp is between >-10 and <10). This update makes it possible to set the number of decimals or to fall-back to the automatic original method. It is transparent for users of the current version.
