### PR TITLE
Fixed bug when OS and MySQL are not using the same decimal separator

### DIFF
--- a/Modules/feed/feed_model.php
+++ b/Modules/feed/feed_model.php
@@ -621,7 +621,9 @@ class Feed
         if ($this->redis) {
             $this->redis->hMset("feed:lastvalue:$feedid", array('value' => $value, 'time' => $updatetime));
         } else {
-            $this->mysqli->query("UPDATE feeds SET `time` = '$updatetime', `value` = '$value' WHERE `id`= '$feedid'");
+			// Explicitly set decimal separator, in case current locale doesn't use a dot (MySQL expects always a dot, regardless of locale)
+            $value2=number_format($value,10,'.','');
+            $this->mysqli->query("UPDATE feeds SET `time` = '$updatetime', `value` = '$value2' WHERE `id`= '$feedid'");
         }
     }
     


### PR DESCRIPTION
I found a few days ago that my kWh counter was fixed at some round value (120.0) and wasn't growing anymore, despite consuming electricity. After some debugging, I found the problem was that the update query sent to MySQL was using the system decimal separator (a comma in my case), while MySQL doesn't take locale into account and always expects a dot. The result is that MySQL was ignoring all decimal places, effectively truncating the value.

The patch here pre-formats the float value to a format suitable for MySQL (10 fixed decimal positions, dot as a decimal separator), so it works well regardless of system locale.