### PR TITLE
Fix 'Use today' kwh in myelectric for mysql timeseries engine

### DIFF
--- a/Modules/feed/engine/MysqlTimeSeries.php
+++ b/Modules/feed/engine/MysqlTimeSeries.php
@@ -104,7 +104,7 @@ class MysqlTimeSeries
                 $td = intval($range / $dp);
                 $sql = "SELECT FLOOR(time/$td) AS time, AVG(data) AS data".
                     " FROM $feedname WHERE time BETWEEN $start AND $end".
-                    " ORDER BY time ASC GROUP BY 1";
+                    " GROUP BY 1 ORDER BY time ASC";
             } else {
                 $td = 1;
                 $sql = "SELECT time, data FROM $feedname".
@@ -300,7 +300,7 @@ class MysqlTimeSeries
                 $td = intval($range / $dp);
                 $sql = "SELECT FLOOR(time/$td) AS time, AVG(data) AS data".
                     " FROM $feedname WHERE time BETWEEN $start AND $end".
-                    " ORDER BY time ASC GROUP BY 1";
+                    " GROUP BY 1 ORDER BY time ASC";
             } else {
                 $td = 1;
                 $sql = "SELECT time, data FROM $feedname".


### PR DESCRIPTION
I tried to make a post about it on the forums [Issues with MyElectric](http://openenergymonitor.org/emon/node/4887) thread but it went off to the moderation gods. This patch resolves one of the issues reported where 'Use today' reports data for the leftmost bar instead of the rightmost.

The long and the short is myelectric expects the feed data to be in time order, as other engines are. However, mysqltimestore feeds are mostly unsorted and the one that is is sorted descending. This patch adjust the sort order so they are all ascending. I don't think any other bit of code relies on the order of feed data being descending.
