### PR TITLE
Fixed extra "$" that made impossible to export CSV

### DIFF
--- a/Modules/feed/feed_model.php
+++ b/Modules/feed/feed_model.php
@@ -465,7 +465,7 @@ class Feed
         
         // Download limit
         $downloadsize = (($end - $start) / $outinterval) * 17; // 17 bytes per dp
-        if ($downloadsize>($this->$settings['csvdownloadlimit_mb']*1048576)) {
+        if ($downloadsize>($this->settings['csvdownloadlimit_mb']*1048576)) {
             $this->log->warn("Feed model: csv download limit exeeded downloadsize=$downloadsize feedid=$feedid");
             return false;
         }


### PR DESCRIPTION
There was a typo in feed_model.php that made impossible to export feed data to CSV.