### PR TITLE
New endpoint for feed list with start of day, month, year values added

### DIFF
--- a/Modules/feed/engine/PHPFina.php
+++ b/Modules/feed/engine/PHPFina.php
@@ -277,6 +277,46 @@ class PHPFina
         }
         return false;
     }
+    
+    /**
+     * Get array with last day, month or year time and value from a feed
+     *
+     * @param integer $feedid The id of the feed
+     * @param integer $time The time to get
+     * @param bool $clip If $time is before the start or after the end, clip to the start/end
+    */
+    public function valueattime($feedid, $time, $clip)
+    {
+        if (!$meta = $this->get_meta($feedid)) return false;
+        $meta->npoints = $this->get_npoints($feedid);
+        
+        $pos = round(($time - $meta->start_time) / $meta->interval);
+        if ($clip) {
+            if ($pos < 0) {
+                $pos = 0;
+                $time = $meta->start_time;
+            } else if ($pos >= $meta->npoints) {
+                $pos = $meta->npoints - 1;
+                $time = $meta->start_time + ($pos * $meta->interval);
+            }
+        }
+        
+        $value = null;
+        
+        if ($pos >= 0 && $pos < $meta->npoints) {
+            // read from the file
+            $fh = fopen($this->dir.$feedid.".dat", 'rb');
+            fseek($fh,$pos*4);
+            $val = unpack("f",fread($fh,4));
+
+            // add to the data array if its not a nan value
+            if (!is_nan($val[1])) {
+                $value = $val[1];
+            }
+        }
+        
+        return array('time'=>$time, 'value'=>$value);
+    }
 
     /**
      * Return the data for the given timerange

--- a/Modules/feed/feed_controller.php
+++ b/Modules/feed/feed_controller.php
@@ -63,6 +63,12 @@ function feed_controller()
             // Export multiple feeds on the same csv
             // http://emoncms.org/feed/csvexport.json?ids=1,3,4,5,6,7,8,157,156,169&start=1450137600&end=1450224000&interval=10&timeformat=1
             $result = $feed->csv_export_multi(get('ids'),get('start'),get('end'),get('interval'),get('timeformat'),get('name'));
+        } else if ($route->action == "listdmy") {
+            if ($session['read']) {
+                if (!isset($_GET['userid']) || (isset($_GET['userid']) && $_GET['userid'] == $session['userid'])) $result = $feed->get_user_feeds_with_dmy($session['userid']);
+                else if (isset($_GET['userid']) && $_GET['userid'] != $session['userid']) $result = $feed->get_user_public_feeds_with_dmy(get('userid'));
+            }
+            else if (isset($_GET['userid'])) $result = $feed->get_user_public_feeds_with_dmy(get('userid'));
         } else {
             $feedid = (int) get('id');
             // Actions that operate on a single existing feed that all use the feedid to select:

--- a/Modules/feed/feed_model.php
+++ b/Modules/feed/feed_model.php
@@ -317,6 +317,33 @@ class Feed
         }
         return $feeds;
     }
+    
+    public function get_user_feeds_with_dmy($userid)
+    {
+        $feeds = $this->get_user_feeds($userid);
+        
+        $newFeeds = array();
+        foreach ($feeds as $feed) {
+            $d_value = $this->get_dmy_timevalue($feed['id'], "d");
+            if ($d_value!==null) $feed["dvalue"] = $d_value;
+            $m_value = $this->get_dmy_timevalue($feed['id'], "m");
+            if ($d_value!==null) $feed["mvalue"] = $m_value;
+            $y_value = $this->get_dmy_timevalue($feed['id'], "y");
+            if ($d_value!==null) $feed["yvalue"] = $y_value;
+            
+            $newFeeds[] = $feed;
+        }
+
+        return $newFeeds;
+    }
+
+    public function get_user_public_feeds_with_dmy($userid)
+    {
+        $feeds = $this->get_user_feeds_with_dmy($userid);
+        $publicfeeds = array();
+        foreach ($feeds as $feed) { if ($feed['public']) $publicfeeds[] = $feed; }
+        return $publicfeeds;
+    }
 
     public function get_user_feed_ids($userid)
     {
@@ -420,6 +447,49 @@ class Feed
             if ($row) {
                 $lastvalue = array('time'=>$row['time'], 'value'=>$row['value']);
             }
+        }
+        return $lastvalue;
+    }
+    
+    public function get_dmy_timevalue($id, $dmy)
+    {
+        $id = (int) $id;
+        //$this->log->info("get_dmy_timevalue() $id");
+        if (!$this->exist($id)) {
+            $this->log->error("get_dmy_timevalue() Feed '".$id."' does not exist.");
+            return null;
+        }
+        $engine = $this->get_engine($id);
+
+        if ($engine != Engine::PHPFINA) { //only support PHPFINA for now
+            return null;
+        }
+        
+        $userid = $this->get_field($id,"userid");
+        $timezone = $this->get_user_timezone($userid);
+        if ($timezone===0) $timezone = "UTC";
+        
+        $date = new DateTime();
+        $date->setTimezone(new DateTimeZone($timezone));
+        $date->modify("midnight");
+        if ($dmy == "d") $date->modify("today");
+        else if ($dmy == "m") $date->modify("first day of this month");
+        else if ($dmy == "y") $date->modify("first day of January");
+        else return null;
+        $time = $date->getTimestamp();
+        
+        $lastvalue = null;
+        $rediskey = "feed:$id:value:$time";
+        
+        if ($this->redis) {
+            if ($this->redis->hExists($rediskey,'time')) {
+                return $this->redis->hmget($rediskey,array('time','value'));
+            }
+        }
+        
+        $lastvalue = $this->EngineClass($engine)->valueattime($id, $time, true);
+        if ($this->redis) {
+            $this->redis->hMset($rediskey, array('time' => $lastvalue['time'],'value' => $lastvalue['value']));
         }
         return $lastvalue;
     }
@@ -898,4 +968,3 @@ class Feed
         return $timezone;
     }
 }
-


### PR DESCRIPTION
# RFC

This started as a [question over on the forums](https://community.openenergymonitor.org/t/incrementing-feeds-daily-monthly-yearly-values/1491).

I'm posting this as an RFC right now. I'm not certain that this is the right way to do it. We could add this information to `list`, but my concern is speed. If you have redis, it's cached at least, but not everyone has that.

This adds a new endpoint called `listdmy` which is the same as `list`, but with values for the feed at the start of the day, week and year added in. So this returns something that looks like this:

```
{
    "id": "3",
    "userid": "1",
    "name": "use_kwh",
    "datatype": "1",
    "tag": "emonpi",
    "public": "0",
    "size": "99999",
    "engine": "5",
    "processList": "",
    "time": "1473448379",
    "value": "100",
    "dvalue": {
      "time": "1473375600",
      "value": "95"
    },
    "mvalue": {
      "time": "1472684400",
      "value": "46"
    },
    "yvalue": {
      "time": "1472156140",
      "value": "0"
    }
  }
```

Current limitation is that it only supports PHPFINA. But that might be OK.
