### PR TITLE
Update feed_model.php

### DIFF
--- a/Modules/feed/feed_model.php
+++ b/Modules/feed/feed_model.php
@@ -453,6 +453,7 @@ class Feed
                 
                 // Merge buffered data into base data timeslots (over-writing null values where they exist)
                 if ($engine==Engine::PHPFINA || $engine==Engine::PHPTIMESERIES) {
+                    if ( $outinterval < 1 ) { $outinterval = (int) 1; } //Fix div by zero errors
                     $outintervalms = $outinterval * 1000;
                     
                     // Convert buffered data to associative array - by timestamp

--- a/Modules/user/profile/profile.php
+++ b/Modules/user/profile/profile.php
@@ -98,12 +98,12 @@ function languagecode_to_name($langs) {
         <br>
         <div id="account">
         <div class="account-item">
-            <span class="muted"><?php echo _('Write API Key'); ?></span> <button id="copyapiwritebtn">Copy to Clipboard</button>
+            <span class="muted"><?php echo _('Write API Key'); ?></span> <button class="btn btn-info" id="copyapiwritebtn">Copy API Key</button>
             <!--<a id="newapikeywrite" >new</a>-->
             <span class="writeapikey" id="copyapiwrite"></span>
         </div>
         <div class="account-item">
-            <span class="muted"><?php echo _('Read API Key'); ?></span> <button id="copyapireadbtn">Copy to Clipboard</button>
+            <span class="muted"><?php echo _('Read API Key'); ?></span> <button class="btn btn-info" id="copyapireadbtn">Copy API Key</button>
             <!--<a id="newapikeyread" >new</a>-->
             <span class="readapikey" id="copyapiread"></span>
             <span id="msg"></span>


### PR DESCRIPTION
Added line 456 to mitigate divide by 0 errors;
This is *NOT* the correct way to fix this issue, this is a reference only to help some of you understand where the issue is.
I have not worked out yet where the variable $outinterval is supposed to be populated from, but at this point in the code its either null or 0 - and this un turn causes the divide by 0 errors.

My code simply detects when $outinterval is less than 1 and sets this variable to 1 before its used. (on line 457 in this version).

Applying my code appears to fix the connection issues with the android app, fixing the divide by zero cleaned that right up, but my fix may have other consequences (although quite unlikely).