### PR TITLE
logger: specify log path

### DIFF
--- a/docs/LinuxInstall.md
+++ b/docs/LinuxInstall.md
@@ -203,4 +203,6 @@ Now save and close and restart your apache.
     
 ensure that log file has write permissions for www-data, pi and root.
     
-    sudo chmod 660 emoncms.log 
+    sudo touch /var/log/emoncms.log
+    sudo chown www-data:root /var/log/emoncms.log
+    sudo chmod 660 /var/log/emoncms.log


### PR DESCRIPTION
The log file full name is /var/log/emoncms.log according to logconfig.xml