### PR TITLE
Make dropdowns a maximum height and allow them to scroll

### DIFF
--- a/Theme/basic/emon.css
+++ b/Theme/basic/emon.css
@@ -93,3 +93,9 @@ input[type=text][class=variable-name-edit] {
 .menu-dashboard,.menu-left,.menu-extra,.menu-setup,.menu-right {
   display: inherit !important;
 }
+
+.scrollable-menu {
+  height: auto;
+  max-height: 250px;
+  overflow-y: auto;
+}

--- a/Theme/basic/menu_view.php
+++ b/Theme/basic/menu_view.php
@@ -42,7 +42,7 @@
                 if ($i > 0) {
                     $out .= '<li class="dropdown' . ($subactive ? " active" : "") . (isset($item['class']) ? " ".$item['class'] : "") . '">';
                     $out .= '<a href="#" class="dropdown-toggle" data-toggle="dropdown">' . drawNameIcon($item,false) . '<b class="caret"></b></a>';
-                    $out .= '<ul class="dropdown-menu">';
+                    $out .= '<ul class="dropdown-menu scrollable-menu">';
                     $out .= $outdrop;
                     $out .= '</ul></li>';
                 }


### PR DESCRIPTION
This aids usability when you have a long list of items. Moving your mouse all the way down can be tedious. Scrolling the list is easier.

In particular this is useful when you have a long list of dashboards which ends up going off the screen. Now it'll scroll so you can get to all of the items. This was picked up here:
https://community.openenergymonitor.org/t/dashboard-menu-does-not-scroll-not-all-dashboards-accessible-from-it