### PR TITLE
Tighten up logging initialisation

### DIFF
--- a/Modules/log/EmonLogger.php
+++ b/Modules/log/EmonLogger.php
@@ -20,16 +20,27 @@ if (LOG4PHP_INSTALLED)
 class EmonLogger
 {
     private $concreteLogger;
-
+    private $loggerConfigured = false;
+    
     public function __construct($clientFileName)
     {
-        $clientFileNameWithoutPath = basename($clientFileName);
-        if (LOG4PHP_INSTALLED)
+        global $log4php_configPath;
+        if (!$log4php_configPath || !file_exists($log4php_configPath)){
+            $this->loggerConfigured = false;
+            return;
+        }
+        
+        
+        if (LOG4PHP_INSTALLED){
+            Logger::configure( $log4php_configPath );
+            $clientFileNameWithoutPath = basename($clientFileName);
             $this->concreteLogger = Logger::getLogger($clientFileNameWithoutPath);
+            $this->loggerConfigured = true;
+        }
     }
 
     public function info ($message){
-        if (LOG4PHP_INSTALLED)
+        if ($this->loggerConfigured)
             $this->concreteLogger->info($message);
     }
 }


### PR DESCRIPTION
Hi,

At some point in the last couple of versions I realised the logging wasn't that robust at initialisation when the filesystem wasn't set up properly.

This commit tightens that up by properly checking global config and not allowing the logger to fall back to ConsoleAppender (i.e. output to screen) in the absence of proper config data.
