### PR TITLE
fetch multiple feed values in one request

### DIFF
--- a/Modules/feed/feed_controller.php
+++ b/Modules/feed/feed_controller.php
@@ -45,6 +45,15 @@ function feed_controller()
             $result = $feed->create($session['userid'],get('name'),get('datatype'),get('engine'),json_decode(get('options')));
         } elseif ($route->action == "updatesize" && $session['write']) {
             $result = $feed->update_user_feeds_size($session['userid']);
+        // To "fetch" multiple feed values in a single request
+        // http://emoncms.org/feed/fetch.json?ids=123,567,890
+        } elseif ($route->action == "fetch" && $session['read']) {
+            $feedids = (array) get('ids');
+            for ($i=0; $i<count($feeds); $i++)
+                    $feedid = (int) $feedids[i]
+                    if ($feed->exist($feedid)) // if the feed exists
+                    { $result[i] = $feed->get_value($feedid);
+                    } else { $result[i] = "";
         } else {
             $feedid = (int) get('id');
             // Actions that operate on a single existing feed that all use the feedid to select:


### PR DESCRIPTION
Rather than requesting data one feed at a time this would allow one request to "fetch" a string of feed values by their feedid. Can be used in a browser directly or more usefully within emonhub to get data to broadcast over RFM network etc.  
