### PR TITLE
Add softlink support for module processlists

### DIFF
--- a/Modules/process/process_model.php
+++ b/Modules/process/process_model.php
@@ -131,7 +131,7 @@ class Process
         $list = array();
         $dir = scandir("Modules");
         for ($i=2; $i<count($dir); $i++) {
-            if (filetype("Modules/".$dir[$i])=='dir') {
+            if (filetype("Modules/".$dir[$i])=='dir' || filetype("Modules/".$dir[$i])=='link') {
                 $class = $this->get_module_class($dir[$i]);
                 if ($class != null) {
                     $mod_process_list = $class->process_list();


### PR DESCRIPTION
Modules with only a softlink in the Modules directory do not get their *_processlist.php processed correctly. 
Make Process->load_modules() aware of softlinks, to enable custon processes of external modules.

Almost identical to my last pull request regarding [module schemas](https://github.com/emoncms/emoncms/pull/651) and again just a very (very) small commit :)