### PR TITLE
Support for unicode characters in multigraph labels

### DIFF
--- a/Modules/vis/multigraph_model.php
+++ b/Modules/vis/multigraph_model.php
@@ -38,7 +38,7 @@ class Multigraph
     {
         $id = intval($id);
         $userid = intval($userid);
-        $feedlist = preg_replace('/[^\w\s-.",:{}\[\]]/','',$feedlist);
+        $feedlist = preg_replace('/[^\p{L}_\p{N}\s-.",:{}\[\]]/u','',$feedlist);
         $name = preg_replace('/[^\p{L}_\p{N}\s-.]/u','',$name);
         $this->mysqli->query("UPDATE multigraph SET `name` = '$name', `feedlist` = '$feedlist' WHERE `id`='$id' AND `userid`='$userid'");
         if ($this->mysqli->affected_rows>0){


### PR DESCRIPTION
Hello,
the multigraph labels mangle unicode sequences dropping them from labels in multigraph, even when they are permitted in feed names. I have changed the line to match the pattern on $name line and permit unicode sequences as well.