### PR TITLE
Encode URL GET params for registration, password change, etc.

### DIFF
--- a/Modules/user/profile/profile.php
+++ b/Modules/user/profile/profile.php
@@ -249,7 +249,7 @@ function languagecode_to_name($langs) {
         {
             $.ajax({
                 url: path+"user/changeemail.json",
-                data: "&email="+email,
+                data: "&email="+encodeURIComponent(email),
                 dataType: 'json',
                 success: function(result)
                 {

--- a/Modules/user/user.js
+++ b/Modules/user/user.js
@@ -24,7 +24,7 @@ var user = {
     $.ajax({
       type: "POST",
       url: path+"user/register.json",
-      data: "&username="+encodeURIComponent(username)+"&password="+encodeURIComponent(password)+"&email="+encodeURIComponent(password),
+      data: "&username="+encodeURIComponent(username)+"&password="+encodeURIComponent(password)+"&email="+encodeURIComponent(email),
       dataType: 'json',
       async: false, 
       success: function(data)

--- a/Modules/user/user.js
+++ b/Modules/user/user.js
@@ -45,7 +45,7 @@ var user = {
   'passwordreset':function(username,email)
   {
     var result = {};
-    $.ajax({ url: path+"user/passwordreset.json", data: "&username="+username+"&email="+email, dataType: 'json', async: false, success: function(data) {result = data;} });
+    $.ajax({ url: path+"user/passwordreset.json", data: "&username="+encodeURIComponent(username)+"&email="+encodeURIComponent(email), dataType: 'json', async: false, success: function(data) {result = data;} });
     return result;
   },
 

--- a/Modules/user/user.js
+++ b/Modules/user/user.js
@@ -7,7 +7,7 @@ var user = {
     $.ajax({
       type: "POST",
       url: path+"user/login.json",
-      data: "&username="+username+"&password="+encodeURIComponent(password)+"&rememberme="+rememberme,
+      data: "&username="+encodeURIComponent(username)+"&password="+encodeURIComponent(password)+"&rememberme="+encodeURIComponent(rememberme),
       dataType: 'json',
       async: false,
       success: function(data)
@@ -24,7 +24,7 @@ var user = {
     $.ajax({
       type: "POST",
       url: path+"user/register.json",
-      data: "&username="+username+"&password="+encodeURIComponent(password)+"&email="+email,
+      data: "&username="+encodeURIComponent(username)+"&password="+encodeURIComponent(password)+"&email="+encodeURIComponent(password),
       dataType: 'json',
       async: false, 
       success: function(data)


### PR DESCRIPTION
This PR resolves #616. 

The cause of #616 was illegal URI characters (in this case a `+`) being replaced with ` `, which in turn results in an illegal email address on the server.

Encoding all URI components is sensible because it also prevents spurious input from having unintended consequences (e.g. if a user entered the username `bob&email=somethingelse@gmail.com`). 

I've tested this change locally and it fixed it for the `+` character issue at least.