### PR TITLE
Enable environment-variable settings in default.settings.php

### DIFF
--- a/process_settings.php
+++ b/process_settings.php
@@ -122,7 +122,7 @@ if (isset($_ENV["MYSQL_PORT"]))     $port = $_ENV["MYSQL_PORT"];
 // create the array if it's not already been done
 if (!isset($redis_server)) $redis_server = array();
 
-if (isset($_ENV["REDIS_ENABLED"]))  $redis_enabled = $_ENV["REDIS_ENABLED"] === 'true' : false;
+if (isset($_ENV["REDIS_ENABLED"]))  $redis_enabled = $_ENV["REDIS_ENABLED"] === 'true';
 if (isset($_ENV["REDIS_HOST"]))     $redis_server['host'] = $_ENV["REDIS_HOST"];
 if (isset($_ENV["REDIS_PORT"]))     $redis_server['port'] = $_ENV["REDIS_PORT"];
 if (isset($_ENV["REDIS_AUTH"]))     $redis_server['auth'] = $_ENV["REDIS_AUTH"];
@@ -131,10 +131,10 @@ if (isset($_ENV["REDIS_PREFIX"]))   $redis_server['prefix'] = $_ENV["REDIS_PREFI
 //3 #### MQTT
 // create the array if it's not already been done
 if (!isset($mqtt_server)) $mqtt_server = array();
-if (isset($_ENV["MQTT_ENABLED"]))  $mqtt_enabled = $_ENV["MQTT_ENABLED"] === 'true' : false;
+if (isset($_ENV["MQTT_ENABLED"]))  $mqtt_enabled = $_ENV["MQTT_ENABLED"] === 'true';
 
-if (isset($_ENV["REDIS_HOST"]))     $redis_server['host'] = $_ENV["MQTT_HOST"];
-if (isset($_ENV["REDIS_HOST"]))     $redis_server['port'] = $_ENV["MQTT_PORT"];
-if (isset($_ENV["REDIS_HOST"]))     $redis_server['user'] = $_ENV["MQTT_USER"];
-if (isset($_ENV["REDIS_HOST"]))     $redis_server['password'] = $_ENV["MQTT_PASSWORD"];
-if (isset($_ENV["REDIS_HOST"]))     $redis_server['basetopic'] = $_ENV["MQTT_BASETOPIC"];
+if (isset($_ENV["MQTT_HOST"]))     $redis_server['host'] = $_ENV["MQTT_HOST"];
+if (isset($_ENV["MQTT_PORT"]))     $redis_server['port'] = $_ENV["MQTT_PORT"];
+if (isset($_ENV["MQTT_USER"]))     $redis_server['user'] = $_ENV["MQTT_USER"];
+if (isset($_ENV["MQTT_PASSWORD"]))     $redis_server['password'] = $_ENV["MQTT_PASSWORD"];
+if (isset($_ENV["MQTT_BASETOPIC"]))     $redis_server['basetopic'] = $_ENV["MQTT_BASETOPIC"];

--- a/process_settings.php
+++ b/process_settings.php
@@ -101,3 +101,40 @@ else
     echo "</div>";
     die;
 }
+
+/*
+    Settings from environment variables
+
+    Environment settings override settings.php and defaults, 
+    and allow you to run multiple variants of the same
+    installation (e.g. for testing).
+*/
+
+//1 #### Mysql database settings
+if (isset($_ENV["MYSQL_HOST"]))     $server = $_ENV["MYSQL_HOST"];
+if (isset($_ENV["MYSQL_DATABASE"])) $database = $_ENV["MYSQL_DATABASE"];
+if (isset($_ENV["MYSQL_USER"]))     $username = $_ENV["MYSQL_USER"];
+if (isset($_ENV["MYSQL_PASSWORD"])) $password = $_ENV["MYSQL_PASSWORD"];
+if (isset($_ENV["MYSQL_PORT"]))     $port = $_ENV["MYSQL_PORT"];
+
+
+//2 #### redis
+// create the array if it's not already been done
+if (!isset($redis_server)) $redis_server = array();
+
+if (isset($_ENV["REDIS_ENABLED"]))  $redis_enabled = $_ENV["REDIS_ENABLED"] === 'true' : false;
+if (isset($_ENV["REDIS_HOST"]))     $redis_server['host'] = $_ENV["REDIS_HOST"];
+if (isset($_ENV["REDIS_PORT"]))     $redis_server['port'] = $_ENV["REDIS_PORT"];
+if (isset($_ENV["REDIS_AUTH"]))     $redis_server['auth'] = $_ENV["REDIS_AUTH"];
+if (isset($_ENV["REDIS_PREFIX"]))   $redis_server['prefix'] = $_ENV["REDIS_PREFIX"];
+
+//3 #### MQTT
+// create the array if it's not already been done
+if (!isset($mqtt_server)) $mqtt_server = array();
+if (isset($_ENV["MQTT_ENABLED"]))  $mqtt_enabled = $_ENV["MQTT_ENABLED"] === 'true' : false;
+
+if (isset($_ENV["REDIS_HOST"]))     $redis_server['host'] = $_ENV["MQTT_HOST"];
+if (isset($_ENV["REDIS_HOST"]))     $redis_server['port'] = $_ENV["MQTT_PORT"];
+if (isset($_ENV["REDIS_HOST"]))     $redis_server['user'] = $_ENV["MQTT_USER"];
+if (isset($_ENV["REDIS_HOST"]))     $redis_server['password'] = $_ENV["MQTT_PASSWORD"];
+if (isset($_ENV["REDIS_HOST"]))     $redis_server['basetopic'] = $_ENV["MQTT_BASETOPIC"];


### PR DESCRIPTION
A belated follow-up to https://github.com/emoncms/emoncms/pull/547. 

This change adds the ability to define some core settings as environment variables. When set, environment variables take precedence over `settings.php` and defaults. This enables Docker (and other services) to provision emoncms without needing to alter the default settings file at all, and (for example) allows the same codebase to be run against different environments for testing.

This doesn't affect the behaviour on systems where the environment variables are not set.