### PR TITLE
New visualization that lets you overlay data from older time periods

### DIFF
--- a/Modules/vis/vis_object.php
+++ b/Modules/vis/vis_object.php
@@ -118,5 +118,11 @@
         
         'graph'=> array('label'=>_("Graph (BETA)"), 'options'=>array(
             array('feedid',_("feed"),1)
+        )),
+        
+        'timecompare'=> array('label'=>_("Time Comparison"), 'options'=>array(
+            array('feedid',_("feed"),1),
+            array('fill',_("fill"),7,1),
+            array('depth',_("depth"),7,3)
         ))
     );

--- a/Modules/vis/visualisations/timecompare.php
+++ b/Modules/vis/visualisations/timecompare.php
@@ -1,0 +1,75 @@
+<!--All Emoncms code is released under the GNU Affero General Public License.
+    See COPYRIGHT.txt and LICENSE.txt.
+
+    Emoncms - open source energy visualisation
+    Part of the OpenEnergyMonitor project:
+    http://openenergymonitor.org
+-->
+
+<?php
+    global $path;
+    $embed = intval(get("embed"));
+    $feedid = intval(get("feedid"));
+    $fill = intval(get("fill"));
+    $depth = intval(get("depth"));
+
+    if (!isset($feedidname)) $feedidname = "";
+?>
+
+<!--[if IE]><script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/excanvas.min.js"></script><![endif]-->
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.min.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.selection.min.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.touch.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.time.min.js"></script>
+
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Modules/vis/visualisations/common/api.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Modules/vis/visualisations/common/vis.helper.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Modules/vis/visualisations/timecompare/timecompare.js"></script>
+
+<?php if (!$embed) { ?>
+<h2><div id="timecompare_title"></div></h2>
+<?php } ?>
+
+<div id="timecompare"></div>
+
+<script id="source" language="javascript" type="text/javascript">
+
+    var path = "<?php echo $path; ?>";
+    var embed = <?php echo $embed; ?>;
+    var apikey = "<?php echo $apikey; ?>";
+    var feedid = "<?php echo $feedid; ?>";
+    var fill = "<?php echo $fill; ?>";
+    var depth = "<?php echo $depth; ?>";
+
+    $("#timecompare_title").replaceWith('<?php echo _("Time Compare: " . $feedidname); ?>');
+    timecompare_init("#timecompare");
+    vis_feed_data();
+    
+    var previousPoint = null;
+    $("#timecompare").bind("plothover", function (event, pos, item) {
+        //$("#x").text(pos.x.toFixed(2));
+        //$("#y").text(pos.y.toFixed(2));
+
+        if ($("#enableTooltip:checked").length > 0) {
+            if (item) {
+                if (previousPoint != item.dataIndex) {
+                    previousPoint = item.dataIndex;
+
+                    $("#tooltip").remove();
+                    var x = item.datapoint[0].toFixed(2);
+                    var y = item.datapoint[1].toFixed(2);
+
+                    var pointDate = new Date(parseInt(x) - parseInt(item.series.adj));
+                    var tipText = $.plot.formatDate(pointDate, y + "<br>%a %b %d %Y<br>%H:%M:%S");
+
+                    tooltip(item.pageX, item.pageY, tipText, "#DDDDDD");
+                }
+            } else {
+                $("#tooltip").remove();
+                previousPoint = null;
+            }
+        }
+    });
+
+</script>
+

--- a/Modules/vis/visualisations/timecompare/timecompare.js
+++ b/Modules/vis/visualisations/timecompare/timecompare.js
@@ -1,0 +1,262 @@
+var compare_unit = 0;
+var event_vis_feed_data;
+var ajaxAsyncXdr = [];
+var plotdata = [];
+var hidden_lines = {};
+var xaxis_format = "";
+  
+function create_plotlist(feedid, skipmissing, fill, depth){
+  var plotlist = [];
+  var unit = "";
+  var unit_plural = "s";
+
+  switch(compare_unit) {
+    case 1000*60*60*24:
+      unit = "Day";
+      xaxis_format = "%H:%M";
+      break;
+    case 1000*60*60*24*7:
+      unit = "Week";
+      xaxis_format = "%a<br>%H:%M";
+      break;
+    case 1000*60*60*24*28:
+      unit = "Month";
+      xaxis_format = "%a<br>%H:%M";
+      break;
+    case 1000*60*60*24*365:
+      unit = "Year";
+      xaxis_format = "%m/%d<br>%a<br>%H:%M";
+      break;
+    default:
+      unit = compare_unit / 1000 + " Seconds";
+      unit_plural = "";
+      xaxis_format = "%H:%M";
+  }
+
+  for (var i = 0; i < depth; i++) {
+    var cur_depth = depth - i - 1;
+    var label;
+
+    if (0 == cur_depth) {
+      label = "Current";
+    } else if (1 == cur_depth) {
+      label = cur_depth + " " + unit + " Prior";
+    } else {
+      label = cur_depth + " " + unit + unit_plural + " Prior";
+    }
+
+    plotlist[i] = {
+      id: feedid,
+      selected: 1,
+      skipmissing: skipmissing,
+      depth: cur_depth,
+      plot:
+      {
+        idx: i,
+        adj: compare_unit * cur_depth,
+        data: null,
+        temp_data: null,
+        label: label,
+        yaxis: 1,
+        lines:
+        {
+          show: true,
+          fill: fill
+        }
+      }
+    };
+  }
+
+  return plotlist;
+}
+
+//-------------
+// Handle Feeds
+//-------------
+
+// Ignore load request spurts
+function vis_feed_data(){
+   clearTimeout(event_vis_feed_data); // Cancel any pending events
+   event_vis_feed_data = setTimeout(function(){ vis_feed_data_delayed(); }, 250);
+}
+  
+// Load relevant feed data asynchronously
+function vis_feed_data_delayed(){
+  var plotlist;
+
+  fill = fill > 0 ? true : false;
+  if (depth <= 0) depth = 3;
+	
+  plotlist = create_plotlist(feedid, false, fill, depth);
+  for(var i in plotlist) {
+    if (plotlist[i].selected) {
+      if (!plotlist[i].plot.data)
+      {
+        var skipmissing = plotlist[i].skipmissing;
+        var npoints = 80;
+        var plot_start = view.start - (compare_unit * plotlist[i].depth); // Need to take into account leapyear
+        var plot_end = view.end - (compare_unit * plotlist[i].depth);
+        interval = Math.round((view.end - view.start)/(npoints * 1000));
+
+        if (plotdata[i] === undefined) plotdata[i] = [];
+
+        if (typeof ajaxAsyncXdr[i] !== 'undefined') { 
+          ajaxAsyncXdr[i].abort(); // Abort pending loads
+          ajaxAsyncXdr[i] = undefined;
+        }
+        var context = {index:i, plotlist:plotlist[i]}; 
+        ajaxAsyncXdr[i] = get_feed_data_async(vis_feed_data_callback, context, 
+          plotlist[i].id, plot_start, plot_end, interval,skipmissing, 1);
+      }
+    }
+  }
+}
+  
+// Asynchronous callback for loading data
+function vis_feed_data_callback(context, data){
+  var i = context['index'];
+  var depth = context['plotlist'].depth;
+
+  for (var d in data) {
+    data[d][0] = data[d][0] + (compare_unit * depth); // Adjust the old data to be visible on the current graph
+  }
+
+  if(i in hidden_lines) {
+    context['plotlist'].plot.temp_data = data;
+    context['plotlist'].plot.data = [];
+    context['plotlist'].plot.lines.show = false;
+  } else {
+    context['plotlist'].plot.data = data;
+  }
+
+  plotdata[i] = context['plotlist'].plot;
+  plot();
+}
+
+//-------------------
+// Graphing Functions
+//-------------------
+
+function toggle_line(idx){
+  plotdata[idx].lines.show = !plotdata[idx].lines.show;
+  if(!plotdata[idx].lines.show){
+    plotdata[idx].temp_data = plotdata[idx].data;
+    plotdata[idx].data = [];
+    hidden_lines[idx] = true;
+  } else {
+    plotdata[idx].data = plotdata[idx].temp_data;
+    delete hidden_lines[idx];
+  }
+
+  plot();
+}
+
+function plot(){
+  $.plot($("#graph"), plotdata, {
+    grid: { show: true, hoverable: true, clickable: true },
+    xaxis: { mode: "time", timezone: "browser", timeformat: xaxis_format, min: view.start, max: view.end },
+    yaxis: { min: 0},
+    selection: { mode: "x" },
+    legend: { position: "nw",
+      labelFormatter: function(label, plot){
+        return '<a href="#" onClick="toggle_line(\''+plot.idx+'\'); return false;"><font color=black>'+label+'</font></a>';
+      }
+    },
+    touch: { pan: "x", scale: "x"}
+  });
+}
+
+function timecompare_init(element){
+  // Get start and end time of view based on default scale and current time
+  var now = new Date().getTime();
+
+  compare_unit = (1000*60*60*24.0*7); // One week in milliseconds 
+  view.start = now - compare_unit;
+  view.end = now;
+
+  var out =
+    "<div id='graph_bound' style='height:400px; width:100%; position:relative; '>"+
+      "<div id='graph'></div>"+
+      "<div id='graph-buttons' style='position:absolute; top:20px; right:30px; opacity:0.5; display: none;'>"+
+        "<div class='input-prepend input-append' id='graph-tooltip' style='margin:0'>"+
+        "<span class='add-on'>Tooltip:</span>"+
+        "<span class='add-on'><input id='enableTooltip' type='checkbox' checked ></span>"+
+        "</div> "+
+
+        "<div class='btn-group'>"+
+        "<button class='btn graph-time' type='button' time='1'>D</button>"+
+        "<button class='btn graph-time' type='button' time='7'>W</button>"+
+        "<button class='btn graph-time' type='button' time='28'>M</button>"+
+        "<button class='btn graph-time' type='button' time='365'>Y</button></div>"+
+
+        "<div class='btn-group' id='graph-navbar' style='display: none;'>"+
+        "<button class='btn graph-nav' id='zoomin'>+</button>"+
+        "<button class='btn graph-nav' id='zoomout'>-</button>"+
+        "<button class='btn graph-nav' id='left'><</button>"+
+        "<button class='btn graph-nav' id='right'>></button></div>"+
+      "</div>"+
+    "</div>"
+  ;
+  $(element).html(out);
+
+  $('#graph').width($('#graph_bound').width());
+  $('#graph').height($('#graph_bound').height());
+  if (embed) $('#graph').height($(window).height());
+
+  $(window).resize(function(){
+    $('#graph').width($('#graph_bound').width());
+    if (embed) $('#graph').height($(window).height());
+    plot();
+  });
+
+  //--------------
+  // Graph zooming
+  //--------------
+  $("#graph").bind("plotselected", function (event, ranges){
+     view.start = ranges.xaxis.from; 
+     view.end = ranges.xaxis.to;
+     vis_feed_data();
+  });
+
+  //----------------
+  // Operate buttons
+  //----------------
+  $("#zoomout").click(function () {view.zoomout(); vis_feed_data();});
+  $("#zoomin").click(function () {view.zoomin(); vis_feed_data();});
+  $('#right').click(function () {view.panright(); vis_feed_data();});
+  $('#left').click(function () {view.panleft(); vis_feed_data();});
+  $('.graph-time').click(function () {
+    view.timewindow($(this).attr("time")); 
+    compare_unit = view.end - view.start;
+    hidden_lines = {};
+    vis_feed_data();
+  });
+
+  //--------------------------------------------------------
+  // Graph buttons and navigation efects for mouse and touch
+  //--------------------------------------------------------
+  $("#graph").mouseenter(function(){
+      $("#graph-navbar").show();
+      $("#graph-tooltip").show();
+      $("#graph-buttons").stop().fadeIn();
+      $("#stats").stop().fadeIn();
+  });
+  $("#graph_bound").mouseleave(function(){
+      $("#graph-buttons").stop().fadeOut();
+      $("#stats").stop().fadeOut();
+  });
+
+  $("#graph").bind("touchstarted", function (event, pos){
+      $("#graph-navbar").hide();
+      $("#graph-tooltip").hide();
+      $("#graph-buttons").stop().fadeOut();
+      $("#stats").stop().fadeOut();
+  });
+  $("#graph").bind("touchended", function (event, ranges){
+      $("#graph-buttons").stop().fadeIn();
+      $("#stats").stop().fadeIn();
+      view.start = ranges.xaxis.from; 
+      view.end = ranges.xaxis.to;
+      vis_feed_data();
+  });
+}

--- a/Modules/vis/widget/vis_render.js
+++ b/Modules/vis/widget/vis_render.js
@@ -166,6 +166,17 @@ function vis_widgetlist(){
       "optionshint":[_Tr("Managed on Visualization module")],
       "optionsdata":[multigraphsDropBoxOptions], // Gets multigraphs from vis_widget.php multigraphsDropBoxOptions variable
       "html":""
+    },
+
+    "timecompare":
+    {
+      "offsetx":0,"offsety":0,"width":400,"height":300,
+      "menu":"Visualisations",  
+      "options":["feedid","fill","depth"],
+      "optionstype":["feedid","value","value"],
+      "optionsname":[_Tr("Feed"),_Tr("Fill"),_Tr("Depth")],
+      "optionshint":[_Tr("Feed source"),_Tr("Fill under line"),_Tr("Number of lines")],
+      "html":""
     }
   }
 


### PR DESCRIPTION
I've created and been using a new visualization to allow you to more easily compare power / energy reading over time.

You select a feed and it will display multiple lines for that same feed at different times. For instance one line will be the current week, another line will be for the previous week, and a third line will be for two weeks ago. They are displayed on top of each other (like a multigraph) so you can quickly compare the data.

You can switch between comparing days, weeks, months, or years.

You can also specify how for back to go (how many lines to display).

You can also hide and restore any line in the graph by clicking the name of the line in the legend. So if one line is obscuring another, simply hide it.