### PR TITLE
Update input api with http post section

### DIFF
--- a/Modules/input/Views/input_api.php
+++ b/Modules/input/Views/input_api.php
@@ -23,9 +23,9 @@
 <h3><?php echo _('Available JSON commands'); ?></h3>
 <p><?php echo _('To use the json api the request url needs to include <b>.json</b>'); ?></p>
 
-<p><b><?php echo _('Post data'); ?></b></p>
+<p><b><?php echo _('Post data (using http get)'); ?></b></p>
 <table class="table">
-    <tr><td><?php echo _('JSON format:'); ?></td><td><a href="<?php echo $path; ?>input/post.json?node=1&json={power:200}"><?php echo $path; ?>input/post.json?<b>node=1</b>&json={power:200}</a></td></tr>
+    <tr><td><?php echo _('JSON format:'); ?></td><td><a href="<?php echo $path; ?>input/post.json?node=1&json={power1:100,power2:200,power3:300}"><?php echo $path; ?>input/post.json?<b>node=1</b>&json={power1:100,power2:200,power3:300}</a></td></tr>
     <tr><td><?php echo _('CSV format:'); ?></td><td><a href="<?php echo $path; ?>input/post.json?node=1&csv=100,200,300"><?php echo $path; ?>input/post.json?<b>node=1</b>&csv=100,200,300</a></td></tr>
     <tr><td><?php echo _('Assign inputs to a node group'); ?></td><td><a href="<?php echo $path; ?>input/post.json?node=1&csv=100,200,300"><?php echo $path; ?>input/post.json?<b>node=1</b>&csv=100,200,300</a></td></tr>
     <tr><td><?php echo _('Set the input entry time manually'); ?></td><td><a href="<?php echo $path; ?>input/post.json?time=<?php echo time(); ?>&node=1&csv=100,200,300"><?php echo $path; ?>input/post.json?<b>time=<?php echo time(); ?></b>&node=1&csv=100,200,300</a></td></tr>
@@ -52,6 +52,18 @@
 <tr><td><?php echo _('Time offset format (-6 is -16 seconds to now):'); ?></td><td><a href="<?php echo $path; ?>input/bulk.json?data=[[-10,16,1137],[-8,17,1437,3164],[-6,19,1412,3077]]&offset=-10"><?php echo $path; ?>input/bulk.json?data=[[-10,16,1137],[-8,17,1437,3164],[-6,19,1412,3077]]<b>&offset=-10</b></a></td></tr>
 <tr><td><?php echo _('Sentat format: (useful for sending as positive increasing time index)'); ?></td><td><a href="<?php echo $path; ?>input/bulk.json?data=[[520,16,1137],[530,17,1437,3164],[535,19,1412,3077]]&sentat=543"><?php echo $path; ?>input/bulk.json?data=[[520,16,1137],[530,17,1437,3164],[535,19,1412,3077]]<b>&sentat=543</b></b></a></td></tr>
 <tr><td><?php echo _('Absolute time format (-6 is 1387730121 seconds since 1970-01-01 00:00:00 UTC))'); ?></td><td><a href="<?php echo $path; ?>input/bulk.json?data=[[-10,16,1137],[-8,17,1437,3164],[-6,19,1412,3077]]&time=<?php echo time(); ?>"><?php echo $path; ?>input/bulk.json?data=[[-10,16,1137],[-8,17,1437,3164],[-6,19,1412,3077]]<b>&time=<?php echo time(); ?></b></a></td></tr>
+</table>
+
+<p><b><?php echo _('Post data (using http post)'); ?></b></p>
+<?php echo _('To post data using http post you can use the "data" post parameter, it will accept csv and json formatting. Other parameters need to be provided as a parameter in the url, the only exception is the apikey which can be a post parameter as well.'); ?></p>
+<?php echo _('The examples below use curl to post the data to the input api. It is availible '); ?><a href="https://curl.haxx.se/">here</a></p>
+<table class="table">
+    <tr><td><?php echo _('JSON format:'); ?></td><td>curl --data "data={power1:100,power2:200,power3:300}" "<?php echo $path; ?>input/post.json?node=1&apikey=<?php echo $user->get_apikey_write($session['userid']); ?>"</td></tr>
+    <tr><td><?php echo _('CSV format:'); ?></td><td>curl --data "data=100,200,300" "<?php echo $path; ?>input/post.json?node=1&apikey=<?php echo $user->get_apikey_write($session['userid']); ?>"</td></tr>
+    <tr><td><?php echo _('Bulk mode legacy format:'); ?></td><td>curl --data "data=[[0,16,1137],[2,17,1437,3164],[4,19,1412,3077]]" "<?php echo $path; ?>input/bulk.json?apikey=<?php echo $user->get_apikey_write($session['userid']); ?>"</td></tr>
+    <tr><td><?php echo _('Bulk mode time offset format:'); ?></td><td>curl --data "data=[[-10,16,1137],[-8,17,1437,3164],[-6,19,1412,3077]]" "<?php echo $path; ?>input/bulk.json?offset=-10&apikey=<?php echo $user->get_apikey_write($session['userid']); ?>"</td></tr>
+    <tr><td><?php echo _('Bulk mode sentat format:'); ?></td><td>curl --data "data=[[520,16,1137],[530,17,1437,3164],[535,19,1412,3077]]" "<?php echo $path; ?>input/bulk.json?sentat=543&apikey=<?php echo $user->get_apikey_write($session['userid']); ?>"</td></tr>
+    <tr><td><?php echo _('Bulk mode absolute time format:'); ?></td><td>curl --data "data=[[-10,16,1137],[-8,17,1437,3164],[-6,19,1412,3077]]" "<?php echo $path; ?>input/bulk.json?time=<?php echo time(); ?>&apikey=<?php echo $user->get_apikey_write($session['userid']); ?>"</td></tr>
 </table>
 
 <br>


### PR DESCRIPTION
As i found out in the sources that the input api accepted http post parameters using the http post "data" variable i updated the input api documentation and added examples for http post using curl.

I also updated the json http get & http post example to include multiple values as it is not clear with only one data value that you can add multiple values at once. This is however clear if you provide a sample with multiple inputs as you can then deduct from multiple values that one values is possible also. However deducting from one value that multiple are possible is not so clear. Hence the change.

I only tested the curl examples in windows, they should work in linux also but i'm not certain of the double quote syntax in linux, perhaps one of you using linux can double check them ?

edit: don't worry about the screenshots showing an api key as this is just a seperate dev install i'm using so it's okay this is public and it's only showing my local url

screenshots:
![Json example with multiple values](https://vw6w1w.bl3301.livefilestore.com/y3myzP0oXr9u5AjGBN71bzmfAbOQ2-BbnMP-1-edr2ZQqRW-eYYWt8_rTUoNR0JO_xmCPtnniFNpes375WUHwJ-kvK8sQVtCcS2_RUf93-lV1IM_8a_Ery-mpvVAYQBK8ECuXm5O7k8ybZ0bPYmaIHx-2mnEStStO8iWXrtJspocbE?width=1265&height=271&cropmode=none)

![http post section](https://vw6x1w.bl3301.livefilestore.com/y3mxHh8tkvSCjhD43CfVIemds5kCCXVPCq8AnPi2dvEesUFvg37apfS4rQ5rjfZP67ELLFtgsK1X6OUaG7S3nu5izLq0h65_GFYklnp-6OAo1lVjRwxKx0X1WkX-07-2EiZP7dkfMW8sxhPjZgl-hWB9EKJkABUDGP_1ImNyWzqyUo?width=1797&height=357&cropmode=none)
