### PR TITLE
Graph clean up, add reboot button.

### DIFF
--- a/Modules/admin/admin_main_view.php
+++ b/Modules/admin/admin_main_view.php
@@ -182,9 +182,8 @@ if ($mqtt_enabled) {
 <?php
 } // Raspberry Pi Detection and additions.
 if ( exec('ifconfig | grep b8:27:eb:') ) {
-              if (isset($rebootPi)) { shell_exec('sudo shutdown -r now'); }
-              echo "              <tr><td><b>Pi</b></td><td>CPU Temp</td><td>".number_format((int)exec('cat /sys/class/thermal/thermal_zone0/temp')/1000, '2', '.', '')."&degC
-                <button id=\"rebootPi\" class=\"btn btn-info btn-small pull-right\">"._('Reboot')."</button></td></tr>\n";
+              if (isset($rebootPi)) { shell_exec('sudo shutdown -r now 2>&1'); }
+              echo "              <tr><td><b>Pi</b></td><td>CPU Temp</td><td>".number_format((int)exec('cat /sys/class/thermal/thermal_zone0/temp')/1000, '2', '.', '')."&degC".chkRebootBtn()."</td></tr>\n";
                 define("ramTotal", "ramTotal");
                 define("ramUsed", "ramUsed");
                 $sysRamTotal = get_server_memory_usage(ramTotal);
@@ -199,6 +198,7 @@ if ( exec('ifconfig | grep b8:27:eb:') ) {
                 echo "<td style=\"border-top-right-radius: 10px; border-bottom-right-radius: 10px;\" bgcolor=\"#d0d0d0\" height=\"10px\" width=\"".$sysRamInvPercent."%\"></td></tr></table>\n";
                 echo "<b>RAM Total:</b> ".$sysRamTotal."MB <b>RAM Used:</b> ".$sysRamUsed."MB <b>RAM Free:</b> ".$sysRamRemaining."MB <b>Used %</b> ".$sysRamPercent."%</td></tr>\n";
 }
+
 // Filesystem Information
 if (is_file('/bin/lsblk')){ // Make sure we can actually do this
               echo "              <tr><td><b>Filesystems</b></td><td>Mount Point</td><td>Disk Stats</td></tr>\n";
@@ -328,5 +328,12 @@ function get_server_memory_usage($field){
   if ($field == 'ramTotal') { return $memory_usage[1]; }
   if ($field == 'ramUsed') { return $memory_bufcache[2]; }
   if (!isset($field)) { return "Total: ".$memory_usage[1]." MB, In use: ".$memory_bufcache[2]." MB"; }
+}
+//Shutdown Command Check
+function chkRebootBtn(){
+  $chkReboot = shell_exec('sudo shutdown -k --no-wall 2>&1');
+  if (stripos($chkReboot, "scheduled ") > 0) {
+    return "<button id=\"rebootPi\" class=\"btn btn-info btn-small pull-right\">"._('Reboot')."</button>";
+  }
 }
 ?>

--- a/Modules/admin/admin_main_view.php
+++ b/Modules/admin/admin_main_view.php
@@ -1,6 +1,6 @@
 
 
-<?php global $path, $emoncms_version, $allow_emonpi_admin, $log_enabled, $log_filename, $mysqli, $redis_enabled, $redis, $mqtt_enabled, $feed_settings;
+<?php global $path, $emoncms_version, $allow_emonpi_admin, $log_enabled, $log_filename, $mysqli, $redis_enabled, $redis, $mqtt_enabled, $feed_settings, $rebootPi;
 
   // Retrieve server information
   $system = system_information();
@@ -182,8 +182,9 @@ if ($mqtt_enabled) {
 <?php
 } // Raspberry Pi Detection and additions.
 if ( exec('ifconfig | grep b8:27:eb:') ) {
-              echo "              <tr><td><b>Pi</b></td><td>CPU Temp</td><td>".number_format((int)exec('cat /sys/class/thermal/thermal_zone0/temp')/1000, '2', '.', '')."&degC</td></tr>\n";
-              echo "              <tr><td class=\"subinfo\"></td><td>System Load</td><td>".get_server_load()."</td></tr>\n";
+              if (isset($rebootPi)) { shell_exec('sudo shutdown -r now'); }
+              echo "              <tr><td><b>Pi</b></td><td>CPU Temp</td><td>".number_format((int)exec('cat /sys/class/thermal/thermal_zone0/temp')/1000, '2', '.', '')."&degC
+                <button id=\"rebootPi\" class=\"btn btn-info btn-small pull-right\">"._('Reboot')."</button></td></tr>\n";
                 define("ramTotal", "ramTotal");
                 define("ramUsed", "ramUsed");
                 $sysRamTotal = get_server_memory_usage(ramTotal);
@@ -202,6 +203,7 @@ if ( exec('ifconfig | grep b8:27:eb:') ) {
 if (is_file('/bin/lsblk')){ // Make sure we can actually do this
               echo "              <tr><td><b>Filesystems</b></td><td>Mount Point</td><td>Disk Stats</td></tr>\n";
               $fileSysems = explode("\n", shell_exec('lsblk -n -o MOUNTPOINT | grep /'));
+              if (strpos(shell_exec('cat /proc/mounts'), "tmpfs /var/log tmpfs") !== false) { array_push($fileSysems, "/var/log"); }
                 foreach($fileSysems as $fs) {
                   if ($fs != "") {
                     $diskFree = disk_free_space($fs);
@@ -306,6 +308,11 @@ function backup_log_update() {
     }
   });
 }
+$("#rebootPi").click(function() {
+  if(confirm('Please confirm you wish to reboot your Pi, this will take approximately 30 secs to complete...')) {
+    $.post( location.href, { rebootPi: "1" } );
+  }
+});
 </script>
 <?php //Disk Size function
 function formatSize( $bytes ){
@@ -321,12 +328,5 @@ function get_server_memory_usage($field){
   if ($field == 'ramTotal') { return $memory_usage[1]; }
   if ($field == 'ramUsed') { return $memory_bufcache[2]; }
   if (!isset($field)) { return "Total: ".$memory_usage[1]." MB, In use: ".$memory_bufcache[2]." MB"; }
-}
-
-//Server Load function
-function get_server_load(){
-  $loadCmd = substr(strrchr(shell_exec("uptime"),":"),1); 
-  $load = array_map("trim",explode(",",$loadCmd));
-  return $load[0]." ".$load[1]." ".$load[2];
 }
 ?>

--- a/Modules/admin/admin_main_view.php
+++ b/Modules/admin/admin_main_view.php
@@ -331,8 +331,9 @@ function get_server_memory_usage($field){
 }
 //Shutdown Command Check
 function chkRebootBtn(){
-  $chkReboot = shell_exec('sudo shutdown -k --no-wall 2>&1');
+  $chkReboot = shell_exec('sudo shutdown -k --no-wall 2>&1'); //Try and run a fake shutdown
   if (stripos($chkReboot, "scheduled ") > 0) {
+    shell_exec('sudo shutdown -c --no-wall'); //Cancel the fake shutdown
     return "<button id=\"rebootPi\" class=\"btn btn-info btn-small pull-right\">"._('Reboot')."</button>";
   }
 }

--- a/index.php
+++ b/index.php
@@ -106,6 +106,11 @@
         $session = $user->emon_session_start();
     }
 
+    // Reboot Code Handler
+    if (isset($_POST['rebootPi'])) {
+      $rebootPi = "TRUE";
+    }
+
     // 4) Language
     if (!isset($session['lang'])) $session['lang']='';
     set_emoncms_lang($session['lang']);

--- a/index.php
+++ b/index.php
@@ -106,9 +106,11 @@
         $session = $user->emon_session_start();
     }
 
-    // Reboot Code Handler
-    if (isset($_POST['rebootPi'])) {
-      $rebootPi = "TRUE";
+    // Shutdown / Reboot Code Handler
+    if (isset($_POST['shutdownPi'])) { 
+      $shutdownPi = trim($_POST['shutdownPi']);
+      $shutdownPi = stripslashes($shutdownPi);
+      $shutdownPi = htmlspecialchars($shutdownPi);
     }
 
     // 4) Language


### PR DESCRIPTION
Cleaned up the code around the graphs for RAM / disk usage.
Show RAM graph for Pi hardware only.
Show /var/log specifically when its mounted on tempfs

The reboot button does require a supporting change in `/etc/sudoers`
`,/sbin/shutdown` should be appended to the www-data line to allow Apache to be able to execute the shutdown command.

The reboot code has been setup such that it can ONLY be executed on Pi hardware, this is a safety measure to help reduce any risks on production class (read non raspberry pi) hardware.