### PR TITLE
Disable thousands separator in csv_export

### DIFF
--- a/Modules/feed/engine/MysqlTimeSeries.php
+++ b/Modules/feed/engine/MysqlTimeSeries.php
@@ -243,6 +243,10 @@ class MysqlTimeSeries
     
     public function csv_export($feedid,$start,$end,$outinterval)
     {
+        global $csv_decimal_places;
+        global $csv_decimal_place_separator;
+        global $csv_field_separator;
+
         //echo $feedid;
         $outinterval = intval($outinterval);
         $feedid = intval($feedid);
@@ -289,7 +293,7 @@ class MysqlTimeSeries
                 if ($stmt->fetch()) {
                     if ($dataValue!=NULL) { // Remove this to show white space gaps in graph
                         $time = $dataTime * 1000;
-                        fwrite($exportfh, $dataTime.",".number_format($dataValue,2,'.','')."\n");
+                        fwrite($exportfh, $dataTime.$csv_field_separator.number_format($dataValue,$csv_decimal_places,$csv_decimal_place_separator,'')."\n");
                     }
                 }
                 $t = $tb;
@@ -313,7 +317,7 @@ class MysqlTimeSeries
                     $dataValue = $row['data'];
                     if ($dataValue!=NULL) { // Remove this to show white space gaps in graph
                         $time = $row['time'] * 1000 * $td;
-                        fwrite($exportfh, $dataTime.",".number_format($dataValue,2,'.','')."\n");
+                        fwrite($exportfh, $dataTime.$csv_field_separator.number_format($dataValue,$csv_decimal_places,$csv_decimal_place_separator,'')."\n");
                     }
                 }
             }

--- a/Modules/feed/engine/PHPFina.php
+++ b/Modules/feed/engine/PHPFina.php
@@ -431,6 +431,10 @@ class PHPFina
     
     public function csv_export($id,$start,$end,$outinterval)
     {
+        global $csv_decimal_places;
+        global $csv_decimal_place_separator;
+        global $csv_field_separator;
+
         $id = intval($id);
         $start = intval($start);
         $end = intval($end);
@@ -501,7 +505,7 @@ class PHPFina
             $time = $meta->start_time + $pos * $meta->interval;
 
             // add to the data array if its not a nan value
-            if (!is_nan($val[1])) fwrite($exportfh, $time.",".number_format($val[1],2,'.','')."\n");
+            if (!is_nan($val[1])) fwrite($exportfh, $time.$csv_field_separator.number_format($val[1],$csv_decimal_places,$csv_decimal_place_separator,'')."\n");
 
             $i++;
         }

--- a/Modules/feed/engine/PHPFiwa.php
+++ b/Modules/feed/engine/PHPFiwa.php
@@ -785,6 +785,10 @@ class PHPFiwa
     
     public function csv_export($feedid,$start,$end,$outinterval)
     {
+        global $csv_decimal_places;
+        global $csv_decimal_place_separator;
+        global $csv_field_separator;
+
         $feedid = (int) $feedid;
         $start = (int) $start;
         $end = (int) $end;
@@ -881,7 +885,7 @@ class PHPFiwa
                 $average = $point_sum / $points_in_sum;
                 //$data[] = array($timestamp*1000,$average);
                 
-                fwrite($exportfh, $timestamp.",".number_format($average,2,'.','')."\n");
+                fwrite($exportfh, $timestamp.$csv_field_separator.number_format($average,$csv_decimal_places,$csv_decimal_place_separator,'')."\n");
             }
         }
         

--- a/Modules/feed/engine/PHPTimeSeries.php
+++ b/Modules/feed/engine/PHPTimeSeries.php
@@ -335,6 +335,10 @@ class PHPTimeSeries
     
     public function csv_export($feedid,$start,$end,$outinterval)
     {
+        global $csv_decimal_places;
+        global $csv_decimal_place_separator;
+        global $csv_field_separator;
+
         $feedid = (int) $feedid;
         $start = (int) $start;
         $end = (int) $end;
@@ -396,7 +400,7 @@ class PHPTimeSeries
 
             // $last_time = 0 only occur in the first run
             if (($time!=$last_time && $time>$last_time) || $last_time==0) {
-                fwrite($exportfh, $time.",".number_format($array['value'],2,'.','')."\n");
+                fwrite($exportfh, $time.$csv_field_separator.number_format($array['value'],$csv_decimal_places,$csv_decimal_place_separator,'')."\n");
             }
         }
         fclose($exportfh);

--- a/Modules/feed/engine/PHPTimestore.php
+++ b/Modules/feed/engine/PHPTimestore.php
@@ -681,6 +681,10 @@ class PHPTimestore
     
     public function csv_export($feedid,$start,$end,$outinterval)
     {
+        global $csv_decimal_places;
+        global $csv_decimal_place_separator;
+        global $csv_field_separator;
+
         $feedid = (int) $feedid;
         $start = (int) $start;
         $end = (int) $end;
@@ -816,7 +820,7 @@ class PHPTimestore
             if ($points_in_sum) {
                 $timestamp = $meta->start + $layer_interval * ($point+$i-1);
                 $average = $point_sum / $points_in_sum;
-                fwrite($exportfh, $timestamp.",".number_format($average,2,'.','')."\n");
+                fwrite($exportfh, $timestamp.$csv_field_separator.number_format($average,$csv_decimal_places,$csv_decimal_place_separator,'')."\n");
                 //print "--".$average."<br>";
             }
 

--- a/Modules/feed/engine/Timestore.php
+++ b/Modules/feed/engine/Timestore.php
@@ -261,6 +261,10 @@ class Timestore
     
     public function csv_export($feedid,$start,$end,$outinterval)
     {
+        global $csv_decimal_places;
+        global $csv_decimal_place_separator;
+        global $csv_field_separator;
+
         $feedid = (int) $feedid;
         $start = (int) $start;
         $end = (int) $end;
@@ -385,7 +389,7 @@ class Timestore
             if ($points_in_sum) {
                 $timestamp = $meta->start + $layer_interval * ($point+$i-1);
                 $average = $point_sum / $points_in_sum;
-                fwrite($exportfh, $timestamp.",".number_format($average,2,'.','')."\n");
+                fwrite($exportfh, $timestamp.$csv_field_separator.number_format($average,$csv_decimal_places,$csv_decimal_place_separator,'')."\n");
                 //print "--".$average."<br>";
             }
 

--- a/default.settings.php
+++ b/default.settings.php
@@ -107,3 +107,17 @@
 
     // Log4PHP configuration
     $log4php_configPath = 'logconfig.xml';
+
+    // CSV export options for the number of decimal_places, decimal_place_separator and field_separator
+    // The thousands separator is not used (specified as "nothing")
+    // NOTE: don't make $csv_decimal_place_separator == $csv_field_separator
+    // Adjust as appropriate for your location
+
+    // number of decimal places
+    $csv_decimal_places = 2;
+
+    // decimal place separator
+    $csv_decimal_place_separator = ".";
+
+    // field separator
+    $csv_field_separator = ",";

--- a/process_settings.php
+++ b/process_settings.php
@@ -31,12 +31,18 @@ if(file_exists(dirname(__FILE__)."/settings.php"))
     if (!isset($feed_settings)) $error_out .= "<p>missing setting: feed_settings</p>";
     
     if (!isset($redis_enabled)) $redis_enabled = true;
-    
+
+    if (!isset($csv_decimal_places) || $csv_decimal_places=="") $csv_decimal_places = 2;
+    if (!isset($csv_decimal_place_separator) || $csv_decimal_place_separator=="") $csv_decimal_place_separator = '.';
+    if (!isset($csv_field_separator) || $csv_field_separator=="") $csv_field_separator = ',';
+
+    if ($csv_decimal_place_separator == $csv_field_separator) $error_out .= '<p>settings incorrect: $csv_decimal_place_separator==$csv_field_separator</p>';
+
     if ($error_out!="") {
       echo "<div style='width:600px; background-color:#eee; padding:20px; font-family:arial;'>";
       echo "<h3>settings.php file error</h3>";
       echo $error_out;
-      echo "<p>To fix check that the settings are set in <i>settings.php</i> or try re-creating your <i>settings.php</i> file from <i>default.settings.php</i> template</p>";
+      echo "<p>To fix, check that the settings are set in <i>settings.php</i> or try re-creating your <i>settings.php</i> file from <i>default.settings.php</i> template</p>";
       echo "</div>";
       die;
     }


### PR DESCRIPTION
csv_export() function in various files in Modules/feed/engine were using
the php function number_format() with 2 parameters which meant the
default thousands separator (comma) was being used when data points were
greater than 999
