### PR TITLE
Option to save log files with a click on the button in the admin page

### DIFF
--- a/Modules/admin/admin_controller.php
+++ b/Modules/admin/admin_controller.php
@@ -159,7 +159,9 @@ function admin_controller()
                     flush();
                     if (file_exists("/home/pi/data/emonpiupdate.log"))
                     {
-                      trim(readfile("/home/pi/data/emonpiupdate.log"));
+                      ob_start();
+                      readfile("/home/pi/data/emonpiupdate.log");
+                      echo(trim(ob_get_clean()));
                     }
                     else
                     {
@@ -193,7 +195,9 @@ function admin_controller()
                     header("Expires: 0");
                     flush();
                     if (file_exists("/home/pi/data/emonpibackup.log")) {
-                      trim(readfile("/home/pi/data/emonpibackup.log"));      
+                      ob_start();
+                      readfile("/home/pi/data/emonpibackup.log");
+                      echo(trim(ob_get_clean()));
                     }
                     else
                     {

--- a/Modules/admin/admin_controller.php
+++ b/Modules/admin/admin_controller.php
@@ -63,7 +63,13 @@ function admin_controller()
                 header("Pragma: no-cache"); 
                 header("Expires: 0");
                 flush();
-                readfile($log_filename);
+                if (file_exists($log_filename)) {
+                  readfile($log_filename);
+                }
+                else
+                {
+                  echo($log_filename . " does not exist!");
+                }
                 exit;
               }
             }
@@ -136,26 +142,30 @@ function admin_controller()
                     @fclose($fh);
                 }
                 
-                if ($route->subaction == 'getupdatelog') { 
+                if ($route->subaction == 'getupdatelog' && $session['admin']) { 
                     $route->format = "text";
                     ob_start();
                     passthru("cat /home/pi/data/emonpiupdate.log");
                     $result = trim(ob_get_clean());
                 }
                 
-                if ($route->subaction == 'downloadupdatelog')
+                if ($route->subaction == 'downloadupdatelog' && $session['admin'])
                 {
-                  if (file_exists("/home/pi/data/emonpiupdate.log"))
-                  {
                     header("Content-Type: application/octet-stream");
                     header("Content-Transfer-Encoding: Binary"); 
                     header("Content-disposition: attachment; filename=emonpiupdate.log");
                     header("Pragma: no-cache"); 
                     header("Expires: 0");
                     flush();
-                    readfile("/home/pi/data/emonpiupdate.log");
+                    if (file_exists("/home/pi/data/emonpiupdate.log"))
+                    {
+                      readfile("/home/pi/data/emonpiupdate.log");
+                    }
+                    else
+                    {
+                      echo("/home/pi/data/emonpiupdate.log does not exist!");
+                    }     
                     exit;
-                  }
                 }
                 
                 if ($route->subaction == 'backup' && $session['write'] && $session['admin']) { 
@@ -167,26 +177,29 @@ function admin_controller()
                     @fclose($fh);
                 }
                 
-                if ($route->subaction == 'getbackuplog') { 
+                if ($route->subaction == 'getbackuplog' && $session['admin']) { 
                     $route->format = "text";
                     ob_start();
                     passthru("cat /home/pi/data/emonpibackup.log");
                     $result = trim(ob_get_clean());
                 }
                 
-                if ($route->subaction == 'downloadbackuplog')
+                if ($route->subaction == 'downloadbackuplog' && $session['admin'])
                 {
-                  if (file_exists("/home/pi/data/emonpibackup.log"))
-                  {
                     header("Content-Type: application/octet-stream");
                     header("Content-Transfer-Encoding: Binary"); 
                     header("Content-disposition: attachment; filename=emonpibackup.log");
                     header("Pragma: no-cache"); 
                     header("Expires: 0");
                     flush();
-                    readfile("/home/pi/data/emonpibackup.log");
+                    if (file_exists("/home/pi/data/emonpibackup.log")) {
+                      readfile("/home/pi/data/emonpibackup.log");      
+                    }
+                    else
+                    {
+                      echo("/home/pi/data/emonpibackup.log does not exist!");
+                    }              
                     exit;
-                  }
                 }
                 
                 if ($route->subaction == "downloadbackup" && $session['write'] && $session['admin']) {

--- a/Modules/admin/admin_controller.php
+++ b/Modules/admin/admin_controller.php
@@ -53,7 +53,21 @@ function admin_controller()
                 $_SESSION['userid'] = intval(get('id'));
                 header("Location: ../user/view");
             }
-
+            
+            else if ($route->action == 'downloadlog')
+            {
+              if ($log_enabled) {
+                ob_start();
+                header('Content-Type: application/octet-stream');
+                header("Content-Transfer-Encoding: Binary"); 
+                header("Content-disposition: attachment; filename=\"" . basename($log_filename) . "\"");
+                ob_clean(); 
+                flush();
+                readfile($log_filename);
+                exit;
+              }
+            }
+            
             else if ($route->action == 'getlog')
             {
                 $route->format = "text";

--- a/Modules/admin/admin_controller.php
+++ b/Modules/admin/admin_controller.php
@@ -64,7 +64,7 @@ function admin_controller()
                 header("Expires: 0");
                 flush();
                 if (file_exists($log_filename)) {
-                  trim(readfile($log_filename));
+                  readfile($log_filename);
                 }
                 else
                 {

--- a/Modules/admin/admin_controller.php
+++ b/Modules/admin/admin_controller.php
@@ -64,7 +64,7 @@ function admin_controller()
                 header("Expires: 0");
                 flush();
                 if (file_exists($log_filename)) {
-                  readfile($log_filename);
+                  trim(readfile($log_filename));
                 }
                 else
                 {
@@ -159,7 +159,7 @@ function admin_controller()
                     flush();
                     if (file_exists("/home/pi/data/emonpiupdate.log"))
                     {
-                      readfile("/home/pi/data/emonpiupdate.log");
+                      trim(readfile("/home/pi/data/emonpiupdate.log"));
                     }
                     else
                     {
@@ -193,7 +193,7 @@ function admin_controller()
                     header("Expires: 0");
                     flush();
                     if (file_exists("/home/pi/data/emonpibackup.log")) {
-                      readfile("/home/pi/data/emonpibackup.log");      
+                      trim(readfile("/home/pi/data/emonpibackup.log"));      
                     }
                     else
                     {

--- a/Modules/admin/admin_controller.php
+++ b/Modules/admin/admin_controller.php
@@ -57,11 +57,11 @@ function admin_controller()
             else if ($route->action == 'downloadlog')
             {
               if ($log_enabled) {
-                ob_start();
-                header('Content-Type: application/octet-stream');
+                header("Content-Type: application/octet-stream");
                 header("Content-Transfer-Encoding: Binary"); 
                 header("Content-disposition: attachment; filename=\"" . basename($log_filename) . "\"");
-                ob_clean(); 
+                header("Pragma: no-cache"); 
+                header("Expires: 0");
                 flush();
                 readfile($log_filename);
                 exit;
@@ -143,6 +143,21 @@ function admin_controller()
                     $result = trim(ob_get_clean());
                 }
                 
+                if ($route->subaction == 'downloadupdatelog')
+                {
+                  if (file_exists("/home/pi/data/emonpiupdate.log"))
+                  {
+                    header("Content-Type: application/octet-stream");
+                    header("Content-Transfer-Encoding: Binary"); 
+                    header("Content-disposition: attachment; filename=emonpiupdate.log");
+                    header("Pragma: no-cache"); 
+                    header("Expires: 0");
+                    flush();
+                    readfile("/home/pi/data/emonpiupdate.log");
+                    exit;
+                  }
+                }
+                
                 if ($route->subaction == 'backup' && $session['write'] && $session['admin']) { 
                     $route->format = "text";
                     $file = "/tmp/emonpibackup";
@@ -157,6 +172,21 @@ function admin_controller()
                     ob_start();
                     passthru("cat /home/pi/data/emonpibackup.log");
                     $result = trim(ob_get_clean());
+                }
+                
+                if ($route->subaction == 'downloadbackuplog')
+                {
+                  if (file_exists("/home/pi/data/emonpibackup.log"))
+                  {
+                    header("Content-Type: application/octet-stream");
+                    header("Content-Transfer-Encoding: Binary"); 
+                    header("Content-disposition: attachment; filename=emonpibackup.log");
+                    header("Pragma: no-cache"); 
+                    header("Expires: 0");
+                    flush();
+                    readfile("/home/pi/data/emonpibackup.log");
+                    exit;
+                  }
                 }
                 
                 if ($route->subaction == "downloadbackup" && $session['write'] && $session['admin']) {

--- a/Modules/admin/admin_main_view.php
+++ b/Modules/admin/admin_main_view.php
@@ -228,8 +228,8 @@ if ($allow_emonpi_admin) {
                     <p>Note: If using emonBase (Raspberry Pi + RFM69Pi) the updater can still be used to update Emoncms, RFM69Pi firmware will not be changed.</p> 
                 </td>
                 <td class="buttons" style="border-top: 0px"><br>
-                    <button id="emonpiupdate" class="btn btn-info"><?php echo _('Update Now'); ?></button><br><br>
-                    <a href="<?php echo $path; ?>admin/emonpi/downloadupdatelog" class="btn btn-info"><?php echo _('Download log'); ?></a>
+                    <button id="emonpiupdate" class="btn btn-info"><?php echo _('Update Now'); ?></button>
+                    <a href="<?php echo $path; ?>admin/emonpi/downloadupdatelog" class="btn btn-info"><?php echo _('Download log'); ?></a><br><br>
                 </td>
             </tr>
             <tr>

--- a/Modules/admin/admin_main_view.php
+++ b/Modules/admin/admin_main_view.php
@@ -203,7 +203,7 @@ if(is_writable($log_filename)) {
 <?php if(is_writable($log_filename)) { ?>
                     <br>
                     <button id="getlog" type="button" class="btn btn-info" data-toggle="button" aria-pressed="false" autocomplete="off"><?php echo _('Auto refresh'); ?></button>
-                    <a href="<?php echo $path; ?>admin/downloadlog" class="btn btn-info"><?php echo _('Download'); ?></a>
+                    <a href="<?php echo $path; ?>admin/downloadlog" class="btn btn-info"><?php echo _('Download log'); ?></a>
 <?php } ?>
                 </td>
             </tr>
@@ -229,6 +229,7 @@ if ($allow_emonpi_admin) {
                 </td>
                 <td class="buttons" style="border-top: 0px"><br>
                     <button id="emonpiupdate" class="btn btn-info"><?php echo _('Update Now'); ?></button><br><br>
+                    <a href="<?php echo $path; ?>admin/emonpi/downloadupdatelog" class="btn btn-info"><?php echo _('Download log'); ?></a>
                 </td>
             </tr>
             <tr>

--- a/Modules/admin/admin_main_view.php
+++ b/Modules/admin/admin_main_view.php
@@ -203,6 +203,7 @@ if(is_writable($log_filename)) {
 <?php if(is_writable($log_filename)) { ?>
                     <br>
                     <button id="getlog" type="button" class="btn btn-info" data-toggle="button" aria-pressed="false" autocomplete="off"><?php echo _('Auto refresh'); ?></button>
+                    <a href="<?php echo $path; ?>admin/downloadlog" class="btn btn-info"><?php echo _('Download'); ?></a>
 <?php } ?>
                 </td>
             </tr>


### PR DESCRIPTION
As per request of @glynhudson  i added a quick option to download the log file. I intentionally did not put text as content type so you always get a download box (depending on the browser) to choose where to save the file and don't view the file inside the browser.

I tested it on my windows and it seems to work fine for me should be tested on linux