### PR TITLE
Removed database password contents check

### DIFF
--- a/process_settings.php
+++ b/process_settings.php
@@ -17,13 +17,13 @@ require_once('Lib/enum.php');
 // Check if settings.php file exists
 if(file_exists(dirname(__FILE__)."/settings.php"))
 {
-    // Load settigs.php
+    // Load settings.php
     require_once('settings.php');
 
     $error_out = "";
     
     if (!isset($username) || $username=="") $error_out .= '<p>missing setting: $username</p>';
-    if (!isset($password) || $password=="") $error_out .= '<p>missing setting: $password</p>';
+    if (!isset($password)) $error_out .= '<p>missing setting: $password</p>';
     if (!isset($server) || $server=="") $error_out .= '<p>missing setting: $server</p>';
     if (!isset($database) || $database=="") $error_out .= '<p>missing setting: $database</p>';
     if ($enable_password_reset && !isset($smtp_email_settings)) $error_out .= '<p>missing setting: $smtp_email_settings</p>';


### PR DESCRIPTION
When developing locally in an environment such as XAMPP the root password isn't set on the database and thus password body check fails. I guess this is in to prevent what originally shipped which was an empty variable which now has been changed to `_DB_PASSWORD_`.

However, if you feel otherwise and do not agree with the change feel free to reject.
