### PR TITLE
Added ability to hide tag name from multigraph legend

### DIFF
--- a/Modules/vis/Views/multigraph_edit.js
+++ b/Modules/vis/Views/multigraph_edit.js
@@ -10,6 +10,7 @@ var multigraph_feedlist = [];
 var multigraphs=[];
 var multigraphs_name=[];
 var movingtime = false;
+var showtag = true;
 
 var baseElement = "#box-options";
 
@@ -48,6 +49,11 @@ function draw_multigraph_feedlist_editor(){
     movingtime=false;
   else
     movingtime=true;
+
+  if (typeof multigraph_feedlist[0] !== 'undefined' && typeof multigraph_feedlist[0]['showtag'] !== 'undefined')
+    showtag = multigraph_feedlist[0]['showtag'];
+  else
+    showtag = true;
 
   var out = "";
   out += '<div id="myModal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true" data-backdrop="static">';
@@ -96,6 +102,12 @@ function draw_multigraph_feedlist_editor(){
   out += "<tr><td>Floating time</strong></td>";
   var checked = ""; if (movingtime) checked = "checked";
   out += "<td><input id='movingtime' type='checkbox' "+checked+" /></td>";
+  out += "<td></td>";
+  out += "<td></td>";
+  out += "<td></td></tr>";
+  out += "<tr><td>Show tag name</strong></td>";
+  var checked = ""; if (showtag) checked = "checked";
+  out += "<td><input id='showtag' type='checkbox' "+checked+" /></td>";
   out += "<td></td>";
   out += "<td></td>";
   out += "<td></td></tr>";
@@ -182,6 +194,12 @@ function load_events(){
 
   $(baseElement).on("click","#movingtime",function(event){
     movingtime = $(this)[0].checked;
+    vis_feed_data();
+    modified();
+  });
+  $(baseElement).on("click","#showtag",function(event){
+    showtag = $(this)[0].checked;
+    multigraph_feedlist[0]['showtag'] = showtag;
     vis_feed_data();
     modified();
   });

--- a/Modules/vis/visualisations/multigraph/multigraph.js
+++ b/Modules/vis/visualisations/multigraph/multigraph.js
@@ -6,8 +6,9 @@
   
   function convert_to_plotlist(multigraph_feedlist){
    var plotlist = [];
+   var showtag = (multigraph_feedlist[0]['showtag'] != undefined ? multigraph_feedlist[0]['showtag'] : true);
    for (z in multigraph_feedlist){
-    var tag = (multigraph_feedlist[z]['tag']!=undefined && multigraph_feedlist[z]['tag'] !="" ? multigraph_feedlist[z]['tag']+": " : "");
+    var tag = (showtag && multigraph_feedlist[z]['tag']!=undefined && multigraph_feedlist[z]['tag']!="" ? multigraph_feedlist[z]['tag']+": " : "");
     if (multigraph_feedlist[z]['datatype']==1){
       plotlist[z] = {
         id: multigraph_feedlist[z]['id'],


### PR DESCRIPTION
By default the multigraph legend includes a tag for the feeds. In my case it is "Node 1". This takes up space on the graph. The buttons to switch between week month, year etc also takes up space. This makes it hard to hover over a line to see the exact reading there.

![image](https://cloud.githubusercontent.com/assets/16628409/12527252/d248178a-c12c-11e5-9da6-70fe10055f54.png)

I added an option to the multigraph editor that lets you turn off the tag. It is enabled by default.

![image](https://cloud.githubusercontent.com/assets/16628409/12527267/3d710dd2-c12d-11e5-82ce-d75a2a8d2db1.png)

With it unchecked, the tag is not displayed and the legend is smaller.

![image](https://cloud.githubusercontent.com/assets/16628409/12527299/60e83a2e-c12d-11e5-8fd6-e0536cf2a12f.png)



