### PR TITLE
Enable override of SMTP port and encryption settings.

### DIFF
--- a/Modules/user/user_model.php
+++ b/Modules/user/user_model.php
@@ -349,8 +349,11 @@ class User
                         return array('success'=>false, 'message'=>"Could not find SwiftMailer - cannot proceed");
                     }
 
-                    $transport = Swift_SmtpTransport::newInstance($smtp_email_settings['host'], 26)
-                    ->setUsername($smtp_email_settings['username'])->setPassword($smtp_email_settings['password']);
+                    $transport = Swift_SmtpTransport::newInstance($smtp_email_settings['host'])
+                      ->setUsername($smtp_email_settings['username'])
+                      ->setPassword($smtp_email_settings['password']);
+                    if ( isset($smtp_email_settings['encryption']) ) { $transport->setEncryption($smtp_email_settings['encryption']); };
+                    if ( isset($smtp_email_settings['port']) ) { $transport->setPort($smtp_email_settings['port']); };
 
                     $mailer = Swift_Mailer::newInstance($transport);
                     $message = Swift_Message::newInstance()

--- a/default.settings.php
+++ b/default.settings.php
@@ -35,6 +35,9 @@
     );
     
     // (OPTIONAL) Used by password reset feature
+    // - optional : 'encryption'=>'ssl'
+    // - optional : 'encryption'=>'tls'
+    // - optional : 'port'=>465 (default: 25)
     $smtp_email_settings = array(
       'host'=>"_SMTP_HOST_",
       'username'=>"_SMTP_USER_",


### PR DESCRIPTION
Using a SMTP serveur which use TLS, I have modified user_model.php to be able to override port to 465 and encryption to 'ssl'.

This pull request enable the ability to override default settings from settings.php adding optionally these parameters : 'port'=>, 'encryption'=>

I have also deleted the port 26 provided when creating the Swift_SmtpTransport instance, letting the Swift Mailer library setting the default smtp port which is 25.
If you want keep a backward compatibility, you should hardcode 'port'=>26 in default.settings.php, but usually, the default smtp port is 25.

