### PR TITLE
Modify Log outputs to enable animated scrolling

### DIFF
--- a/Modules/admin/admin_main_view.php
+++ b/Modules/admin/admin_main_view.php
@@ -358,7 +358,10 @@ function getLog() {
   $.ajax({ url: path+"admin/getlog", async: true, dataType: "text", success: function(result)
     {
       $("#logreply").html(result);
-      $("#logreply-bound").scrollTop = $("#logreply-bound").scrollHeight;
+      var height = $("#logreply-bound").get(0).scrollHeight;
+      $("#logreply-bound").animate({
+        scrollTop: height
+      }, 500);
     }
   });
 }
@@ -387,10 +390,10 @@ function getUpdateLog() {
   $.ajax({ url: path+"admin/emonpi/getupdatelog", async: true, dataType: "text", success: function(result)
     {
       $("#update-log").html(result);
-      $("#update-log-bound").scrollTop = $("#update-log-bound").scrollHeight;
-      if (result.indexOf("emonPi update done")!=-1) {
-          clearInterval(refresher_update);
-      }
+      var height = $("#update-log-bound").get(0).scrollHeight;
+      $("#update-log-bound").animate({
+        scrollTop: height
+      }, 500);
     }
   });
 }


### PR DESCRIPTION
This makes the log views auto scroll (when auto refresh is on).

Discussion here: https://community.openenergymonitor.org/t/wouldnt-it-be-nice-if-the-log-windows-on-the-admin-page-would-scroll-before-your-eyes/1986
