### PR TITLE
Encapsulate redis configuration

### DIFF
--- a/Lib/Config/RedisConfig.php
+++ b/Lib/Config/RedisConfig.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Emoncms\Config;
+
+class RedisConfig
+{
+    /**
+     * @var string
+     */
+    private $host;
+
+    /**
+     * @var int
+     */
+    private $port;
+
+    /**
+     * @var string
+     */
+    private $auth;
+
+    /**
+     * @var string
+     */
+    private $prefix;
+
+    /**
+     * @var bool
+     */
+    private $isRedisEnabled;
+
+    /**
+     * @param bool $isRedisEnabled
+     * @param string $host
+     * @param int $port
+     * @param string $auth
+     * @param string $prefix
+     */
+    public function __construct($isRedisEnabled, $host, $port, $auth, $prefix)
+    {
+        $this->isRedisEnabled = $isRedisEnabled;
+        $this->host = $host;
+        $this->port = $port;
+        $this->auth = $auth;
+        $this->prefix = $prefix;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHost()
+    {
+        return $this->host;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPort()
+    {
+        return $this->port;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAuth()
+    {
+        return $this->auth;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasAuth()
+    {
+        return !empty($this->auth);
+    }
+
+    /**
+     * @return string
+     */
+    public function getPrefix()
+    {
+        return $this->prefix;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasPrefix()
+    {
+        return !empty($this->prefix);
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasValidConfig()
+    {
+        return $this->isRedisEnabled && !empty($this->host) && !empty($this->port);
+    }
+}

--- a/Lib/Redis/Redis.php
+++ b/Lib/Redis/Redis.php
@@ -19,22 +19,16 @@ class Redis
 
     /**
      * @param RedisConfig $config
+     * @throws Exception
      */
     public function __construct(RedisConfig $config)
     {
         $this->config = $config;
+        $this->initialize();
     }
 
     /**
-     * @return bool
-     */
-    public function isRedisEnabled()
-    {
-        return $this->config->hasValidConfig();
-    }
-
-    /**
-     * Get Redis connection. Return false if connection not setup.
+     * Get Redis connection. Return false if connection not connected.
      *
      * @return \Redis|false
      */
@@ -69,7 +63,7 @@ class Redis
      * @return \Redis
      * @throws Exception
      */
-    public function connect()
+    private function initialize()
     {
         $this->redis = new \Redis();
         $connected = $this->redis->connect($this->config->getHost(), $this->config->getPort());

--- a/Lib/Redis/Redis.php
+++ b/Lib/Redis/Redis.php
@@ -24,7 +24,10 @@ class Redis
     public function __construct(RedisConfig $config)
     {
         $this->config = $config;
-        $this->initialize();
+
+        if ($this->config->hasValidConfig()) {
+            $this->initialize();
+        }
     }
 
     /**

--- a/Lib/Redis/Redis.php
+++ b/Lib/Redis/Redis.php
@@ -40,7 +40,7 @@ class Redis
      */
     public function getRedis()
     {
-        if ($this->redis === null) {
+        if (!$this->isConnected()) {
             return false;
         }
         

--- a/Lib/Redis/Redis.php
+++ b/Lib/Redis/Redis.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Emoncms\Redis;
+
+use Emoncms\Config\RedisConfig;
+use Exception;
+
+class Redis
+{
+    /**
+     * @var RedisConfig
+     */
+    private $config;
+
+    /**
+     * @var \Redis
+     */
+    private $redis;
+
+    /**
+     * @param RedisConfig $config
+     */
+    public function __construct(RedisConfig $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isRedisEnabled()
+    {
+        return $this->config->hasValidConfig();
+    }
+
+    /**
+     * Get Redis connection.
+     *
+     * @return \Redis
+     */
+    public function getRedis()
+    {
+        return $this->redis;
+    }
+
+    /**
+     * Close Redis connection.
+     */
+    public function close()
+    {
+        if ($this->isConnected()) {
+            $this->redis->close();
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function isConnected()
+    {
+        return $this->redis !== null;
+    }
+
+    /**
+     * @return \Redis
+     * @throws Exception
+     */
+    public function connect()
+    {
+        $this->redis = new \Redis();
+        $connected = $this->redis->connect($this->config->getHost(), $this->config->getPort());
+
+        if (!$connected) {
+            throw new Exception(sprintf('Cannot connect to redis at %s:%d, it may be that redis-server is not installed or started see readme for redis installation',
+                $this->config->getHost(), $this->config->getPort()));
+        }
+
+        if ($this->config->hasPrefix()) {
+            $this->redis->setOption(\Redis::OPT_PREFIX, $this->config->getPrefix());
+        }
+
+        if ($this->config->hasAuth()) {
+            if (!$this->redis->auth($this->config->getAuth())) {
+                throw new Exception(sprintf('Cannot connect to redis at %s:%d, authentication failed',
+                    $this->config->getHost(), $this->config->getPort()));
+            }
+        }
+    }
+
+}

--- a/Lib/Redis/Redis.php
+++ b/Lib/Redis/Redis.php
@@ -34,12 +34,16 @@ class Redis
     }
 
     /**
-     * Get Redis connection.
+     * Get Redis connection. Return false if connection not setup.
      *
-     * @return \Redis
+     * @return \Redis|false
      */
     public function getRedis()
     {
+        if ($this->redis === null) {
+            return false;
+        }
+        
         return $this->redis;
     }
 

--- a/Modules/user/user_model.php
+++ b/Modules/user/user_model.php
@@ -12,15 +12,22 @@
 // no direct access
 defined('EMONCMS_EXEC') or die('Restricted access');
 
+use Emoncms\Redis\Redis;
+
 class User
 {
     private $mysqli;
     private $rememberme;
     private $enable_rememberme = false;
+
+    /**
+     * @var \Redis
+     */
     private $redis;
+
     private $log;
 
-    public function __construct($mysqli,$redis)
+    public function __construct(mysqli $mysqli, Redis $redis)
     {
         //copy the settings value, otherwise the enable_rememberme will always be false.
         global $enable_rememberme;
@@ -31,7 +38,7 @@ class User
         require "Modules/user/rememberme_model.php";
         $this->rememberme = new Rememberme($mysqli);
 
-        $this->redis = $redis;
+        $this->redis = $redis->getRedis();
         $this->log = new EmonLogger(__FILE__);
     }
 

--- a/Modules/user/user_model.php
+++ b/Modules/user/user_model.php
@@ -10,9 +10,9 @@
 */
 
 // no direct access
-defined('EMONCMS_EXEC') or die('Restricted access');
+use Redis;
 
-use Emoncms\Redis\Redis;
+defined('EMONCMS_EXEC') or die('Restricted access');
 
 class User
 {
@@ -21,13 +21,13 @@ class User
     private $enable_rememberme = false;
 
     /**
-     * @var \Redis
+     * @var Redis
      */
     private $redis;
 
     private $log;
 
-    public function __construct(mysqli $mysqli, Redis $redis)
+    public function __construct(mysqli $mysqli, $redis)
     {
         //copy the settings value, otherwise the enable_rememberme will always be false.
         global $enable_rememberme;
@@ -38,7 +38,7 @@ class User
         require "Modules/user/rememberme_model.php";
         $this->rememberme = new Rememberme($mysqli);
 
-        $this->redis = $redis->getRedis();
+        $this->redis = $redis;
         $this->log = new EmonLogger(__FILE__);
     }
 

--- a/index.php
+++ b/index.php
@@ -12,7 +12,7 @@
     */
 
     use Emoncms\Config\RedisConfig;
-    use Emoncms\Redis\Redis;
+    use Emoncms\Redis\RedisFactory;
 
     $ltime = microtime(true);
     define('EMONCMS_EXEC', 1);
@@ -40,13 +40,13 @@
 
 
     try {
-        require "Lib/Redis/Redis.php";
-        $emonRedis = new Redis($redisConfig);
+        require "Lib/Redis/RedisFactory.php";
+        $redisFactory = new RedisFactory($redisConfig);
     } catch (Exception $e) {
         echo $e->getMessage(); die;
     }
 
-    $redis = $emonRedis->getRedis();
+    $redis = $redisFactory->getRedis();
 
     $mqtt = false;
 
@@ -68,7 +68,7 @@
 
     // 3) User sessions
     require("Modules/user/user_model.php");
-    $user = new User($mysqli, $emonRedis);
+    $user = new User($mysqli, $redis);
 
     $apikey = false;
     $devicekey = false;

--- a/index.php
+++ b/index.php
@@ -38,13 +38,12 @@
         $redis_server['prefix']
     );
 
-    if ($redisConfig->hasValidConfig()) {
-        try {
-            require "Lib/Redis/Redis.php";
-            $emonRedis = new Redis($redisConfig);
-        } catch (Exception $e) {
-            echo $e->getMessage(); die;
-        }
+
+    try {
+        require "Lib/Redis/Redis.php";
+        $emonRedis = new Redis($redisConfig);
+    } catch (Exception $e) {
+        echo $e->getMessage(); die;
     }
 
     $redis = $emonRedis->getRedis();

--- a/index.php
+++ b/index.php
@@ -38,11 +38,10 @@
         $redis_server['prefix']
     );
 
-    require "Lib/Redis/Redis.php";
-    $emonRedis =  new Redis($redisConfig);
-    if ($emonRedis->isRedisEnabled()) {
+    if ($redisConfig->hasValidConfig()) {
         try {
-            $emonRedis->connect();
+            require "Lib/Redis/Redis.php";
+            $emonRedis = new Redis($redisConfig);
         } catch (Exception $e) {
             echo $e->getMessage(); die;
         }

--- a/index.php
+++ b/index.php
@@ -40,15 +40,15 @@
 
     require "Lib/Redis/Redis.php";
     $emonRedis =  new Redis($redisConfig);
-    $redis = false;
     if ($emonRedis->isRedisEnabled()) {
         try {
             $emonRedis->connect();
-            $redis = $emonRedis->getRedis();
         } catch (Exception $e) {
             echo $e->getMessage(); die;
         }
     }
+
+    $redis = $emonRedis->getRedis();
 
     $mqtt = false;
 


### PR DESCRIPTION
I think we should start to try and wrap some of the configuration settings into classes to provide more structure and make it easier to slowly move away from `global $blah` declarations. I went with the Redis settings as they are fairly straight forward to wrap.

I maintained `$redis = false` to keep BC with all modules so it shouldn't impact anything. Also Redis has been setup on the vagrant scripts so you can test this out with that :+1: 
## Todo
- Add tests ;D
## To Discuss
- Do you think this is a good idea?
- Since we should be using namespaces, where should such files live? I stuck these in `/Libs` for now, but is this where we want to keep things?
- Autoloading (I vote following PSR-0 or PSR-4, but we should really use composer to handle this)
- Testing,  we need to organize the code file structure e.g. we could have `/Libs/Config/RedisConfig.php` and `/Libs/Test/Config/RedisConfig.php`. Where the test structure mirrors the Libs folder.
