### PR TITLE
Multigraph, new options - stack, refresh

### DIFF
--- a/Modules/vis/Views/multigraph_edit.js
+++ b/Modules/vis/Views/multigraph_edit.js
@@ -11,6 +11,8 @@ var multigraphs=[];
 var multigraphs_name=[];
 var movingtime = false;
 var showtag = true;
+var autorefresh = 0;
+var showlegend = true;
 
 var baseElement = "#box-options";
 
@@ -55,6 +57,16 @@ function draw_multigraph_feedlist_editor(){
   else
     showtag = true;
 
+  if (typeof multigraph_feedlist[0] !== 'undefined' && typeof multigraph_feedlist[0]['autorefresh'] !== 'undefined')
+    autorefresh = multigraph_feedlist[0]['autorefresh'];
+  else
+    autorefresh = 0;
+
+  if (typeof multigraph_feedlist[0] !== 'undefined' && typeof multigraph_feedlist[0]['showlegend'] !== 'undefined')
+    showlegend = multigraph_feedlist[0]['showlegend'];
+  else
+    showlegend = true;
+
   var out = "";
   out += '<div id="myModal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true" data-backdrop="static">';
   out += '<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button><h3 id="myModalLabel">Delete Multigraph</h3></div>';
@@ -86,7 +98,10 @@ function draw_multigraph_feedlist_editor(){
     out += "<tr>";
     out += "<td style='text-align: right;vertical-align:middle;border-color:transparent;'>Skip missing data</td>";
     out += "<td style='text-align: center;vertical-align:middle;'><input id='skipmissing'  listid='"+z+"' type='checkbox' "+checked+" /></td>";
-    out += "<td colspan='3'></td>";
+    var checked = ""; if (multigraph_feedlist[z]['stacked']) checked = "checked";
+    out += "<td style='text-align: right;vertical-align:middle;border-color:transparent;'>Stack</td>";
+    out += "<td style='text-align: center;vertical-align:middle;'><input id='stacked'  listid='"+z+"' type='checkbox' "+checked+" /></td>";
+    out += "<td ></td>";
     out += "</tr>";
     if (publicfeed == 1) publicfeed = (get_feed_public(multigraph_feedlist[z]['id']));
   }
@@ -108,6 +123,17 @@ function draw_multigraph_feedlist_editor(){
   out += "<tr><td>Show tag name</strong></td>";
   var checked = ""; if (showtag) checked = "checked";
   out += "<td><input id='showtag' type='checkbox' "+checked+" /></td>";
+  out += "<td></td>";
+  out += "<td></td>";
+  out += "<td></td></tr>";
+  out += "<tr><td>Refresh Interval(s)</strong></td>";
+  out += "<td><input style='width:110px' id='autorefresh' value='" + autorefresh + "'/></td>";
+  out += "<td></td>";
+  out += "<td></td>";
+  out += "<td></td></tr>";
+  out += "<tr><td>Show Legend</strong></td>";
+  var checked = ""; if (showlegend) checked = "checked";
+  out += "<td><input id='showlegend' type='checkbox' "+checked+" /></td>";
   out += "<td></td>";
   out += "<td></td>";
   out += "<td></td></tr>";
@@ -203,6 +229,18 @@ function load_events(){
     vis_feed_data();
     modified();
   });
+  $(baseElement).on("change","#autorefresh",function(event){
+    autorefresh = $(this)[0].value;
+    multigraph_feedlist[0]['autorefresh'] = autorefresh;
+    // vis_feed_data(); doesn't affect data
+    modified();
+  });
+  $(baseElement).on("click","#showlegend",function(event){
+    showlegend = $(this)[0].checked;
+    multigraph_feedlist[0]['showlegend'] = showlegend;
+    vis_feed_data();
+    modified();
+  });
   // Event for every change event in the lineColour input for each line in the plot.
   $(baseElement).on("input","#lineColour",function(event){
     var z = $(this).attr('listid');
@@ -222,7 +260,14 @@ function load_events(){
     modified();
   });
   
-  $(baseElement).on("click",".left",function(event){
+   $(baseElement).on("click","#stacked",function(event){
+    var z = $(this).attr('listid');
+    multigraph_feedlist[z]['stacked'] = $(this)[0].checked;
+    vis_feed_data();
+    modified();
+  });
+  
+ $(baseElement).on("click",".left",function(event){
     var z = $(this).attr('listid');
     multigraph_feedlist[z]['left'] = $(this)[0].checked;
     if (multigraph_feedlist[z]['left'] == true && multigraph_feedlist[z]['right'] == true)

--- a/Modules/vis/Views/vis_main_view.php
+++ b/Modules/vis/Views/vis_main_view.php
@@ -14,6 +14,7 @@ Part of the OpenEnergyMonitor project: http://openenergymonitor.org
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.touch.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.togglelegend.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/jquery.flot.time.min.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/jquery.flot.stack.min.js"></script>
 
 <script language="javascript" type="text/javascript" src="<?php echo $path; ?>Modules/vis/visualisations/common/api.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path; ?>Modules/vis/visualisations/common/vis.helper.js"></script>

--- a/Modules/vis/visualisations/multigraph.php
+++ b/Modules/vis/visualisations/multigraph.php
@@ -18,6 +18,7 @@
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.touch.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.togglelegend.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.time.min.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.stack.min.js"></script>
 
 <script language="javascript" type="text/javascript" src="<?php echo $path; ?>Modules/vis/visualisations/common/api.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path; ?>Modules/vis/visualisations/common/vis.helper.js"></script>

--- a/Modules/vis/visualisations/multigraph/multigraph.js
+++ b/Modules/vis/visualisations/multigraph/multigraph.js
@@ -2,10 +2,12 @@ var plotdata = [];
 var timeWindowChanged = 0;
 var ajaxAsyncXdr = [];
 var event_vis_feed_data;
+var showlegend = true;
   
 function convert_to_plotlist(multigraph_feedlist) {
   var plotlist = [];
   var showtag = (multigraph_feedlist[0]['showtag'] != undefined ? multigraph_feedlist[0]['showtag'] : true);
+  showlegend = (multigraph_feedlist[0]['showlegend']==undefined || multigraph_feedlist[0]['showlegend']);
   for (z in multigraph_feedlist) {
     var tag = (showtag && multigraph_feedlist[z]['tag']!=undefined && multigraph_feedlist[z]['tag']!="" ? multigraph_feedlist[z]['tag']+": " : "");
     if (multigraph_feedlist[z]['datatype']==1) {
@@ -15,6 +17,7 @@ function convert_to_plotlist(multigraph_feedlist) {
         plot: {
           data: null,
           label: tag + multigraph_feedlist[z]['name'],
+ 		  stack: stacked,
           points: { 
             show: true,
             radius: 0,
@@ -23,7 +26,7 @@ function convert_to_plotlist(multigraph_feedlist) {
           },
           lines: {
             show: true,
-            fill: multigraph_feedlist[z]['fill']
+            fill: multigraph_feedlist[z]['fill'] ? (stacked ? 1.0 : 0.5) : 0.0
           }
         }
       };
@@ -36,9 +39,11 @@ function convert_to_plotlist(multigraph_feedlist) {
         plot: {
           data: null,
           label: tag + multigraph_feedlist[z]['name'],
+		  stack: stacked,
           bars: {
             show: true,
-            align: "left", barWidth: 3600*24*1000, fill: multigraph_feedlist[z]['fill']
+            align: "left", barWidth: 3600*24*1000,
+			fill: multigraph_feedlist[z]['fill'] ? (stacked ? 1.0 : 0.5) : 0.0
           }
         }
       };
@@ -76,8 +81,24 @@ function convert_to_plotlist(multigraph_feedlist) {
  Handle Feeds
 */
 
-// Ignore load request spurts
 function vis_feed_data() {
+	if (multigraph_feedlist !== undefined && multigraph_feedlist[0] != undefined && multigraph_feedlist[0]['autorefresh'] != undefined) {
+	  var now = new Date().getTime();
+	  var timeWindow = view.end - view.start;
+	  if (now - view.end < 2000 * multigraph_feedlist[0]['autorefresh']) {
+	    view.end = now;
+	    view.start = view.end - timeWindow;
+        vis_feed_data1();
+	    setTimeout(vis_feed_data, 1000 * multigraph_feedlist[0]['autorefresh']);
+      } else{		
+        vis_feed_data1();
+	  }
+    } else{		
+      vis_feed_data1();
+	}
+ }
+// Ignore load request spurts
+function vis_feed_data1() {
    clearTimeout(event_vis_feed_data); // Cancel any pending events
    event_vis_feed_data = setTimeout(function() { vis_feed_data_delayed(); }, 500);
    if (multigraph_feedlist !== undefined && multigraph_feedlist.length != plotdata.length) plotdata = [];
@@ -133,7 +154,7 @@ function plot() {
     grid: { show: true, hoverable: true, clickable: true },
     xaxis: { mode: "time", timezone: "browser", min: view.start, max: view.end },
     selection: { mode: "x" },
-    legend: { position: "nw", toggle: true },
+    legend: { show: showlegend, position: "nw", toggle: true },
     toggle: { scale: "visible" },
     touch: { pan: "x", scale: "x" }
   });

--- a/Modules/vis/visualisations/multigraph/multigraph.js
+++ b/Modules/vis/visualisations/multigraph/multigraph.js
@@ -8,6 +8,7 @@ function convert_to_plotlist(multigraph_feedlist) {
   var plotlist = [];
   var showtag = (multigraph_feedlist[0]['showtag'] != undefined ? multigraph_feedlist[0]['showtag'] : true);
   showlegend = (multigraph_feedlist[0]['showlegend']==undefined || multigraph_feedlist[0]['showlegend']);
+  var stacked = (multigraph_feedlist[z]['stacked']!=undefined && multigraph_feedlist[z]['stacked']);
   for (z in multigraph_feedlist) {
     var tag = (showtag && multigraph_feedlist[z]['tag']!=undefined && multigraph_feedlist[z]['tag']!="" ? multigraph_feedlist[z]['tag']+": " : "");
     if (multigraph_feedlist[z]['datatype']==1) {

--- a/Modules/vis/visualisations/multigraph/multigraph.js
+++ b/Modules/vis/visualisations/multigraph/multigraph.js
@@ -8,9 +8,9 @@ function convert_to_plotlist(multigraph_feedlist) {
   var plotlist = [];
   var showtag = (multigraph_feedlist[0]['showtag'] != undefined ? multigraph_feedlist[0]['showtag'] : true);
   showlegend = (multigraph_feedlist[0]['showlegend']==undefined || multigraph_feedlist[0]['showlegend']);
-  var stacked = (multigraph_feedlist[z]['stacked']!=undefined && multigraph_feedlist[z]['stacked']);
   for (z in multigraph_feedlist) {
     var tag = (showtag && multigraph_feedlist[z]['tag']!=undefined && multigraph_feedlist[z]['tag']!="" ? multigraph_feedlist[z]['tag']+": " : "");
+    var stacked = (multigraph_feedlist[z]['stacked']!=undefined && multigraph_feedlist[z]['stacked']);
     if (multigraph_feedlist[z]['datatype']==1) {
       plotlist[z] = {
         id: multigraph_feedlist[z]['id'],


### PR DESCRIPTION
Add new options on Multigraph:
Lines/Bars can be defined as 'stacked'. E.g. can be used to show usage on individual branch circuits combining to a total usage.
The graph can be set to 'auto refresh' periodically. So that a dashboard can be configured to automatically update with current data. (The automatic update will be disabled if the graph has been scrolled so that the current time is no longer the end of the graph)
Show/Hide Legend. Either for simple graphs where the title is all that's needed. Or on a dashboard where multiple graphs have the same legend & only needs shown once.