### PR TITLE
Display phpmodules versions on admin page - Part 2

### DIFF
--- a/Modules/admin/admin_main_view.php
+++ b/Modules/admin/admin_main_view.php
@@ -328,7 +328,7 @@ if ($system['mem_info']) {
 
 ?>
               <tr><td><b>PHP</b></td><td>Version</td><td colspan="2"><?php echo $system['php'] . ' (' . "Zend Version" . ' ' . $system['zend'] . ')'; ?></td></tr>
-              <tr><td class="subinfo"></td><td>Modules</td><td colspan="2"><?php while (list($key, $val) = each($system['php_modules'])) { echo "$val &nbsp; "; } ?></td></tr>
+              <tr><td class="subinfo"></td><td>Modules</td><td colspan="2"><?php natcasesort($system['php_modules']); while ( list($key, $val) = each($system['php_modules']) ) { $ver = phpversion($val); echo $val; if (!empty($ver) && is_numeric($ver[0])) { $first = explode(" ", $ver); echo " v" .$first[0]; } echo " &nbsp; "; } ?></td></tr>
             </table>
             
         </td>


### PR DESCRIPTION
See issue #660 and issue #663.

The php modules are in alphabetical order, round brackets removed, added "v" for version.