### PR TITLE
Add iOS full-screen app capability to embed=1 pages

### DIFF
--- a/Theme/basic/embed.php
+++ b/Theme/basic/embed.php
@@ -9,13 +9,17 @@
   Part of the OpenEnergyMonitor project:
   http://openenergymonitor.org
   */
-  global $ltime,$path,$fullwidth,$emoncms_version;
+  global $ltime,$path,$fullwidth,$emoncms_version,$theme;
 ?>
 <html>
     <head>
         <meta http-equiv="content-type" content="text/html; charset=UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Emoncms embed - <?php echo $route->controller.' '.$route->action.' '.$route->subaction; ?></title>
+        <meta name="apple-mobile-web-app-capable" content="yes">
+        <meta name="apple-mobile-web-app-status-bar-style" content="black">
+        <link rel="apple-touch-startup-image" href="<?php echo $path; ?>Theme/<?php echo $theme; ?>/ios_load.png">
+        <link rel="apple-touch-icon" href="<?php echo $path; ?>Theme/<?php echo $theme; ?>/logo_normal.png">
 
         <script type="text/javascript" src="<?php echo $path; ?>Lib/jquery-1.11.3.min.js"></script>
         <link href="<?php echo $path; ?>Lib/bootstrap/css/bootstrap.min.css" rel="stylesheet">


### PR DESCRIPTION
This ensures that if you have `embed=1`, to have a page with no chrome, that you can use this successfully with "Add to home screen" on iOS.

Without this, when you open the "app" that gets added to the home screen, it just opens Safari rather than showing the page in full screen without Safari's chrome.

I believe the intended behaviour is to show it full screen. That way you can use `embed=1` and "Add to home screen" to make a dashboard that shows literally just the dashboard.