### PR TITLE
Selectable input updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ Modules/scheduler
 Modules/myip
 Modules/heat
 emoncms.log
+.idea

--- a/Modules/input/input_controller.php
+++ b/Modules/input/input_controller.php
@@ -135,8 +135,11 @@ function input_controller()
                             $name = 1;
                             for ($i=2; $i<count($item); $i++)
                             {
-                                $value = (float) $item[$i];
-                                $inputs[$name] = $value;
+                                if (strlen($item[$i]))
+				                {
+                                    $value = (float) $item[$i];
+                                    $inputs[$name] = $value;
+                                }
                                 $name ++;
                             }
 


### PR DESCRIPTION
When using "bulk" update any individual values of  "null" will not get
updated whilst any numerical value inc 0 will update. This enables
selective input updates by "placing" any value(s) in the correct
position and order using  "null" entries eg
[[1409566580,10,null,20,null,40]] will update node 10 input 2 to 20 and
4 to 40 without effecting inputs 1 , 3 or 5+.
