### PR TITLE
Validate variables after environment loaded

### DIFF
--- a/process_settings.php
+++ b/process_settings.php
@@ -17,9 +17,50 @@ require_once('Lib/enum.php');
 // Check if settings.php file exists
 if(file_exists(dirname(__FILE__)."/settings.php"))
 {
-    // Load settings.php
+    /*
+        Load settings.php
+    */
     require_once('settings.php');
 
+    /*
+        Load settings from environment variables
+
+        Environment settings override settings.php and defaults, 
+        and allow you to run multiple variants of the same
+        installation (e.g. for testing).
+    */
+
+    //1 #### Mysql database settings
+    if (isset($_ENV["MYSQL_HOST"]))     $server = $_ENV["MYSQL_HOST"];
+    if (isset($_ENV["MYSQL_DATABASE"])) $database = $_ENV["MYSQL_DATABASE"];
+    if (isset($_ENV["MYSQL_USER"]))     $username = $_ENV["MYSQL_USER"];
+    if (isset($_ENV["MYSQL_PASSWORD"])) $password = $_ENV["MYSQL_PASSWORD"];
+    if (isset($_ENV["MYSQL_PORT"]))     $port = $_ENV["MYSQL_PORT"];
+
+    //2 #### redis
+    // create the array if it's not already been done
+    if (!isset($redis_server)) $redis_server = array();
+
+    if (isset($_ENV["REDIS_ENABLED"]))  $redis_enabled = $_ENV["REDIS_ENABLED"] === 'true';
+    if (isset($_ENV["REDIS_HOST"]))     $redis_server['host'] = $_ENV["REDIS_HOST"];
+    if (isset($_ENV["REDIS_PORT"]))     $redis_server['port'] = $_ENV["REDIS_PORT"];
+    if (isset($_ENV["REDIS_AUTH"]))     $redis_server['auth'] = $_ENV["REDIS_AUTH"];
+    if (isset($_ENV["REDIS_PREFIX"]))   $redis_server['prefix'] = $_ENV["REDIS_PREFIX"];
+
+    //3 #### MQTT
+    // create the array if it's not already been done
+    if (!isset($mqtt_server)) $mqtt_server = array();
+    if (isset($_ENV["MQTT_ENABLED"]))  $mqtt_enabled = $_ENV["MQTT_ENABLED"] === 'true';
+
+    if (isset($_ENV["MQTT_HOST"]))     $redis_server['host'] = $_ENV["MQTT_HOST"];
+    if (isset($_ENV["MQTT_PORT"]))     $redis_server['port'] = $_ENV["MQTT_PORT"];
+    if (isset($_ENV["MQTT_USER"]))     $redis_server['user'] = $_ENV["MQTT_USER"];
+    if (isset($_ENV["MQTT_PASSWORD"]))     $redis_server['password'] = $_ENV["MQTT_PASSWORD"];
+    if (isset($_ENV["MQTT_BASETOPIC"]))     $redis_server['basetopic'] = $_ENV["MQTT_BASETOPIC"];
+
+    /*
+        Validate settings are complete
+    */
     $error_out = "";
 
     if (!isset($config_file_version) || $config_file_version < 8) $error_out .= '<p>settings.php config file has new settings for this version. Copy default.settings.php to settings.php and modify the later.</p>';
@@ -101,40 +142,3 @@ else
     echo "</div>";
     die;
 }
-
-/*
-    Settings from environment variables
-
-    Environment settings override settings.php and defaults, 
-    and allow you to run multiple variants of the same
-    installation (e.g. for testing).
-*/
-
-//1 #### Mysql database settings
-if (isset($_ENV["MYSQL_HOST"]))     $server = $_ENV["MYSQL_HOST"];
-if (isset($_ENV["MYSQL_DATABASE"])) $database = $_ENV["MYSQL_DATABASE"];
-if (isset($_ENV["MYSQL_USER"]))     $username = $_ENV["MYSQL_USER"];
-if (isset($_ENV["MYSQL_PASSWORD"])) $password = $_ENV["MYSQL_PASSWORD"];
-if (isset($_ENV["MYSQL_PORT"]))     $port = $_ENV["MYSQL_PORT"];
-
-
-//2 #### redis
-// create the array if it's not already been done
-if (!isset($redis_server)) $redis_server = array();
-
-if (isset($_ENV["REDIS_ENABLED"]))  $redis_enabled = $_ENV["REDIS_ENABLED"] === 'true';
-if (isset($_ENV["REDIS_HOST"]))     $redis_server['host'] = $_ENV["REDIS_HOST"];
-if (isset($_ENV["REDIS_PORT"]))     $redis_server['port'] = $_ENV["REDIS_PORT"];
-if (isset($_ENV["REDIS_AUTH"]))     $redis_server['auth'] = $_ENV["REDIS_AUTH"];
-if (isset($_ENV["REDIS_PREFIX"]))   $redis_server['prefix'] = $_ENV["REDIS_PREFIX"];
-
-//3 #### MQTT
-// create the array if it's not already been done
-if (!isset($mqtt_server)) $mqtt_server = array();
-if (isset($_ENV["MQTT_ENABLED"]))  $mqtt_enabled = $_ENV["MQTT_ENABLED"] === 'true';
-
-if (isset($_ENV["MQTT_HOST"]))     $redis_server['host'] = $_ENV["MQTT_HOST"];
-if (isset($_ENV["MQTT_PORT"]))     $redis_server['port'] = $_ENV["MQTT_PORT"];
-if (isset($_ENV["MQTT_USER"]))     $redis_server['user'] = $_ENV["MQTT_USER"];
-if (isset($_ENV["MQTT_PASSWORD"]))     $redis_server['password'] = $_ENV["MQTT_PASSWORD"];
-if (isset($_ENV["MQTT_BASETOPIC"]))     $redis_server['basetopic'] = $_ENV["MQTT_BASETOPIC"];


### PR DESCRIPTION
This PR improves the recently merged environment variable support (https://github.com/emoncms/emoncms/pull/602) by validating the setup _after_ the environment variables have been pulled in. This has a couple of benefits:

1. In a setup where environment variables are used, the config no longer needs to be duplicated in `settings.php`, but omitting the config from _both_ yields the correct error.
2. Any validation added in future will be applied to values loaded from environment variables, making the behaviour consistent across config approaches.

