### PR TITLE
is_nan throws an error if used on empty string

### DIFF
--- a/Modules/process/process_processlist.php
+++ b/Modules/process/process_processlist.php
@@ -803,7 +803,7 @@ class Process_ProcessList
                 $p = 0;
                 $sum = 0;
                 while($p<$cnt) {
-                    if (isset($data[$p][1]) && !is_nan($data[$p][1])) {
+                    if (isset($data[$p][1]) && is_numeric($data[$p][1])) {
                         $sum += $data[$p][1];
                     }
                     $p++;


### PR DESCRIPTION
This error occurs when creating a virtual feed comprised of newly created feeds resulting in the list of feeds not displaying.