### PR TITLE
Add a colour option to the realtime visualisation type

### DIFF
--- a/Modules/vis/vis_object.php
+++ b/Modules/vis/vis_object.php
@@ -18,7 +18,9 @@
     $visualisations = array(
     
         'realtime' => array('label'=>_("RealTime"), 'options'=>array(
-            array('feedid',_("feed"),1))
+            array('feedid',_("feed"),1),
+            array('colour',_("colour"),9,'EDC240'),
+            )
         ),
         
         // Hex colour EDC240 is the default color for flot. since we want existing setups to not change, we set the default value to it manually now,

--- a/Modules/vis/visualisations/realtime.php
+++ b/Modules/vis/visualisations/realtime.php
@@ -12,7 +12,8 @@
 <!--[if IE]><script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/excanvas.min.js"></script><![endif]-->
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.time.min.js"></script>
-<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Modules/vis/visualisations/common/api.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/api.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/vis.helper.js"></script>
     
     <?php if (!$embed) { ?>
     <h2><?php echo _("Realtime data:"); ?> <?php echo $feedidname; ?></h2>
@@ -38,6 +39,12 @@
     var timerget;
     var timeWindow = (900*1000);  //Initial 15m time window
     var fast_update_fps = 10;
+
+    var plotColour = urlParams.colour;
+    if (plotColour==undefined || plotColour=='') plotColour = "EDC240";
+    if (plotColour.indexOf("#") == -1) {
+        plotColour = "#" + plotColour;
+    }
     
     var graph_bound = $('#graph_bound'),
     graph = $("#graph");
@@ -94,8 +101,9 @@
     }
 
     function plot(){
-      $.plot(graph,[{data: data, lines: { fill: true }}],
+      $.plot(graph,[{data: data, color: plotColour}],
       {
+        lines: { fill: true },
         series: { shadowSize: 0 },
         xaxis: { tickLength:10, mode: "time", timezone: "browser", min: start, max: end }
       });

--- a/Modules/vis/widget/vis_render.js
+++ b/Modules/vis/widget/vis_render.js
@@ -16,10 +16,10 @@ function vis_widgetlist(){
     {
       "offsetx":0,"offsety":0,"width":400,"height":300,
       "menu":"Visualisations",
-      "options":["feedid"],
-      "optionstype":["feedid"],
-      "optionsname":[_Tr("Feed")],
-      "optionshint":[_Tr("Feed source")],
+      "options":["feedid","colour"],
+      "optionstype":["feedid","colour_picker"],
+      "optionsname":[_Tr("Feed"),_Tr("Colour")],
+      "optionshint":[_Tr("Feed source"),_Tr("Line colour in hex. Blank is use default.")],
       "html":""
     },
 


### PR DESCRIPTION
This pull request adds a colour option to the realtime visualisation type.

<img width="1055" alt="screen shot 2016-09-06 at 15 16 57" src="https://cloud.githubusercontent.com/assets/753010/18277056/05489d6e-7445-11e6-8a86-59ae96de6b0e.png">
