### PR TITLE
processList==null issue correction

### DIFF
--- a/Modules/input/Views/input_view.php
+++ b/Modules/input/Views/input_view.php
@@ -200,7 +200,7 @@ input[type="text"] {
         processlist_ui.inputid = i.id;
         
         var processlist = [];
-        if (i.processList!="")
+        if (i.processList!=null && i.processList!="")
         {
             var tmp = i.processList.split(",");
             for (n in tmp)


### PR DESCRIPTION
i.processList!="" results true (Safari/Chrome on Mac, not tested on another system) when input processList==null (on newly added input)
Added explicit check for ==null
