### PR TITLE
Disable PHPFIWA feed engine

### DIFF
--- a/default.emonpi.settings.php
+++ b/default.emonpi.settings.php
@@ -34,7 +34,7 @@
             //Engine::MYSQLMEMORY   // 8  Mysql with MEMORY tables on RAM. All data is lost on shutdown
             //Engine::PHPTIMESERIES // 2
             //,Engine::PHPFINA      // 5
-            //,Engine::PHPFIWA      // 6
+               Engine::PHPFIWA      // 6  PHPFIWA disabled for compatibility with Low-write mode
         ),
 
         // Redis Low-write mode


### PR DESCRIPTION
To ensure compatibility with Low-Write mode. If not disabled, and is then user selected, emoncms will crash.