### PR TITLE
Re-enable auto scrolling of update log view...

### DIFF
--- a/Modules/admin/admin_main_view.php
+++ b/Modules/admin/admin_main_view.php
@@ -390,9 +390,8 @@ function getUpdateLog() {
   $.ajax({ url: path+"admin/emonpi/getupdatelog", async: true, dataType: "text", success: function(result)
     {
       $("#update-log").html(result);
-      $("#update-log-bound").scrollTop = $("#update-log-bound").scrollHeight;
-      if (result.indexOf("emonPi update done")!=-1) {
-          clearInterval(refresher_update);
+      if(result.indexOf("emonPi update done") > -1) {} else {
+        $('#update-log-bound').animate({scrollTop: $('#update-log-bound').prop("scrollHeight")}, 1000);
       }
     }
   });


### PR DESCRIPTION
Re-worked my original commit for this from a couple of days ago.
It now scrolls the log to the end, once the end "emonPi update done" is reached, control of scrolling is relinquished allowing the user to scroll back up the log.

The one caveat to this - is that if the update process bails before completion, the user cannot scroll up - however that is somewhat of a mute point given the new option to download the log for diagnosis / debugging / support.