### PR TITLE
Added "saveAsImage" functionality to Visualisations

### DIFF
--- a/Lib/flot/plugin/saveAsImage/README.md
+++ b/Lib/flot/plugin/saveAsImage/README.md
@@ -1,0 +1,51 @@
+canvasAsImage.js
+================
+
+Reference this file in your header of which page you are using canvas, then when you right click on your canvas, a context menu would appeared and gave you a option to save your drawings on canvas as image to your local disk.
+
+##Online examples:##
+http://zizhujy.com/GraphWorld
+
+jquery.flot.saveAsImage.js
+==========================
+
+Flot plugin that adds a function to allow user save the current graph as an image by right clicking on the graph and then choose "Save image as ..." to local disk.
+
+Copyright (c) 2013 http://zizhujy.com.
+Licensed under the MIT license.
+
+##Screen shot:##
+http://zizhujy.com/blog/post/2013/07/02/A-Flot-plugin-for-saving-canvas-image-to-local-disk.aspx
+
+##Installation and usage:##
+```html
+bower install flot.saveasimage
+
+<script type="text/javascript" src="bower_components/flot.saveasimage/lib/base64.js">
+<script type="text/javascript" src="bower_components/flot.saveasimage/lib/canvas2image.js">
+<script type="text/javascript" src="bower_components/flot.saveasimage/jquery.flot.saveAsImage.js">
+```
+    
+Now you are all set. Right click on your flot canvas, you will see the "Save image as ..." option.
+
+##Online examples:##
+http://zizhujy.com/FunctionGrapher is using it, you can try right clicking on the function graphs and
+you will see you can save the image to local disk.
+
+##Dependencies:##
+
+This plugin references the base64.js and canvas2image.js.
+
+##Customizations:##
+
+The default behavior of this plugin is dynamically creating an image from the flot canvas, and then puts the 
+image above the flot canvas. If you want to add some css effects on to the dynamically created image, you can
+apply whatever css styles on to it, only remember to make sure the css class name is set correspondingly by 
+the options object of this plugin. You can also customize the image format through this options object:
+
+```javascript
+options: {
+    imageClassName: "canvas-image",
+    imageFormat: "png"
+}
+```

--- a/Lib/flot/plugin/saveAsImage/jquery.flot.saveAsImage.js
+++ b/Lib/flot/plugin/saveAsImage/jquery.flot.saveAsImage.js
@@ -1,0 +1,169 @@
+/* Flot plugin that adds a function to allow user save the current graph as an image
+    by right clicking on the graph and then choose "Save image as ..." to local disk.
+
+Copyright (c) 2013 http://zizhujy.com.
+Licensed under the MIT license.
+
+Usage:
+    Inside the <head></head> area of your html page, add the following lines:
+    
+    <script type="text/javascript" src="http://zizhujy.com/Scripts/base64.js"></script>
+    <script type="text/javascript" src="http://zizhujy.com/Scripts/drawing/canvas2image.js"></script>
+    <script type="text/javascript" src="http://zizhujy.com/Scripts/flot/jquery.flot.saveAsImage.js"></script>
+
+    Now you are all set. Right click on your flot canvas, you will see the "Save image as ..." option.
+
+Online examples:
+    http://zizhujy.com/FunctionGrapher is using it, you can try right clicking on the function graphs and
+    you will see you can save the image to local disk.
+
+Dependencies:
+    This plugin references the base64.js and canvas2image.js.
+
+Customizations:
+    The default behavior of this plugin is dynamically creating an image from the flot canvas, and then puts the 
+    image above the flot canvas. If you want to add some css effects on to the dynamically created image, you can
+    apply whatever css styles on to it, only remember to make sure the css class name is set correspondingly by 
+    the options object of this plugin. You can also customize the image format through this options object:
+
+    options: {
+        imageClassName: "canvas-image",
+        imageFormat: "png"
+    }
+
+*/
+
+; (function ($, Canvas2Image) {
+    var imageCreated = null;
+    var mergedCanvas = null;
+    var theClasses = null;
+
+    function init(plot, classes) {
+        theClasses = classes;
+        plot.hooks.bindEvents.push(bindEvents);
+        plot.hooks.shutdown.push(shutdown);
+
+        function bindEvents(plot, eventHolder) {
+            eventHolder.mousedown(onMouseDown);
+        }
+
+        function shutdown(plot, eventHolder) {
+            eventHolder.unbind("mousedown", onMouseDown);
+        }
+
+        function onMouseDown(e) {
+            if (e.button == 2) {
+                // Open an API in Canvas2Image, in case you would need to call
+                // it to delete the dynamically created image.
+                //Canvas2Image.deleteStaleCanvasImage = deleteStaleCanvasImage;
+                deleteStaleCanvasImage(plot, mergedCanvas);
+                mergedCanvas = mergeCanvases(plot);
+                createImageFromCanvas(mergedCanvas, plot, plot.getOptions().imageFormat);
+                // For ubuntu chrome:
+                setTimeout(function () { deleteStaleCanvasImage(plot, mergedCanvas); }, 500);
+            }
+        }
+    }
+
+    function onMouseUp(plot) {
+        setTimeout(function () { deleteStaleCanvasImage(plot, mergedCanvas); }, 100);
+    }
+
+    function deleteStaleCanvasImage(plot, mergedCanvas) {
+        //$(plot.getCanvas()).parent().find("img." + plot.getOptions().imageClassName).unbind("mouseup", onMouseUp).remove();
+        $(imageCreated).unbind("mouseup", onMouseUp).remove();
+        if (!!mergedCanvas) {
+            $(mergedCanvas).remove();
+        }
+        $(".mergedCanvas").remove();
+    }
+    
+    function mergeCanvases(plot) {
+        
+        var theMergedCanvas = plot.getCanvas();
+
+        if (!!theClasses) {
+            theMergedCanvas = new theClasses.Canvas("mergedCanvas", plot.getPlaceholder());
+            var mergedContext = theMergedCanvas.context;
+            var plotCanvas = plot.getCanvas();
+            
+            theMergedCanvas.element.height = plotCanvas.height;
+            theMergedCanvas.element.width = plotCanvas.width;
+            
+            mergedContext.restore();
+
+            $(theMergedCanvas).css({
+                "visibility": "hidden",
+                "z-index": "-100",
+                "position": "absolute"
+            });
+
+            var $canvases = $(plot.getPlaceholder()).find("canvas").not('.mergedCanvas');
+            $canvases.each(function(index, canvas) {
+                mergedContext.drawImage(canvas, 0, 0);
+            });
+
+            return theMergedCanvas.element;
+        }
+
+        return theMergedCanvas;
+    }
+
+    function createImageFromCanvas(canvas, plot, format) {
+        if (!canvas) {
+            canvas = plot.getCanvas();
+        }
+        
+        var img = null;
+        switch (format.toLowerCase()) {
+            case "png":
+                img = Canvas2Image.saveAsPNG(canvas, format);
+                break;
+            case "bmp":
+                img = Canvas2Image.saveAsBMP(canvas, format);
+                break;
+            case "jpeg":
+                img = Canvas2Image.saveAsJPEG(canvas, format);
+                break;
+            default:
+                break;
+        }
+
+        if (!img) {
+            img = Canvas2Image.saveAsPNG(canvas, "png");
+        }
+
+        if (!img) {
+            img = Canvas2Image.saveAsPNG(canvas, "bmp");
+        }
+
+        if (!img) {
+            img = Canvas2Image.saveAsJPEG(canvas, "jpeg");
+        }
+
+        if (!img) {
+            alert(plot.getOptions().notSupportMessage || "Oh Sorry, but this browser is not capable of creating image files, please use PRINT SCREEN key instead!");
+            return false;
+        }
+
+        $(img).attr("class", plot.getOptions().imageClassName);
+        $(img).css({ "border": $(canvas).css("border"), "z-index": "9999", "position": "absolute" });
+        $(img).insertBefore($(canvas));
+        $(img).mouseup(plot, onMouseUp);
+
+        imageCreated = img;
+    }
+
+    var options = {
+        imageClassName: "canvas-image",
+        imageFormat: "png"
+    };
+
+    $.plot.plugins.push({
+        init: init,
+        options: options,
+        name: 'saveAsImage',
+        version: '1.6'
+    });
+
+})(jQuery, Canvas2Image);

--- a/Lib/flot/plugin/saveAsImage/lib/base64.js
+++ b/Lib/flot/plugin/saveAsImage/lib/base64.js
@@ -1,0 +1,111 @@
+﻿/* Copyright (C) 1999 Masanao Izumo <iz@onicos.co.jp>
+* Version: 1.0
+* LastModified: Dec 25 1999
+* This library is free.  You can redistribute it and/or modify it.
+*/
+
+/*
+* Interfaces:
+* b64 = base64encode(data);
+* data = base64decode(b64);
+*/
+
+(function () {
+
+    var base64EncodeChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    var base64DecodeChars = new Array(
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1, -1, 63,
+    52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -1, -1, -1,
+    -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+    15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1,
+    -1, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+    41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, -1, -1, -1, -1, -1);
+
+    function base64encode(str) {
+        var out, i, len;
+        var c1, c2, c3;
+
+        len = str.length;
+        i = 0;
+        out = "";
+        while (i < len) {
+            c1 = str.charCodeAt(i++) & 0xff;
+            if (i == len) {
+                out += base64EncodeChars.charAt(c1 >> 2);
+                out += base64EncodeChars.charAt((c1 & 0x3) << 4);
+                out += "==";
+                break;
+            }
+            c2 = str.charCodeAt(i++);
+            if (i == len) {
+                out += base64EncodeChars.charAt(c1 >> 2);
+                out += base64EncodeChars.charAt(((c1 & 0x3) << 4) | ((c2 & 0xF0) >> 4));
+                out += base64EncodeChars.charAt((c2 & 0xF) << 2);
+                out += "=";
+                break;
+            }
+            c3 = str.charCodeAt(i++);
+            out += base64EncodeChars.charAt(c1 >> 2);
+            out += base64EncodeChars.charAt(((c1 & 0x3) << 4) | ((c2 & 0xF0) >> 4));
+            out += base64EncodeChars.charAt(((c2 & 0xF) << 2) | ((c3 & 0xC0) >> 6));
+            out += base64EncodeChars.charAt(c3 & 0x3F);
+        }
+        return out;
+    }
+
+    function base64decode(str) {
+        var c1, c2, c3, c4;
+        var i, len, out;
+
+        len = str.length;
+        i = 0;
+        out = "";
+        while (i < len) {
+            /* c1 */
+            do {
+                c1 = base64DecodeChars[str.charCodeAt(i++) & 0xff];
+            } while (i < len && c1 == -1);
+            if (c1 == -1)
+                break;
+
+            /* c2 */
+            do {
+                c2 = base64DecodeChars[str.charCodeAt(i++) & 0xff];
+            } while (i < len && c2 == -1);
+            if (c2 == -1)
+                break;
+
+            out += String.fromCharCode((c1 << 2) | ((c2 & 0x30) >> 4));
+
+            /* c3 */
+            do {
+                c3 = str.charCodeAt(i++) & 0xff;
+                if (c3 == 61)
+                    return out;
+                c3 = base64DecodeChars[c3];
+            } while (i < len && c3 == -1);
+            if (c3 == -1)
+                break;
+
+            out += String.fromCharCode(((c2 & 0XF) << 4) | ((c3 & 0x3C) >> 2));
+
+            /* c4 */
+            do {
+                c4 = str.charCodeAt(i++) & 0xff;
+                if (c4 == 61)
+                    return out;
+                c4 = base64DecodeChars[c4];
+            } while (i < len && c4 == -1);
+            if (c4 == -1)
+                break;
+            out += String.fromCharCode(((c3 & 0x03) << 6) | c4);
+        }
+        return out;
+    }
+
+    if (!window.btoa) window.btoa = base64encode;
+    if (!window.atob) window.atob = base64decode;
+
+})();

--- a/Lib/flot/plugin/saveAsImage/lib/canvas2image.js
+++ b/Lib/flot/plugin/saveAsImage/lib/canvas2image.js
@@ -1,0 +1,235 @@
+﻿/*
+* Canvas2Image v0.1
+* Copyright (c) 2008 Jacob Seidelin, jseidelin@nihilogic.dk
+* MIT License [http://www.opensource.org/licenses/mit-license.php]
+*/
+
+var Canvas2Image = (function () {
+
+    // check if we have canvas support
+    var bHasCanvas = false;
+    var oCanvas = document.createElement("canvas");
+    if (!!oCanvas.getContext && !!oCanvas.getContext("2d")) {
+        bHasCanvas = true;
+    }
+
+    // no canvas, bail out.
+    if (!bHasCanvas) {
+        return {
+            saveAsBMP: function () { },
+            saveAsPNG: function () { },
+            saveAsJPEG: function () { }
+        }
+    }
+
+    var bHasImageData = !!oCanvas.getContext && !!oCanvas.getContext("2d").getImageData;
+    var bHasDataURL = !!(oCanvas.toDataURL);
+    var bHasBase64 = !!(window.btoa);
+
+    var strDownloadMime = "image/octet-stream";
+
+    // ok, we're good
+    var readCanvasData = function (oCanvas) {
+        var iWidth = parseInt(oCanvas.width);
+        var iHeight = parseInt(oCanvas.height);
+        return oCanvas.getContext("2d").getImageData(0, 0, iWidth, iHeight);
+    }
+
+    // base64 encodes either a string or an array of charcodes
+    var encodeData = function (data) {
+        var strData = "";
+        if (typeof data == "string") {
+            strData = data;
+        } else {
+            var aData = data;
+            for (var i = 0; i < aData.length; i++) {
+                strData += String.fromCharCode(aData[i]);
+            }
+        }
+        return btoa(strData);
+    }
+
+    // creates a base64 encoded string containing BMP data
+    // takes an imagedata object as argument
+    var createBMP = function (oData) {
+        var aHeader = [];
+
+        var iWidth = oData.width;
+        var iHeight = oData.height;
+
+        aHeader.push(0x42); // magic 1
+        aHeader.push(0x4D);
+
+        var iFileSize = iWidth * iHeight * 3 + 54; // total header size = 54 bytes
+        aHeader.push(iFileSize % 256); iFileSize = Math.floor(iFileSize / 256);
+        aHeader.push(iFileSize % 256); iFileSize = Math.floor(iFileSize / 256);
+        aHeader.push(iFileSize % 256); iFileSize = Math.floor(iFileSize / 256);
+        aHeader.push(iFileSize % 256);
+
+        aHeader.push(0); // reserved
+        aHeader.push(0);
+        aHeader.push(0); // reserved
+        aHeader.push(0);
+
+        aHeader.push(54); // dataoffset
+        aHeader.push(0);
+        aHeader.push(0);
+        aHeader.push(0);
+
+        var aInfoHeader = [];
+        aInfoHeader.push(40); // info header size
+        aInfoHeader.push(0);
+        aInfoHeader.push(0);
+        aInfoHeader.push(0);
+
+        var iImageWidth = iWidth;
+        aInfoHeader.push(iImageWidth % 256); iImageWidth = Math.floor(iImageWidth / 256);
+        aInfoHeader.push(iImageWidth % 256); iImageWidth = Math.floor(iImageWidth / 256);
+        aInfoHeader.push(iImageWidth % 256); iImageWidth = Math.floor(iImageWidth / 256);
+        aInfoHeader.push(iImageWidth % 256);
+
+        var iImageHeight = iHeight;
+        aInfoHeader.push(iImageHeight % 256); iImageHeight = Math.floor(iImageHeight / 256);
+        aInfoHeader.push(iImageHeight % 256); iImageHeight = Math.floor(iImageHeight / 256);
+        aInfoHeader.push(iImageHeight % 256); iImageHeight = Math.floor(iImageHeight / 256);
+        aInfoHeader.push(iImageHeight % 256);
+
+        aInfoHeader.push(1); // num of planes
+        aInfoHeader.push(0);
+
+        aInfoHeader.push(24); // num of bits per pixel
+        aInfoHeader.push(0);
+
+        aInfoHeader.push(0); // compression = none
+        aInfoHeader.push(0);
+        aInfoHeader.push(0);
+        aInfoHeader.push(0);
+
+        var iDataSize = iWidth * iHeight * 3;
+        aInfoHeader.push(iDataSize % 256); iDataSize = Math.floor(iDataSize / 256);
+        aInfoHeader.push(iDataSize % 256); iDataSize = Math.floor(iDataSize / 256);
+        aInfoHeader.push(iDataSize % 256); iDataSize = Math.floor(iDataSize / 256);
+        aInfoHeader.push(iDataSize % 256);
+
+        for (var i = 0; i < 16; i++) {
+            aInfoHeader.push(0); // these bytes not used
+        }
+
+        var iPadding = (4 - ((iWidth * 3) % 4)) % 4;
+
+        var aImgData = oData.data;
+
+        var strPixelData = "";
+        var y = iHeight;
+        do {
+            var iOffsetY = iWidth * (y - 1) * 4;
+            var strPixelRow = "";
+            for (var x = 0; x < iWidth; x++) {
+                var iOffsetX = 4 * x;
+
+                strPixelRow += String.fromCharCode(aImgData[iOffsetY + iOffsetX + 2]);
+                strPixelRow += String.fromCharCode(aImgData[iOffsetY + iOffsetX + 1]);
+                strPixelRow += String.fromCharCode(aImgData[iOffsetY + iOffsetX]);
+            }
+            for (var c = 0; c < iPadding; c++) {
+                strPixelRow += String.fromCharCode(0);
+            }
+            strPixelData += strPixelRow;
+        } while (--y);
+
+        var strEncoded = encodeData(aHeader.concat(aInfoHeader)) + encodeData(strPixelData);
+
+        return strEncoded;
+    }
+
+
+    // sends the generated file to the client
+    var saveFile = function (strData) {
+        document.location.href = strData;
+    }
+
+    var makeDataURI = function (strData, strMime) {
+        return "data:" + strMime + ";base64," + strData;
+    }
+
+    // generates a <img> object containing the imagedata
+    var makeImageObject = function (strSource) {
+        var oImgElement = document.createElement("img");
+        oImgElement.src = strSource;
+        return oImgElement;
+    }
+
+    var scaleCanvas = function (oCanvas, iWidth, iHeight) {
+        if (iWidth && iHeight) {
+            var oSaveCanvas = document.createElement("canvas");
+            oSaveCanvas.width = iWidth;
+            oSaveCanvas.height = iHeight;
+            oSaveCanvas.style.width = iWidth + "px";
+            oSaveCanvas.style.height = iHeight + "px";
+
+            var oSaveCtx = oSaveCanvas.getContext("2d");
+
+            oSaveCtx.drawImage(oCanvas, 0, 0, oCanvas.width, oCanvas.height, 0, 0, iWidth, iHeight);
+            return oSaveCanvas;
+        }
+        return oCanvas;
+    }
+
+    return {
+
+        saveAsPNG: function (oCanvas, bReturnImg, iWidth, iHeight) {
+            if (!bHasDataURL) {
+                return false;
+            }
+            var oScaledCanvas = scaleCanvas(oCanvas, iWidth, iHeight);
+            var strData = oScaledCanvas.toDataURL("image/png");
+            if (bReturnImg) {
+                return makeImageObject(strData);
+            } else {
+                saveFile(strData.replace("image/png", strDownloadMime));
+            }
+            return true;
+        },
+
+        saveAsJPEG: function (oCanvas, bReturnImg, iWidth, iHeight) {
+            if (!bHasDataURL) {
+                return false;
+            }
+
+            var oScaledCanvas = scaleCanvas(oCanvas, iWidth, iHeight);
+            var strMime = "image/jpeg";
+            var strData = oScaledCanvas.toDataURL(strMime);
+
+            // check if browser actually supports jpeg by looking for the mime type in the data uri.
+            // if not, return false
+            if (strData.indexOf(strMime) != 5) {
+                return false;
+            }
+
+            if (bReturnImg) {
+                return makeImageObject(strData);
+            } else {
+                saveFile(strData.replace(strMime, strDownloadMime));
+            }
+            return true;
+        },
+
+        saveAsBMP: function (oCanvas, bReturnImg, iWidth, iHeight) {
+            if (!(bHasImageData && bHasBase64)) {
+                return false;
+            }
+
+            var oScaledCanvas = scaleCanvas(oCanvas, iWidth, iHeight);
+
+            var oData = readCanvasData(oScaledCanvas);
+            var strImgData = createBMP(oData);
+            if (bReturnImg) {
+                return makeImageObject(makeDataURI(strImgData, "image/bmp"));
+            } else {
+                saveFile(makeDataURI(strImgData, strDownloadMime));
+            }
+            return true;
+        }
+    };
+
+})();

--- a/Modules/vis/Views/vis_main_view.php
+++ b/Modules/vis/Views/vis_main_view.php
@@ -15,6 +15,11 @@ Part of the OpenEnergyMonitor project: http://openenergymonitor.org
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.togglelegend.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/jquery.flot.time.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/jquery.flot.stack.min.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.canvas.js"></script>
+
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/base64.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/canvas2image.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/jquery.flot.saveAsImage.js"></script>
 
 <script language="javascript" type="text/javascript" src="<?php echo $path; ?>Modules/vis/visualisations/common/api.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path; ?>Modules/vis/visualisations/common/vis.helper.js"></script>

--- a/Modules/vis/visualisations/bargraph.php
+++ b/Modules/vis/visualisations/bargraph.php
@@ -18,6 +18,11 @@
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.touch.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.time.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/date.format.min.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.canvas.js"></script>
+
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/base64.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/canvas2image.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/jquery.flot.saveAsImage.js"></script>
 
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/api.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/vis.helper.js"></script>
@@ -327,6 +332,7 @@
                 intervalrange=interval;
 
             var options = {
+                canvas: true,
                 bars: { show: true, align: "center", barWidth: 0.75*intervalrange*1000, fill: true},
                 xaxis: { mode: "time", timezone: "browser",
                 min: view.start, max: view.end, minTickSize: [intervalrange, "second"] },

--- a/Modules/vis/visualisations/compare.php
+++ b/Modules/vis/visualisations/compare.php
@@ -17,6 +17,11 @@
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.selection.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.touch.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.time.min.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.canvas.js"></script>
+
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/base64.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/canvas2image.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/jquery.flot.saveAsImage.js"></script>
 
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/api.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/inst.js"></script>
@@ -206,6 +211,7 @@
     var plot = $.plot($("#graph"), [
     {data: feedA, lines: { show: true }},
     {data: feedB_cal, lines: { show: true }}], {
+      canvas: true,
       grid: { show: true, hoverable: true, clickable: true },
       xaxis: { mode: "time", timezone: "browser", min: start, max: end },
       selection: { mode: "x" },
@@ -213,6 +219,7 @@
     });
 
     var plot = $.plot($("#diff"), [{color:2, data: diff, lines: { show: true }}], {
+      canvas: true,
       grid: { show: true, hoverable: true },
       xaxis: { mode: "time", timezone: "browser", min: start, max: end },
       touch: { pan: "", scale: "x" , delayTouchEnded: 0}
@@ -227,6 +234,7 @@
     var plot = $.plot($("#line"), [
       {color:2,data: feedAB, points: { show: true }},
       {color: "#000",data: line_data,lines: { show: true, fill: false }}],{
+        canvas: true,
         grid: { show: true, hoverable: true },
         xaxis: { min: lineAmin-lineAoffset, max: lineAmax+lineAoffset},
         yaxis: { min: lineBmin-lineBoffset, max: lineBmax+lineBoffset},

--- a/Modules/vis/visualisations/dailyhistogram/dailyhistogram.php
+++ b/Modules/vis/visualisations/dailyhistogram/dailyhistogram.php
@@ -25,6 +25,11 @@
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.selection.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/date.format.min.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.canvas.js"></script>
+
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/base64.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/canvas2image.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/jquery.flot.saveAsImage.js"></script>
 
 <script language="javascript" type="text/javascript" src="<?php echo $path; ?>Modules/vis/visualisations/common/daysmonthsyears.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path; ?>Modules/vis/visualisations/dailyhistogram/view.js"></script>

--- a/Modules/vis/visualisations/dailyhistogram/graphs.js
+++ b/Modules/vis/visualisations/dailyhistogram/graphs.js
@@ -15,6 +15,7 @@ function bargraph(data,barwidth,mode)
 {
   $.plot($("#placeholder"), [{color: "#0096ff", data: data}],
   {
+    canvas: true,
     bars: { show: true,align: "center",barWidth: (barwidth*1000),fill: true },
     grid: { show: true, hoverable: true, clickable: true },
     xaxis: { mode: "time", timezone: "browser", minTickSize: [1, mode], tickLength: 1}

--- a/Modules/vis/visualisations/editdaily.php
+++ b/Modules/vis/visualisations/editdaily.php
@@ -16,6 +16,11 @@
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.selection.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.touch.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.time.min.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.canvas.js"></script>
+
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/base64.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/canvas2image.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/jquery.flot.saveAsImage.js"></script>
 
 <script language="javascript" type="text/javascript" src="<?php echo $path; ?>Modules/vis/visualisations/common/api.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path; ?>Modules/vis/visualisations/common/inst.js"></script>
@@ -82,6 +87,7 @@
     if (type == 2) plotdata = {data: graph_data, bars: { show: true, align: "center", barWidth: 3600*18*1000, fill: true}};
 
     var plot = $.plot($("#graph"), [plotdata], {
+      canvas: true,
       grid: { show: true, hoverable: true, clickable: true },
       xaxis: { mode: "time", timezone: "browser", min: start, max: end },
       selection: { mode: "x" },

--- a/Modules/vis/visualisations/editrealtime.php
+++ b/Modules/vis/visualisations/editrealtime.php
@@ -16,6 +16,11 @@
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.selection.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.touch.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.time.min.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.canvas.js"></script>
+
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/base64.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/canvas2image.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/jquery.flot.saveAsImage.js"></script>
 
 <script language="javascript" type="text/javascript" src="<?php echo $path; ?>Modules/vis/visualisations/common/api.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path; ?>Modules/vis/visualisations/common/inst.js"></script>
@@ -105,6 +110,7 @@
     if (type == 2) plotdata = {data: graph_data, bars: { show: true, align: "center", barWidth: 3600*18*1000, fill: true}};
 
     var plot = $.plot($("#graph"), [plotdata], {
+      canvas: true,
       //grid: { show: true, clickable: true},
       grid: { show: true, hoverable: true, clickable: true },
       xaxis: { mode: "time", timezone: "browser", min: start, max: end },

--- a/Modules/vis/visualisations/graph.js
+++ b/Modules/vis/visualisations/graph.js
@@ -143,6 +143,7 @@ var app_graph = {
                 else
                 { 
                     var options = {
+                        canvas: true,
                         lines: { fill: false },
                         xaxis: { 
                             mode: "time", timezone: "browser", 

--- a/Modules/vis/visualisations/graph.php
+++ b/Modules/vis/visualisations/graph.php
@@ -16,6 +16,11 @@
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.time.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.selection.min.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.canvas.js"></script>
+
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/base64.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/canvas2image.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/jquery.flot.saveAsImage.js"></script>
 
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/graph.js"></script>
 

--- a/Modules/vis/visualisations/histgraph.php
+++ b/Modules/vis/visualisations/histgraph.php
@@ -29,6 +29,12 @@
 <!--[if IE]><script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/excanvas.min.js"></script><![endif]-->
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/feed/feed.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.canvas.js"></script>
+
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/base64.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/canvas2image.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/jquery.flot.saveAsImage.js"></script>
+
 <?php if (!$embed) { ?>
 <h2><?php echo _("Histogram:"); ?> <?php echo $feedidname; ?></h2>
 <?php } ?>
@@ -78,6 +84,7 @@
       bars: { show: true, align: "center", barWidth: barwidth, fill: true },
       color: plotColour
     }], {
+      canvas: true,
       xaxis: { mode: null }, grid: { show: true, hoverable: true }
     });
     $('#loading').hide();

--- a/Modules/vis/visualisations/multigraph.php
+++ b/Modules/vis/visualisations/multigraph.php
@@ -19,6 +19,11 @@
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.togglelegend.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.time.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.stack.min.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.canvas.js"></script>
+
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/base64.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/canvas2image.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/jquery.flot.saveAsImage.js"></script>
 
 <script language="javascript" type="text/javascript" src="<?php echo $path; ?>Modules/vis/visualisations/common/api.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path; ?>Modules/vis/visualisations/common/vis.helper.js"></script>

--- a/Modules/vis/visualisations/multigraph/multigraph.js
+++ b/Modules/vis/visualisations/multigraph/multigraph.js
@@ -154,6 +154,7 @@ function vis_feed_data_callback(context,data) {
 
 function plot() {
   $.plot($("#graph"), plotdata, {
+    canvas: true,
     grid: { show: true, hoverable: true, clickable: true },
     xaxis: { mode: "time", timezone: "browser", min: view.start, max: view.end },
     selection: { mode: "x" },

--- a/Modules/vis/visualisations/orderbars.php
+++ b/Modules/vis/visualisations/orderbars.php
@@ -11,6 +11,11 @@
 
 <!--[if IE]><script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/excanvas.min.js"></script><![endif]-->
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.min.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.canvas.js"></script>
+
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/base64.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/canvas2image.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/jquery.flot.saveAsImage.js"></script>
  
 <script language="javascript" type="text/javascript" src="<?php echo $path; ?>Modules/vis/visualisations/common/api.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path; ?>Modules/vis/visualisations/common/inst.js"></script>
@@ -89,6 +94,7 @@
   function plot()
   {
     var plot = $.plot($("#graph"), [{data: graph_data, bars: { show: true, align: "center", fill: true}}], {
+      canvas: true,
       grid: { show: true, hoverable: true },
       yaxis: {min: 0}
     });

--- a/Modules/vis/visualisations/orderthreshold.php
+++ b/Modules/vis/visualisations/orderthreshold.php
@@ -16,6 +16,11 @@
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.stack.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.time.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/date.format.min.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.canvas.js"></script>
+
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/base64.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/canvas2image.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/jquery.flot.saveAsImage.js"></script>
 
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/api.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/inst.js"></script>
@@ -127,6 +132,7 @@
     // Draw the plot
     $.plot($("#graph"), [{color: "#c1a81f", data:dataA}, {color: "#dec225", data:dataB}, {color: "#deb368", data:dataC}],
     {
+      canvas: true,
       series: {
         stack: true,
         bars: { show: true,align: "center",fill: true }

--- a/Modules/vis/visualisations/rawdata.php
+++ b/Modules/vis/visualisations/rawdata.php
@@ -19,6 +19,11 @@
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.touch.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.time.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/date.format.min.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.canvas.js"></script>
+
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/base64.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/canvas2image.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/jquery.flot.saveAsImage.js"></script>
 
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/api.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/vis.helper.js"></script>
@@ -182,6 +187,7 @@ $(function() {
     function plot()
     {
         var options = {
+            canvas: true,
             lines: { fill: fill },
             xaxis: { mode: "time", timezone: "browser", min: view.start, max: view.end, minTickSize: [interval, "second"] },
             //yaxis: { min: 0 },

--- a/Modules/vis/visualisations/realtime.php
+++ b/Modules/vis/visualisations/realtime.php
@@ -12,6 +12,12 @@
 <!--[if IE]><script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/excanvas.min.js"></script><![endif]-->
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.time.min.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.canvas.js"></script>
+
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/base64.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/canvas2image.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/jquery.flot.saveAsImage.js"></script>
+
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/api.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/vis.helper.js"></script>
     
@@ -103,6 +109,7 @@
     function plot(){
       $.plot(graph,[{data: data, color: plotColour}],
       {
+        canvas: true,
         lines: { fill: true },
         series: { shadowSize: 0 },
         xaxis: { tickLength:10, mode: "time", timezone: "browser", min: start, max: end }

--- a/Modules/vis/visualisations/simplezoom.php
+++ b/Modules/vis/visualisations/simplezoom.php
@@ -15,6 +15,11 @@
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.touch.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.time.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/date.format.min.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.canvas.js"></script>
+
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/base64.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/canvas2image.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/jquery.flot.saveAsImage.js"></script>
 
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/api.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/inst.js"></script>
@@ -159,6 +164,7 @@
   function plot()
   {
     var plot = $.plot($("#graph"), plotdata, {
+      canvas: true,
       selection: { mode: "x" },
       grid: { show: true, clickable: true, hoverable: true },
       xaxis: { mode: "time", timezone: "browser", min: start, max: end },

--- a/Modules/vis/visualisations/stacked.php
+++ b/Modules/vis/visualisations/stacked.php
@@ -15,6 +15,11 @@
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.stack.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.time.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/date.format.min.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.canvas.js"></script>
+
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/base64.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/canvas2image.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/jquery.flot.saveAsImage.js"></script>
 
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/api.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/vis.helper.js"></script>
@@ -142,6 +147,7 @@
   function bargraph(dataA,dataB,barwidth, mode){
     $.plot($("#graph"), [ {color: colourb, data:dataA}, {color: colourt, data:dataB}],
     {
+      canvas: true,
       series: {
         stack: true,
         bars: { show: true,align: "center",barWidth: (barwidth*1000),fill: true }

--- a/Modules/vis/visualisations/stackedsolar.php
+++ b/Modules/vis/visualisations/stackedsolar.php
@@ -14,6 +14,11 @@
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.stack.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.time.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/date.format.min.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.canvas.js"></script>
+
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/base64.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/canvas2image.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/jquery.flot.saveAsImage.js"></script>
 
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/api.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/daysmonthsyears.js"></script>
@@ -144,6 +149,7 @@
 
   function bargraph(dataA,dataB,dataC,barwidth, mode){
     $.plot($("#graph"), [ {color: "#e0c21f", data:dataA}, {color: "#4e9acf", data:dataB}, {color: "#AA96ff", data:dataC}], {
+      canvas: true,
       series: {
         stack: true,
         bars: { show: true,align: "center",barWidth: (barwidth*1000),fill: true }

--- a/Modules/vis/visualisations/threshold.php
+++ b/Modules/vis/visualisations/threshold.php
@@ -15,6 +15,11 @@
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.touch.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.stack.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.time.min.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.canvas.js"></script>
+
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/base64.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/canvas2image.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/jquery.flot.saveAsImage.js"></script>
 
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/api.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/inst.js"></script>
@@ -79,6 +84,7 @@
 
     $.plot($("#graph"), [{color: "#c1a81f", data:dataA}, {color: "#dec225", data:dataB}, {color: "#deb368", data:dataC}],
     {
+      canvas: true,
       series: {
         stack: true,
         bars: { show: true,align: "center",barWidth: (3600*18*1000),fill: true }

--- a/Modules/vis/visualisations/timecompare.php
+++ b/Modules/vis/visualisations/timecompare.php
@@ -23,6 +23,11 @@
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.touch.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.togglelegend.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.time.min.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.canvas.js"></script>
+
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/base64.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/canvas2image.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/jquery.flot.saveAsImage.js"></script>
 
 <script language="javascript" type="text/javascript" src="<?php echo $path; ?>Modules/vis/visualisations/common/api.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path; ?>Modules/vis/visualisations/common/vis.helper.js"></script>

--- a/Modules/vis/visualisations/timecompare/timecompare.js
+++ b/Modules/vis/visualisations/timecompare/timecompare.js
@@ -127,6 +127,7 @@ function vis_feed_data_callback(context, data) {
 
 function plot() {
   $.plot($("#graph"), plotdata, {
+    canvas: true,
     grid: { show: true, hoverable: true, clickable: true },
     xaxis: { mode: "time", timezone: "browser", timeformat: xaxis_format, min: view.start, max: view.end },
     selection: { mode: "x" },

--- a/Modules/vis/visualisations/timestoredaily.php
+++ b/Modules/vis/visualisations/timestoredaily.php
@@ -18,6 +18,11 @@
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.touch.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.time.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/date.format.min.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.canvas.js"></script>
+
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/base64.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/canvas2image.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/jquery.flot.saveAsImage.js"></script>
 
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/api.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/vis.helper.js"></script>
@@ -149,6 +154,7 @@ $(function() {
     function plot()
     {
         var plot = $.plot(placeholder, [plotdata], {
+            canvas: true,
             //points: {show:true},
             bars: { show: true, align: "center", barWidth: 0.75*interval*1000, fill: true},
             xaxis: { mode: "time", timezone: "browser", min: view.start, max: view.end, minTickSize: [interval, "second"] },

--- a/Modules/vis/visualisations/zoom.php
+++ b/Modules/vis/visualisations/zoom.php
@@ -15,6 +15,11 @@
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.touch.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.time.min.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/date.format.min.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Lib/flot/jquery.flot.canvas.js"></script>
+
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/base64.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/lib/canvas2image.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path; ?>Lib/flot/plugin/saveAsImage/jquery.flot.saveAsImage.js"></script>
 
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/daysmonthsyears.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/zoom/view.js"></script>

--- a/Modules/vis/visualisations/zoom/graphs.js
+++ b/Modules/vis/visualisations/zoom/graphs.js
@@ -15,6 +15,7 @@ function bargraph(data,barwidth,mode)
 {
   $.plot($("#placeholder"), [{color: "#0096ff", data: data}],
   {
+    canvas: true,
     bars: { show: true,align: "center",barWidth: (barwidth*1000),fill: true },
     grid: { show: true, hoverable: true, clickable: true },
     xaxis: { mode: "time", timezone: "browser", minTickSize: [1, mode], tickLength: 1},


### PR DESCRIPTION
Added saveAsImage functionality to:

- timestoredaily
- editrealtime
- editdaily
- orderbars
- histgraph
- timecompare
- graph
- rawdata
- zoom
- stackedsolar
- stacked
- simplezoom
- realtime
- threshold
- orderthreshold
- dailyhistogram
- compare
- bargraph
- multigraph

_Note: The functionality is available clicking with the secondary mouse button_

Flot Plugins
http://www.flotcharts.org/plugins/

Plugin saveAsImage origin:
https://github.com/Jeff-Tian/jquery.flot.saveAsImage.js