### PR TITLE
Remove reliance on linux / unix tail command.

### DIFF
--- a/Modules/admin/admin_controller.php
+++ b/Modules/admin/admin_controller.php
@@ -59,7 +59,45 @@ function admin_controller()
                 $route->format = "text";
                 if ($log_enabled) {
                     ob_start();
-                    passthru("tail -25 " . $log_filename);
+                      // PHP replacement for tail starts here
+                      // full path to text file
+                      define("TEXT_FILE", $log_filename);
+                      // number of lines to read from the end of file
+                      define("LINES_COUNT", 25);
+
+                      function read_file($file, $lines) {
+                        //global $fsize;
+                        $handle = fopen($file, "r");
+                        $linecounter = $lines;
+                        $pos = -2;
+                        $beginning = false;
+                        $text = array();
+                        while ($linecounter > 0) {
+                          $t = " ";
+                          while ($t != "\n") {
+                            if(fseek($handle, $pos, SEEK_END) == -1) {
+                            $beginning = true;
+                            break;
+                            }
+                          $t = fgetc($handle);
+                          $pos --;
+                          }
+                        $linecounter --;
+                        if ($beginning) {
+                          rewind($handle);
+                          }
+                        $text[$lines-$linecounter-1] = fgets($handle);
+                        if ($beginning) break;
+                        }
+                      fclose ($handle);
+                      return array_reverse($text);
+                      }
+
+                      $fsize = round(filesize(TEXT_FILE)/1024/1024,2);
+                      $lines = read_file(TEXT_FILE, LINES_COUNT);
+                      foreach ($lines as $line) {
+                        echo $line;
+                      } //End PHP replacement for Tail
                     $result = trim(ob_get_clean());
                 } else {
                     $result = "Log is disabled.";


### PR DESCRIPTION
Replaced the reliance on 'tail' in the admin module.
Source PHP from here: http://tekkie.flashbit.net/php/tail-functionality-in-php

This should provide a like for like drop in for tail so that Windows server users can still get the log file displayed in the admin module.