### PR TITLE
Created ability to toggle lines in multigraph

### DIFF
--- a/Modules/vis/visualisations/multigraph/multigraph.js
+++ b/Modules/vis/visualisations/multigraph/multigraph.js
@@ -7,7 +7,7 @@
   function convert_to_plotlist(multigraph_feedlist){
    var plotlist = [];
    for (z in multigraph_feedlist){
-	var tag = (multigraph_feedlist[z]['tag']!=undefined && multigraph_feedlist[z]['tag'] !="" ? multigraph_feedlist[z]['tag']+": " : "");
+    var tag = (multigraph_feedlist[z]['tag']!=undefined && multigraph_feedlist[z]['tag'] !="" ? multigraph_feedlist[z]['tag']+": " : "");
     if (multigraph_feedlist[z]['datatype']==1){
       plotlist[z] = {
         id: multigraph_feedlist[z]['id'],

--- a/Modules/vis/visualisations/multigraph/multigraph.js
+++ b/Modules/vis/visualisations/multigraph/multigraph.js
@@ -2,24 +2,22 @@
   var timeWindowChanged = 0;
   var ajaxAsyncXdr = [];
   var event_vis_feed_data;
+  var hidden_lines = {};
   
   function convert_to_plotlist(multigraph_feedlist){
    var plotlist = [];
    for (z in multigraph_feedlist){
-    var tag = (multigraph_feedlist[z]['tag']!=undefined && multigraph_feedlist[z]['tag'] !="" ? multigraph_feedlist[z]['tag']+": " : "");
+	var tag = (multigraph_feedlist[z]['tag']!=undefined && multigraph_feedlist[z]['tag'] !="" ? multigraph_feedlist[z]['tag']+": " : "");
     if (multigraph_feedlist[z]['datatype']==1){
       plotlist[z] = {
         id: multigraph_feedlist[z]['id'],
         selected: 1,
         plot:
         {
+          idx: z,
           data: null,
+          temp_data: null,
           label: tag + multigraph_feedlist[z]['name'],
-          points: { show: true,
-                    radius: 0,
-                    lineWidth: 1, // in pixels
-                    fill: false
-          },
           lines:
           {
             show: true,
@@ -113,10 +111,30 @@
   //load feed data to multigraph plot
   function vis_feed_data_callback(context,data){
     var i = context['index'];
-    context['plotlist'].plot.data = data;
-    if (context['plotlist'].plot.data) {
-      plotdata[i] = context['plotlist'].plot;
+
+    if(i in hidden_lines) {
+      context['plotlist'].plot.temp_data = data;
+      context['plotlist'].plot.data = [];
+      context['plotlist'].plot.lines.show = false;
+    } else {
+      context['plotlist'].plot.data = data;
     }
+      
+    plotdata[i] = context['plotlist'].plot;
+    plot();
+  }
+
+  function toggle_line(idx){
+    plotdata[idx].lines.show = !plotdata[idx].lines.show;
+    if(!plotdata[idx].lines.show){
+      plotdata[idx].temp_data = plotdata[idx].data;
+      plotdata[idx].data = [];
+      hidden_lines[idx] = true;
+    } else {
+      plotdata[idx].data = plotdata[idx].temp_data;
+      delete hidden_lines[idx];
+    }
+
     plot();
   }
 
@@ -124,8 +142,13 @@
     $.plot($("#graph"), plotdata, {
       grid: { show: true, hoverable: true, clickable: true },
       xaxis: { mode: "time", timezone: "browser", min: view.start, max: view.end },
+      yaxis: { min: 0},
       selection: { mode: "x" },
-      legend: { position: "nw"},
+      legend: { position: "nw",
+        labelFormatter: function(label, plot){
+          return '<a href="#" onClick="toggle_line(\''+plot.idx+'\'); return false;"><font color=black>'+label+'</font></a>';
+        }
+      },
       touch: { pan: "x", scale: "x"}
     });
   }

--- a/Modules/vis/visualisations/multigraph/multigraph.js
+++ b/Modules/vis/visualisations/multigraph/multigraph.js
@@ -146,7 +146,8 @@
       selection: { mode: "x" },
       legend: { position: "nw",
         labelFormatter: function(label, plot){
-          return '<a href="#" onClick="toggle_line(\''+plot.idx+'\'); return false;"><font color=black>'+label+'</font></a>';
+          var colour = plot.idx in hidden_lines ? "gray" : "black";
+          return '<a href="#" onClick="toggle_line(\''+plot.idx+'\'); return false;"><font color='+colour+'>'+label+'</font></a>';
         }
       },
       touch: { pan: "x", scale: "x"}

--- a/Modules/vis/visualisations/timecompare/timecompare.js
+++ b/Modules/vis/visualisations/timecompare/timecompare.js
@@ -159,7 +159,8 @@ function plot(){
     selection: { mode: "x" },
     legend: { position: "nw",
       labelFormatter: function(label, plot){
-        return '<a href="#" onClick="toggle_line(\''+plot.idx+'\'); return false;"><font color=black>'+label+'</font></a>';
+        var colour = plot.idx in hidden_lines ? "gray" : "black";
+        return '<a href="#" onClick="toggle_line(\''+plot.idx+'\'); return false;"><font color='+colour+'>'+label+'</font></a>';
       }
     },
     touch: { pan: "x", scale: "x"}


### PR DESCRIPTION
I often have a multigraph where most of the lines are small values, but one line has large values that dominate the graph. When that happens, I cannot get a very good idea of what the other lines look like. Here's an example:

![image](https://cloud.githubusercontent.com/assets/16628409/12375221/33cdfc96-bc6d-11e5-8e9e-a58242bd3bed.png)

So I added the ability to toggle lines by clicking on the name of the line in the legend. When you toggle the line, I have the y axis rescale so you can see the lines with smaller values.

Here I have hidden furnace:

![image](https://cloud.githubusercontent.com/assets/16628409/12375224/57b74bee-bc6d-11e5-9346-8b8f66317809.png)

When a line is hidden, you can zoom or pan the graph without restoring the line. You can also change from daily to weekly, monthly etc views without restoring the lines. You can hide as many lines as you like and restore them whenever you want by clicking on the name in the legend again.