### PR TITLE
Initial zoom level option in Visualizations

### DIFF
--- a/Modules/vis/visualisations/bargraph.php
+++ b/Modules/vis/visualisations/bargraph.php
@@ -84,6 +84,9 @@
     var mode = urlParams.mode;
     if (mode==undefined || mode=='') mode = false;
     
+    var initzoom = urlParams.initzoom;
+    if (initzoom==undefined || initzoom=='' || "DWMY".indexOf(initzoom)===-1) initzoom = 'W';
+    
     document.getElementById("textunitD").innerHTML=units;
     document.getElementById("textunitM").innerHTML=units;
     document.getElementById("textunitY").innerHTML=units;
@@ -112,16 +115,14 @@
 
     var intervalms = interval * 1000;
 
-    var timeWindow;
-
-    if (intervalcode=='y')
-       timeWindow = 3600000*24*365*5;
-    else if (intervalcode=='m')
-       timeWindow = 3600000*24*365;
-    else if (intervalcode=='d')
-       timeWindow = 3600000*24*10;
-    else
-       timeWindow = 3600000*24*31;
+    if (initzoom==='D')
+        var timeWindow = (3600000*24.0);
+    if (initzoom==='W')
+        var timeWindow = (3600000*24.0*7);
+    if (initzoom==='M')
+        var timeWindow = (3600000*24.0*30);
+    if (initzoom==='Y')
+        var timeWindow = (3600000*24.0*365);
 
     view.start = +new Date - timeWindow;
     view.end = +new Date;

--- a/Modules/vis/visualisations/rawdata.php
+++ b/Modules/vis/visualisations/rawdata.php
@@ -84,7 +84,9 @@ var scale = urlParams.scale;
     if (scale==undefined || scale=='') scale = 1;
 var fill = +urlParams.fill;
     if (fill==undefined || fill=='') fill = 0;
-if (fill>0) fill = true;
+    if (fill>0) fill = true;
+var initzoom = urlParams.initzoom;
+    if (initzoom==undefined || initzoom=='' || "DWMY".indexOf(initzoom)===-1) initzoom = 'W';
 // Some browsers want the colour codes to be prepended with a "#". Therefore, we
 // add one if it's not already there
 if (plotColour.indexOf("#") == -1) {
@@ -104,7 +106,14 @@ placeholder.height(height-top_offset);
 
 if (embed) placeholder.height($(window).height()-top_offset);
 
-var timeWindow = (3600000*24.0*7);
+if (initzoom==='D')
+    var timeWindow = (3600000*24.0);
+if (initzoom==='W')
+    var timeWindow = (3600000*24.0*7);
+if (initzoom==='M')
+    var timeWindow = (3600000*24.0*30);
+if (initzoom==='Y')
+    var timeWindow = (3600000*24.0*365);
 view.start = +new Date - timeWindow;
 view.end = +new Date;
 

--- a/Modules/vis/visualisations/threshold.php
+++ b/Modules/vis/visualisations/threshold.php
@@ -23,6 +23,7 @@
 
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/api.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/inst.js"></script>
+<script language="javascript" type="text/javascript" src="<?php echo $path;?>Modules/vis/visualisations/common/vis.helper.js"></script>
 
 <?php if (!$embed) { ?>
 <h2><?php echo _("Threshold"); ?></h2>
@@ -62,8 +63,18 @@
 
   var path = "<?php echo $path; ?>";
   var apikey = "<?php echo $apikey; ?>";
+  
+  var initzoom = urlParams.initzoom;
+    if (initzoom==undefined || initzoom=='' || "DWMY".indexOf(initzoom)===-1) initzoom = 'W'; //Initial time window
 
-  var timeWindow = (3600000*24.0*7);        //Initial time window
+  if (initzoom==='D')
+    var timeWindow = (3600000*24.0);
+  if (initzoom==='W')
+    var timeWindow = (3600000*24.0*7);
+  if (initzoom==='M')
+    var timeWindow = (3600000*24.0*30);
+  if (initzoom==='Y')
+    var timeWindow = (3600000*24.0*365);      
   var start = ((new Date()).getTime())-timeWindow;    //Get start time
   var end = (new Date()).getTime();       //Get end time
 

--- a/Modules/vis/visualisations/timestoredaily.php
+++ b/Modules/vis/visualisations/timestoredaily.php
@@ -76,13 +76,23 @@ var apikey = "";
 // var feedid = urlParams['feedid'];
 // var embed = urlParams['embed'] || false;
 
+var initzoom = urlParams.initzoom;
+    if (initzoom==undefined || initzoom=='' || "DWMY".indexOf(initzoom)===-1) initzoom = 'W';
+
 var placeholder_bound = $('#placeholder_bound');
 var placeholder = $('#placeholder').width(placeholder_bound.width()).height($('#placeholder_bound').height()-top_offset);
 if (embed) placeholder.height($(window).height()-top_offset);
 
 
 
-var timeWindow = (3600000*24.0*7);
+if (initzoom==='D')
+    var timeWindow = (3600000*24.0);
+if (initzoom==='W')
+    var timeWindow = (3600000*24.0*7);
+if (initzoom==='M')
+    var timeWindow = (3600000*24.0*30);
+if (initzoom==='Y')
+    var timeWindow = (3600000*24.0*365);
 view.start = +new Date - timeWindow;
 view.end = +new Date;
 

--- a/Modules/vis/widget/vis_render.js
+++ b/Modules/vis/widget/vis_render.js
@@ -27,10 +27,10 @@ function vis_widgetlist(){
     {
       "offsetx":0,"offsety":0,"width":400,"height":300,
       "menu":"Visualisations",  
-      "options":["feedid","colour","units","dp","scale","fill"],
-      "optionstype":["feedid","colour_picker","value","value","value","value"],
-      "optionsname":[_Tr("Feed"),_Tr("Colour"),_Tr("units"),_Tr("dp"),_Tr("scale"),_Tr("Fill")],
-      "optionshint":[_Tr("Feed source"),_Tr("Line colour in hex. Blank is use default."),_Tr("units"),_Tr("Decimal points"),_Tr("Scale by"),_Tr("Fill value")],
+      "options":["feedid","colour","units","dp","scale","fill","initzoom"],
+      "optionstype":["feedid","colour_picker","value","value","value","value","value"],
+      "optionsname":[_Tr("Feed"),_Tr("Colour"),_Tr("units"),_Tr("dp"),_Tr("scale"),_Tr("Fill"),_Tr("Initial Zoom")],
+      "optionshint":[_Tr("Feed source"),_Tr("Line colour in hex. Blank is use default."),_Tr("units"),_Tr("Decimal points"),_Tr("Scale by"),_Tr("Fill value"),_Tr("D=Day, W=Week, M=Month, Y=Year")],
       
       "html":""
     },

--- a/Modules/vis/widget/vis_render.js
+++ b/Modules/vis/widget/vis_render.js
@@ -50,10 +50,10 @@ function vis_widgetlist(){
     {
       "offsetx":0,"offsety":0,"width":400,"height":300,
       "menu":"Visualisations",
-      "options":["feedid","units"],
-      "optionstype":["feedid","value"],
-      "optionsname":[_Tr("Feed"),_Tr("Units")],
-      "optionshint":[_Tr("Feed source"),_Tr("Units to show")],
+      "options":["feedid","units","initzoom"],
+      "optionstype":["feedid","value","value"],
+      "optionsname":[_Tr("Feed"),_Tr("Units"),_Tr("Initial Zoom")],
+      "optionshint":[_Tr("Feed source"),_Tr("Units to show"),_Tr("D=Day, W=Week, M=Month, Y=Year")],
       "html":""
     },
 

--- a/Modules/vis/widget/vis_render.js
+++ b/Modules/vis/widget/vis_render.js
@@ -94,10 +94,10 @@ function vis_widgetlist(){
     {
       "offsetx":0,"offsety":0,"width":400,"height":300,
       "menu":"Visualisations",
-      "options":["feedid","thresholdA","thresholdB"],
-      "optionstype":["feedid","value","value"],
-      "optionsname":[_Tr("Feed"),_Tr("Threshold A"),_Tr("Threshold B")],
-      "optionshint":[_Tr("Feed source"),_Tr("Threshold A used"),_Tr("Threshold B used")],
+      "options":["feedid","thresholdA","thresholdB","initzoom"],
+      "optionstype":["feedid","value","value","value"],
+      "optionsname":[_Tr("Feed"),_Tr("Threshold A"),_Tr("Threshold B"),_Tr("Initial Zoom")],
+      "optionshint":[_Tr("Feed source"),_Tr("Threshold A used"),_Tr("Threshold B used"),_Tr("D=Day, W=Week, M=Month, Y=Year")],
       "html":""
     },
 

--- a/Modules/vis/widget/vis_render.js
+++ b/Modules/vis/widget/vis_render.js
@@ -39,10 +39,10 @@ function vis_widgetlist(){
     {
       "offsetx":0,"offsety":0,"width":400,"height":300,
       "menu":"Visualisations",
-      "options":["feedid","colour","interval","units","dp","scale","delta","mode"],
-      "optionstype":["feedid","colour_picker","value","value","value","value","boolean","value"],
-      "optionsname":[_Tr("Feed"),_Tr("Colour"),_Tr("interval"),_Tr("units"),_Tr("dp"),_Tr("scale"),_Tr("delta"),_Tr("mode")],
-      "optionshint":[_Tr("Feed source"),_Tr("Line colour in hex. Blank is use default."),_Tr("Interval (seconds)-you can set \"d\" for day, \"m\" for month, or \"y\" for year"),_Tr("Units"),_Tr("Decimal points"),_Tr("Scale by"),_Tr("Show difference between each bar"),_Tr("Mode set to 'daily' can be used instead of interval for timezone based daily data")],
+      "options":["feedid","colour","interval","units","dp","scale","delta","mode","initzoom"],
+      "optionstype":["feedid","colour_picker","value","value","value","value","boolean","value","value"],
+      "optionsname":[_Tr("Feed"),_Tr("Colour"),_Tr("interval"),_Tr("units"),_Tr("dp"),_Tr("scale"),_Tr("delta"),_Tr("mode"),_Tr("Initial Zoom")],
+      "optionshint":[_Tr("Feed source"),_Tr("Line colour in hex. Blank is use default."),_Tr("Interval (seconds)-you can set \"d\" for day, \"m\" for month, or \"y\" for year"),_Tr("Units"),_Tr("Decimal points"),_Tr("Scale by"),_Tr("Show difference between each bar"),_Tr("Mode set to 'daily' can be used instead of interval for timezone based daily data"),_Tr("D=Day, W=Week, M=Month, Y=Year")],
       "html":""
     },
 


### PR DESCRIPTION
Default zoom level of the radata visualization (day , week, month, year) in the configuration panel.

By default the visualization uses week zoom. The zoom level selection is robust to unexpected values or undefined value.

It could be extended to other visualizations. I can prepare another PR to do that.