### PR TITLE
Node variable MQTT topic structure & change of PHP MQTT library

### DIFF
--- a/default.emonpi.settings.php
+++ b/default.emonpi.settings.php
@@ -26,7 +26,7 @@
                           'user'     => 'emonpi',
                           'password' => 'emonpimqtt2016'
                           // Used with scripts/phpmqtt_input.php
-                          'user'=>1,
+                          'userid'=>1,
                           'basetopic'=> 'nodes'                          
                           );
 

--- a/default.emonpi.settings.php
+++ b/default.emonpi.settings.php
@@ -110,8 +110,8 @@
     $default_action = "login";
 
     // Default controller and action if none are specified and user is logged in
-    $default_controller_auth = "nodes";
-    $default_action_auth = "view";
+    $default_controller_auth = "feed";
+    $default_action_auth = "list";
 
     // Public profile functionality
     // Allows http://yourdomain.com/[username]/[dash alias] or ?id=[dash id]

--- a/default.emonpi.settings.php
+++ b/default.emonpi.settings.php
@@ -24,7 +24,11 @@
     $mqtt_server = array( 'host'     => 'localhost',
                           'port'     => 1883,
                           'user'     => 'emonpi',
-                          'password' => 'emonpimqtt2016');
+                          'password' => 'emonpimqtt2016'
+                          // Used with scripts/phpmqtt_input.php
+                          'user'=>1,
+                          'basetopic'=> 'nodes'                          
+                          );
 
 
 //4 #### Engine settings

--- a/default.emonpi.settings.php
+++ b/default.emonpi.settings.php
@@ -27,7 +27,7 @@
                           'password' => 'emonpimqtt2016',
                           // Used with scripts/phpmqtt_input.php
                           'userid'=>1,
-                          'basetopic'=> 'nodes'                          
+                          'basetopic'=> 'emon'                          
                           );
 
 

--- a/default.settings.php
+++ b/default.settings.php
@@ -26,7 +26,7 @@
                           'user'     => '',
                           'password' => '',
                           // Used with scripts/phpmqtt_input.php
-                          'user'=>1,
+                          'userid'=>1,
                           'basetopic'=> 'nodes'
                           );
 

--- a/default.settings.php
+++ b/default.settings.php
@@ -24,7 +24,11 @@
     $mqtt_server = array( 'host'     => 'localhost',
                           'port'     => 1883,
                           'user'     => '',
-                          'password' => '');
+                          'password' => '',
+                          // Used with scripts/phpmqtt_input.php
+                          'user'=>1,
+                          'basetopic'=> 'nodes'
+                          );
 
 
 //4 #### Engine settings

--- a/default.settings.php
+++ b/default.settings.php
@@ -27,7 +27,7 @@
                           'password' => '',
                           // Used with scripts/phpmqtt_input.php
                           'userid'=>1,
-                          'basetopic'=> 'emoncms'
+                          'basetopic'=> 'emon'
                           );
 
 

--- a/default.settings.php
+++ b/default.settings.php
@@ -27,7 +27,7 @@
                           'password' => '',
                           // Used with scripts/phpmqtt_input.php
                           'userid'=>1,
-                          'basetopic'=> 'nodes'
+                          'basetopic'=> 'emoncms'
                           );
 
 

--- a/docs/RaspberryPi/Low-write-mode.md
+++ b/docs/RaspberryPi/Low-write-mode.md
@@ -89,7 +89,7 @@ Save & exit:
 
 Ensure all redis databases have been removed from `/var/lib/redis` with: 
     
-    sudo rm -rf /var/lib/redis/
+   rm -rf /var/lib/redis/*
 
 #### Configure Feedwriter
 

--- a/docs/RaspberryPi/Low-write-mode.md
+++ b/docs/RaspberryPi/Low-write-mode.md
@@ -85,6 +85,10 @@ Comment out all redis saves:
 
 Save & exit:
 
+    sudo service redis-server reboot
+
+**Ensure all redis databases have been removed from `/var/lib/redis`**
+
 #### Configure Feedwriter
 
 Create a symlink to run feedwriter as a daemon and set permissions:

--- a/docs/RaspberryPi/Low-write-mode.md
+++ b/docs/RaspberryPi/Low-write-mode.md
@@ -87,7 +87,9 @@ Save & exit:
 
     sudo service redis-server reboot
 
-**Ensure all redis databases have been removed from `/var/lib/redis`**
+Ensure all redis databases have been removed from `/var/lib/redis` with: 
+    
+    sudo rm -rf /var/lib/redis/
 
 #### Configure Feedwriter
 

--- a/docs/RaspberryPi/MQTT.md
+++ b/docs/RaspberryPi/MQTT.md
@@ -1,50 +1,89 @@
-##Enabling MQTT
-MQTT is a "lightweight" messaging protocol, which enables the publishing of data from emoncms, as well as subscribing to data from
-other connected devices.
-###Preparation
+## Enabling MQTT
+MQTT is a "lightweight" messaging protocol, which enables the publishing of data from Emoncms, as well as subscribing to data from other connected devices. The emonPi uses MQTT to transfer data from emonHub to Emoncms.
 
-Before following this guide, it is essential that emoncms was initially installed by following either the [Raspbian Jessie](readme.md) or [Raspbian Wheezy](install_Wheezy.md) installation guide, or you have used git to install a working version of emoncms on your Raspberry Pi, as well as a MQTT message broker such as [mosquitto](http://mosquitto.org/) installed and running.
+### Preparation
 
-Update emoncms to current version
+Before following this guide, it is essential that emoncms was initially installed by following either the [Raspbian Jessie](readme.md) or [Raspbian Wheezy](install_Wheezy.md) installation guide, or you have used git to install a working version of Emoncms & emonHub on your Raspberry Pi, as well as a MQTT message broker such as [Mosquitto](http://mosquitto.org/) installed and running.
+
+#### Ensure package are installed
+
+In addition to Mosquitto MQTT server we will need:
+
+    sudo apt-get install libmosquitto-dev​
+    pecl install Mosquitto-alpha
+    (​Hit enter to autodetect libmosquitto location)
+
+If PHP extension config files `/etc/php5/cli/conf.d/20-mosquitto.ini` and `/etc/php5/apache2/conf.d/20-mosquitto.ini` don't exist then create with:
+
+    sudo sh -c 'echo "extension=mosquitto.so" > /etc/php5/cli/conf.d/20-mosquitto.ini'
+    sudo sh -c 'echo "extension=mosquitto.so" > /etc/php5/apache2/conf.d/20-mosquitto.ini'
+
+#### Update Emoncms & emomnHub:
 
     cd /var/www/emoncms && git pull
+    cd ~/emonhub && git pull
 
-Create a symlink to run phpmqtt_input as a daemon and set permissions
+### Enable MQTT in emonHub:
+
+Ensure you have the latest emonub.conf config file (backup your settings first!):
+
+    cp ~/emonhub/conf/emonpi.default.emonhub.conf ~/data/emonhub.conf
+
+The new config file has MQTT authentication and the new node variable MQTT topic data structure turned on by default, see [emonHub config guide](http://github.com/openenergymonitor/emonhub/blob/emon-pi/configuration.md) for more info.
+
+    sudo service emonhub restart
+
+After restart emonHub should now be publishing to basetopic (default 'emon') using the new node variable topic data structure e.g `emon/emontx/power1`. We can check by subcribing to the base topic:
+
+    mosquitto_sub -v -u 'emonpi' -P 'emonpimqtt2016' -t 'emon/#'
+
+### Enable MQTT in Emoncms
+
+Ensure you have the latest settings file (backup your settings first!):
+
+    cp /var/www/emoncms/default.settings.php /var/www/emoncms/settings.php
+
+or if using an emonPi:
+
+    cp /var/www/emoncms/default.settings.php /var/www/emoncms/settings.php
+
+Edit the settings file:
+
+    nano /var/www/emoncms/settings.php
+
+In the settings file in the **MQTT** section change `$mqtt_enabled` from `false` to `true`, and also change the `$mqtt_server` IP address to that of your MQTT server. On the emonPi the host is `localhost` and authentication is enabled: `user => emonpi` and `password => emonpimqtt2016`.
+
+The `basetopic` option sets the base MQTT topic to which Emoncms subscribers. The default base topic is `emon` which means Enmoncms will subcribe to `emon/#` e.g. `emon/emontx/power1`. This base topic needs to match the MQTT basetopic published from emonHub.  
+
+### Run Emoncms phpmqtt_input script
+
+Create a symlink to run `scripts/phpmqtt_input` as a daemon and set permissions
 
     cd /etc/init.d && sudo ln -s /var/www/emoncms/scripts/mqtt_input
     sudo chown root:root /var/www/emoncms/scripts/mqtt_input
     sudo chmod 755 /var/www/emoncms/scripts/mqtt_input
     sudo update-rc.d mqtt_input defaults
 
-###Enable MQTT in emoncms
 
-    nano /var/www/emoncms/settings.php
 
-In the section **MQTT**, change `$mqtt_enabled` from `false` to `true`, and also change the `$mqtt_server` IP address to that of your mqtt
-server.
-Save & exit, then reboot
+### Node format
 
-    sudo reboot
-
-###Node format
-
-####emoncms as a publisher
+#### emoncms as a publisher
 
 Data from within emoncms can be published by adding the `Publish to MQTT` input process to one or more of the node inputs.
 In the process 'Text' box add the topic, for example; `house/power/solar`
 
-####emoncms as a subscriber
+#### emoncms as a subscriber
 
 [basetopic] and user ID of the target Emocnms account can be set in settings.php. **Default basetopic = `emon`**
 
 Data posted to `nodes/[nodeID/name]/[keyname (optional)]` is posted to Emoncms inputs where it can be logged to feeds e.g:
 
-* `[basetopioc]/emontx/power 10` 
+* `[basetopic]/emontx/power 10`
     * create an input from emonTx node called `power` with value `10`  
-* `[basetopioc]/10/power 10` 
+* `[basetopic]/10/power 10`
     * create an input from `node 10` called `power` with value `10`
-* `[basetopioc]/emontx 10` 
+* `[basetopic]/emontx 10`
     * create input from `emontx` with `key 0` of value `10`
-* `[basetopioc]/emontx 10,11,12`
+* `[basetopic]/emontx 10,11,12`
     * create input from `emontx` with `key 0` of value `10`, `key 1` of value `11` and `key 2` of value `11`
-

--- a/docs/RaspberryPi/MQTT.md
+++ b/docs/RaspberryPi/MQTT.md
@@ -10,7 +10,7 @@ Before following this guide, it is essential that emoncms was initially installe
 In addition to Mosquitto MQTT server we will need:
 
     sudo apt-get install libmosquitto-dev​
-    pecl install Mosquitto-alpha
+    sudo pecl install Mosquitto-alpha
     (​Hit enter to autodetect libmosquitto location)
 
 If PHP extension config files `/etc/php5/cli/conf.d/20-mosquitto.ini` and `/etc/php5/apache2/conf.d/20-mosquitto.ini` don't exist then create with:

--- a/docs/RaspberryPi/MQTT.md
+++ b/docs/RaspberryPi/MQTT.md
@@ -5,37 +5,9 @@ MQTT is a "lightweight" messaging protocol, which enables the publishing of data
 
 Before following this guide, it is essential that emoncms was initially installed by following either the [Raspbian Jessie](readme.md) or [Raspbian Wheezy](install_Wheezy.md) installation guide, or you have used git to install a working version of Emoncms & emonHub on your Raspberry Pi, as well as a MQTT message broker such as [Mosquitto](http://mosquitto.org/) installed and running.
 
-#### Ensure package are installed
-
-In addition to Mosquitto MQTT server we will need:
-
-    sudo apt-get install libmosquitto-dev
-    sudo pecl install Mosquitto-alpha
-    (​Hit enter to autodetect libmosquitto location)
-
-If PHP extension config files `/etc/php5/cli/conf.d/20-mosquitto.ini` and `/etc/php5/apache2/conf.d/20-mosquitto.ini` don't exist then create with:
-
-    sudo sh -c 'echo "extension=mosquitto.so" > /etc/php5/cli/conf.d/20-mosquitto.ini'
-    sudo sh -c 'echo "extension=mosquitto.so" > /etc/php5/apache2/conf.d/20-mosquitto.ini'
-
-#### Update Emoncms & emomnHub:
+#### Update Emoncms:
 
     cd /var/www/emoncms && git pull
-    cd ~/emonhub && git pull
-
-### Enable MQTT in emonHub:
-
-Ensure you have the latest emonub.conf config file (backup your settings first!):
-
-    cp ~/emonhub/conf/emonpi.default.emonhub.conf ~/data/emonhub.conf
-
-The new config file has MQTT authentication and the new node variable MQTT topic data structure turned on by default, see [emonHub config guide](http://github.com/openenergymonitor/emonhub/blob/emon-pi/configuration.md) for more info.
-
-    sudo service emonhub restart
-
-After restart emonHub should now be publishing to basetopic (default 'emon') using the new node variable topic data structure e.g `emon/emontx/power1`. We can check by subcribing to the base topic:
-
-    mosquitto_sub -v -u 'emonpi' -P 'emonpimqtt2016' -t 'emon/#'
 
 ### Enable MQTT in Emoncms
 
@@ -53,7 +25,7 @@ Edit the settings file:
 
 In the settings file in the **MQTT** section change `$mqtt_enabled` from `false` to `true`, and also change the `$mqtt_server` IP address to that of your MQTT server. On the emonPi the host is `localhost` and authentication is enabled: `user => emonpi` and `password => emonpimqtt2016`.
 
-The `basetopic` option sets the base MQTT topic to which Emoncms subscribers. The default base topic is `emon` which means Enmoncms will subcribe to `emon/#` e.g. `emon/emontx/power1`. This base topic needs to match the MQTT basetopic published from emonHub.  
+The `basetopic` option sets the base MQTT topic to which Emoncms subscribers. The default base topic is `emon` which means Enmoncms will subcribe to `emon/#`. In emonpi, this base topic needs to match the MQTT basetopic published from emonHub.
 
 ### Run Emoncms phpmqtt_input script
 
@@ -64,10 +36,55 @@ Create a symlink to run `scripts/phpmqtt_input` as a daemon and set permissions
     sudo chmod 755 /var/www/emoncms/scripts/mqtt_input
     sudo update-rc.d mqtt_input defaults
 
+## Emonpi only
+
+#### Ensure packages are installed
+
+Update emonhub
+
+    cd ~/emonhub && git pull
+
+In addition to Mosquitto MQTT server we will need:
+
+    sudo apt-get install libmosquitto-dev
+    sudo pecl install Mosquitto-alpha
+    (​Hit enter to autodetect libmosquitto location)
+
+If PHP extension config files `/etc/php5/cli/conf.d/20-mosquitto.ini` and `/etc/php5/apache2/conf.d/20-mosquitto.ini` don't exist then create with:
+
+    sudo sh -c 'echo "extension=mosquitto.so" > /etc/php5/cli/conf.d/20-mosquitto.ini'
+    sudo sh -c 'echo "extension=mosquitto.so" > /etc/php5/apache2/conf.d/20-mosquitto.ini'
+
+### Enable MQTT in emonHub:
+
+Ensure you have the latest emonub.conf config file (backup your settings first!):
+
+    cp ~/emonhub/conf/emonpi.default.emonhub.conf ~/data/emonhub.conf
+
+The new config file has MQTT authentication and the new node variable MQTT topic data structure turned on by default, see [emonHub config guide](http://github.com/openenergymonitor/emonhub/blob/emon-pi/configuration.md) for more info.
+
+    sudo service emonhub restart
+
+After restart emonHub should now be publishing to basetopic (default 'emon') using the new node variable topic data structure e.g `emon/emontx/power1`. We can check by subcribing to the base topic:
+
+    mosquitto_sub -v -u 'emonpi' -P 'emonpimqtt2016' -t 'emon/#'
 
 
-### Node format
+## Node format
 
+Both emonbase & emonpi process MQTT differently, therefore refer to the appropriate section below. 
+
+### Emonbase
+#### emoncms as a publisher
+
+Data from within emoncms can be published by adding the Publish to MQTT input process to one or more of the node inputs. In the process 'Text' box add the topic, for example; emoncms/solar
+
+####emoncms as a subscriber
+
+Unlike the above, the [basetopic] is hardcoded within emoncms, and takes the format emon/* - where * is the emoncms node number. For example, if data is published to topic emon/20 then emoncms will subscribe to that data, creating and updating node 20 in your inputs page.
+Emoncms will also decode data in comma-delimited format, so for example; publishing values 657,899,5,776 to emon/20 will create Node 20, with 4 Key inputs which correspond with the 4 published comma-delimited values. Name labels can then be added to the key inputs in emoncms
+
+### Emonpi
 #### emoncms as a publisher
 
 Data from within emoncms can be published by adding the `Publish to MQTT` input process to one or more of the node inputs.

--- a/docs/RaspberryPi/MQTT.md
+++ b/docs/RaspberryPi/MQTT.md
@@ -9,7 +9,7 @@ Before following this guide, it is essential that emoncms was initially installe
 
 In addition to Mosquitto MQTT server we will need:
 
-    sudo apt-get install libmosquitto-dev​
+    sudo apt-get install libmosquitto-dev
     sudo pecl install Mosquitto-alpha
     (​Hit enter to autodetect libmosquitto location)
 

--- a/docs/RaspberryPi/MQTT.md
+++ b/docs/RaspberryPi/MQTT.md
@@ -35,14 +35,16 @@ In the process 'Text' box add the topic, for example; `emoncms/solar`
 
 ####emoncms as a subscriber
 
+[basetopic] and user ID of the target Emocnms account can be set in settings.php. **Default basetopic = `emoncms`'**
+
 Data posted to `nodes/[nodeID/name]/[keyname (optional)]` is posted to Emoncms inputs where it can be logged to feeds e.g:
 
-* `nodes/emontx/power 10` 
+* `[basetopioc]/emontx/power 10` 
     * create an input from emonTx node called `power` with value `10`  
-* `nodes/10/power 10` 
+* `[basetopioc]/10/power 10` 
     * create an input from `node 10` called `power` with value `10`
-* `nodes/emontx 10` 
+* `[basetopioc]/emontx 10` 
     * create input from `emontx` with `key 0` of value `10`
-* `nodes/emontx 10,11,12`
+* `[basetopioc]/emontx 10,11,12`
     * create input from `emontx` with `key 0` of value `10`, `key 1` of value `11` and `key 2` of value `11`
 

--- a/docs/RaspberryPi/MQTT.md
+++ b/docs/RaspberryPi/MQTT.md
@@ -31,11 +31,11 @@ Save & exit, then reboot
 ####emoncms as a publisher
 
 Data from within emoncms can be published by adding the `Publish to MQTT` input process to one or more of the node inputs.
-In the process 'Text' box add the topic, for example; `emoncms/solar`
+In the process 'Text' box add the topic, for example; `house/power/solar`
 
 ####emoncms as a subscriber
 
-[basetopic] and user ID of the target Emocnms account can be set in settings.php. **Default basetopic = `emoncms`'**
+[basetopic] and user ID of the target Emocnms account can be set in settings.php. **Default basetopic = `emon`**
 
 Data posted to `nodes/[nodeID/name]/[keyname (optional)]` is posted to Emoncms inputs where it can be logged to feeds e.g:
 

--- a/docs/RaspberryPi/MQTT.md
+++ b/docs/RaspberryPi/MQTT.md
@@ -45,7 +45,7 @@ Ensure you have the latest settings file (backup your settings first!):
 
 or if using an emonPi:
 
-    cp /var/www/emoncms/default.settings.php /var/www/emoncms/settings.php
+    cp /var/www/emoncms/default.emonpi.settings.php /var/www/emoncms/settings.php
 
 Edit the settings file:
 

--- a/process_settings.php
+++ b/process_settings.php
@@ -53,6 +53,8 @@ if(file_exists(dirname(__FILE__)."/settings.php"))
         if (!isset($mqtt_server['port'])) $mqtt_server['port'] = 1883;
         if (!isset($mqtt_server['user'])) $mqtt_server['user'] = null;
         if (!isset($mqtt_server['password'])) $mqtt_server['password'] = null;
+        if (!isset($mqtt_server['user'])) $mqtt_server['user'] = 1;
+        if (!isset($mqtt_server['basetopic'])) $mqtt_server['basetopic'] = "rx";
     }
 
     if (!isset($feed_settings)) $feed_settings = array();

--- a/process_settings.php
+++ b/process_settings.php
@@ -53,8 +53,8 @@ if(file_exists(dirname(__FILE__)."/settings.php"))
         if (!isset($mqtt_server['port'])) $mqtt_server['port'] = 1883;
         if (!isset($mqtt_server['user'])) $mqtt_server['user'] = null;
         if (!isset($mqtt_server['password'])) $mqtt_server['password'] = null;
-        if (!isset($mqtt_server['user'])) $mqtt_server['user'] = 1;
-        if (!isset($mqtt_server['basetopic'])) $mqtt_server['basetopic'] = "rx";
+        if (!isset($mqtt_server['userid'])) $mqtt_server['userid'] = 1;
+        if (!isset($mqtt_server['basetopic'])) $mqtt_server['basetopic'] = "nodes";
     }
 
     if (!isset($feed_settings)) $feed_settings = array();

--- a/scripts/old.phpmqtt_input.php
+++ b/scripts/old.phpmqtt_input.php
@@ -1,0 +1,163 @@
+<?php
+
+    $mqttsettings = array(
+        'userid' => 1,
+        'basetopic' => "nodes"
+    );
+
+    /*
+    
+    **MQTT input interface script**
+    
+    SERVICE INSTALL INSTRUCTIONS:
+    https://github.com/emoncms/emoncms/blob/master/docs/RaspberryPi/MQTT.md
+    
+    EXAMPLES: 
+    
+    create an input from emonTx node called power with value 10:
+        nodes/emontx/power 10
+    
+    create an input from node 10 called power with value 10 :       
+        nodes/10/power 10
+        
+    create input from emontx with key 0 of value 10
+        nodes/emontx 10
+        
+    create input from emontx with key 0 of value 10, key 1 of value 11 and key 2 of value 11
+        nodes/emontx 10,11,12
+
+    
+    * userid has to be set in script (1 default emonPi), no method of setting timestamp
+    
+    Emoncms then processes these inputs in the same way as they would be
+    if sent to the HTTP Api.
+    
+    */
+
+    // This code is released under the GNU Affero General Public License.
+    // OpenEnergyMonitor project:
+    // http://openenergymonitor.org
+    
+    define('EMONCMS_EXEC', 1);
+
+    $fp = fopen("/var/lock/phpmqtt_input.lock", "w");
+    if (! flock($fp, LOCK_EX | LOCK_NB)) { echo "Already running\n"; die; }
+    
+    chdir(dirname(__FILE__)."/../");
+    require "Lib/EmonLogger.php";
+    require "process_settings.php";
+    
+    if (!$mqtt_enabled) { echo "Error: setting must be true: mqtt_enabled\n"; die; }
+    
+    $log = new EmonLogger(__FILE__);
+    $log->info("Starting MQTT Input script");
+    
+    $mysqli = @new mysqli($server,$username,$password,$database);
+    if ($mysqli->connect_error) { $log->error("Can't connect to database:". $mysqli->connect_error);  die('Check log\n'); }
+
+    if ($redis_enabled) {
+        $redis = new Redis();
+        if (!$redis->connect($redis_server['host'], $redis_server['port'])) { 
+            $log->error("Could not connect to redis at ".$redis_server['host'].":".$redis_server['port']);  die('Check log\n'); 
+        }
+        if (!empty($redis_server['prefix'])) $redis->setOption(Redis::OPT_PREFIX, $redis_server['prefix']);
+        if (!empty($redis_server['auth'])) {
+            if (!$redis->auth($redis_server['auth'])) { 
+                $log->error("Could not connect to redis at ".$redis_server['host'].", autentication failed"); die('Check log\n');
+            }
+        }
+    } else {
+        $redis = false;
+    }
+    
+    require("Lib/phpMQTT.php");
+    $mqtt = new phpMQTT($mqtt_server['host'], $mqtt_server['port'], "Emoncms input subscriber");
+    
+    require("Modules/user/user_model.php");
+    $user = new User($mysqli,$redis,null);
+
+    require_once "Modules/feed/feed_model.php";
+    $feed = new Feed($mysqli,$redis, $feed_settings);
+
+    require_once "Modules/input/input_model.php";
+    $input = new Input($mysqli,$redis, $feed);
+
+    require_once "Modules/process/process_model.php";
+    $process = new Process($mysqli,$input,$feed,$user->get_timezone($mqttsettings['userid']));
+  
+    if(!$mqtt->connect(true,NULL,$mqtt_server['user'], $mqtt_server['password'])){
+        $log->error ("Cannot connect to MQTT Server"); 
+        die('Check log\n');
+    }
+
+    $topic = $mqttsettings['basetopic']."/#";
+    echo "Subscribing to: ".$topic."\n";
+    
+    $topics[$topic] = array("qos"=>0, "function"=>"procmsg");
+    $mqtt->subscribe($topics,0);
+    while($mqtt->proc()){ }
+    $mqtt->close();
+    
+    function procmsg($topic,$value)
+    { 
+        $time = time();
+        echo $topic." ".$value."\n";
+        
+        global $mqttsettings, $user, $input, $process, $feed;
+        
+        $userid = $mqttsettings['userid'];
+        
+        $inputs = array();
+        
+        $route = explode("/",$topic);
+
+        if ($route[0]==$mqttsettings['basetopic'])
+        {
+            // nodeid defined in topic:  emoncms/input/10
+            if (isset($route[1]))
+            {
+                $nodeid = $route[1];
+                $dbinputs = $input->get_inputs($userid);
+            
+                // input id defined in topic:  emoncms/input/10/1
+                if (isset($route[2]))
+                {
+                    $inputs[] = array("userid"=>$userid, "time"=>$time, "nodeid"=>$nodeid, "name"=>$route[2], "value"=>$value);
+                }
+                else 
+                {
+                    $values = explode(",",$value);
+                    $name = 0;
+                    foreach ($values as $value) {
+                        $inputs[] = array("userid"=>$userid, "time"=>$time, "nodeid"=>$nodeid, "name"=>$name++, "value"=>$value);
+                    }
+                }
+            }
+        }
+        
+        $tmp = array();
+        foreach ($inputs as $i)
+        {
+            $userid = $i['userid'];
+            $time = $i['time'];
+            $nodeid = $i['nodeid'];
+            $name = $i['name'];
+            $value = $i['value'];
+            
+            if (!isset($dbinputs[$nodeid][$name])) {
+                $inputid = $input->create_input($userid, $nodeid, $name);
+                $dbinputs[$nodeid][$name] = true;
+                $dbinputs[$nodeid][$name] = array('id'=>$inputid);
+                $input->set_timevalue($dbinputs[$nodeid][$name]['id'],$time,$value);
+                echo "set_timevalue\n";
+            } else {
+                $inputid = $dbinputs[$nodeid][$name]['id'];
+                $input->set_timevalue($dbinputs[$nodeid][$name]['id'],$time,$value);
+                
+                if ($dbinputs[$nodeid][$name]['processList']) $tmp[] = array('value'=>$value,'processList'=>$dbinputs[$nodeid][$name]['processList']);
+            }
+        }
+        
+        foreach ($tmp as $i) $process->input($time,$i['value'],$i['processList']);
+      
+    }

--- a/scripts/phpmqtt_input.php
+++ b/scripts/phpmqtt_input.php
@@ -4,7 +4,7 @@
     **MQTT input interface script**
     
     SERVICE INSTALL INSTRUCTIONS:
-    https://github.com/emoncms/emoncms/blob/master/docs/RaspberryPi/MQTT.md
+    https://github.com/emoncms/blob/master/docs/RaspberryPi/MQTT.md
     
     EXAMPLES: 
     

--- a/scripts/phpmqtt_input.php
+++ b/scripts/phpmqtt_input.php
@@ -75,9 +75,11 @@
 
     require_once "Modules/process/process_model.php";
     $process = new Process($mysqli,$input,$feed,$user->get_timezone($mqtt_server['userid']));
-  
+
     $mqtt_client = new Mosquitto\Client();
     $mqtt_client->setCredentials($mqtt_server['user'],$mqtt_server['password']);
+    
+    $connected = false;
     $mqtt_client->onConnect('connect');
     $mqtt_client->onDisconnect('disconnect');
     $mqtt_client->onSubscribe('subscribe');
@@ -87,9 +89,32 @@
     $topic = $mqtt_server['basetopic']."/#";
     echo "Subscribing to: ".$topic."\n";
     $mqtt_client->subscribe($topic,2);
-    
-    while($mqtt_client->loop()){ }
-    
+
+    while(true){
+        $mqtt_client->loop();
+        
+    }
+
+    function connect($r, $message) {
+        global $connected;
+        $connected = true;
+    	echo "I got code {$r} and message {$message}\n";
+    }
+
+    function subscribe() {
+	echo "Subscribed to a topic\n";
+    }
+
+    function unsubscribe() {
+	echo "Unsubscribed from a topic\n";
+    }
+
+    function disconnect() {
+        global $connected;
+        $connected = false;
+	echo "Disconnected cleanly\n";
+    }
+
     function message($message)
     { 
         $topic = $message->topic;

--- a/scripts/phpmqtt_input.php
+++ b/scripts/phpmqtt_input.php
@@ -9,19 +9,18 @@
     EXAMPLES: 
     
     create an input from emonTx node called power with value 10:
-        nodes/emontx/power 10
+        [basetopic]/emontx/power 10
     
     create an input from node 10 called power with value 10 :       
-        nodes/10/power 10
+        [basetopic]/10/power 10
         
     create input from emontx with key 0 of value 10
-        nodes/emontx 10
+        [basetopic]/emontx 10
         
     create input from emontx with key 0 of value 10, key 1 of value 11 and key 2 of value 11
-        nodes/emontx 10,11,12
+        [basetopic]/emontx 10,11,12
 
-    
-    * userid has to be set in script (1 default emonPi), no method of setting timestamp
+    * [basetopic] and user ID of target Emoncms account can be set in settings.php
     
     Emoncms then processes these inputs in the same way as they would be
     if sent to the HTTP Api.
@@ -133,7 +132,7 @@
 
         if ($route[0]==$mqtt_server['basetopic'])
         {
-            // nodeid defined in topic:  emoncms/input/10
+            // nodeid defined in topic:  [bsaetopic]/input/10
             if (isset($route[1]))
             {
                 $nodeid = $route[1];

--- a/scripts/phpmqtt_input.php
+++ b/scripts/phpmqtt_input.php
@@ -93,7 +93,7 @@
     $topic = $mqttsettings['basetopic']."/#";
     echo "Subscribing to: ".$topic."\n";
     
-    $topics[$topic] = array("qos"=>2, "function"=>"procmsg");
+    $topics[$topic] = array("qos"=>0, "function"=>"procmsg");
     $mqtt->subscribe($topics,0);
     while($mqtt->proc()){ }
     $mqtt->close();


### PR DESCRIPTION
**Issue**

The old emonHub MQTT topic structure posting a CSV with all the keys for a particular node to topic  `emonhub/rx/[NODEID]/values`. This is not following MQTT recommended practices and this was making it difficult to subscribe to a particular value in other applications (e.g in openHab, nodeRED). 

MQTT best practice states that all MQTT topics should be human readable with one value per topic. 

The [Nodes Module](https://github.com/emoncms/nodes) was used to subscribe to the `emonhub/rx/#` MQTT topic and post the data to Emoncms via the Nodes module interface. 

`RFM69Pi/emonPi > emonHub > MQTT > Emoncms Nodes Module `

**Solution**

1. Modify emonHub to post data to MQTT in the format `[basetopic]/[nodename]/[keyname]` e.g. `emon/emontx/power1`. This new node variable MQTT topic structure can be turned on/off and basetopic set in emonub.conf. The new posting structure is turned on by default in the new [default.emonpi.emonhub.conf](https://github.com/openenergymonitor/emonhub/blob/emon-pi/conf/emonpi.default.emonhub.conf). The old method is implemented by default in [old.default.emonhub.conf](https://github.com/openenergymonitor/emonhub/blob/emon-pi/conf/old.default.emonhub.conf)

2. Use `phpmqtt_input.php` script to subscribe to the base MQTT topic (default `emon/#`) and post to Emoncms Inputs using MQTT topic structure as feed and key name (nodes module not required). *MQTT basetopic to subscribe to can now be set in settings.php. *

`RFM69Pi/emonPi > emonHub > MQTT > Emoncms Inputs`

e.g. `emon/emontx/power1` will result in an input from a node called `emontx` with feed `power1` set to corresponding value. This Input can then be logged to a feed. 

**More Issues!**

It was found that the [bluerhinos PHP MQTT library](https://github.com/bluerhinos/phpMQTT) that phpmqtt_input.php was using was not reliable. This library does not seem to be maintained or developed any more. 

**More Solutions!**

Switch to using  [mgdm PHP-Mosquitto Library](https://github.com/mgdm/Mosquitto-PHP). This required installing some packages and a partial rewrite of phpmqtt_input.php. This library is actively maintained and has proved to be much more reliable. See 'how to install section below'.  

**How this update will effect current users**

If a user is using `phpmqtt_input.php` running as a `mqtt_input` daemon service they will need to update following the guide below. Is is expected that this will only effect a minority of users. MQTT input service was not implemented on any of our pre-build SD card images. The user will also have to update to the latest settings.php


**How to Update**

[Follow MQTT Raspberry Pi Install guide](https://github.com/emoncms/emoncms/blob/dev-mosquitto-php/docs/RaspberryPi/MQTT.md). 

*Note: there is no reason why this solutions should not work on non-Raspberry Pi setups. Non Raspberry Pi support should be improved now the Nodes modules (that was written for emonPi) is not used any more*

**Going Forward**

We will implement this new MQTT topic structure and depreciate the Nodes module on the next emonPi / emonBase pre-build SD card image based on Raspbian Jessie Lite (currently a weeks away from beta release)

**Related Forum Topic**

http://openenergymonitor.org/emon/node/12091