### PR TITLE
Fixed issue with split on 30 minute interval

### DIFF
--- a/Modules/feed/engine/PHPFina.php
+++ b/Modules/feed/engine/PHPFina.php
@@ -413,21 +413,24 @@ class PHPFina
     public function get_data_DMY_time_of_day($id,$start,$end,$mode,$timezone,$split) 
     {
         if ($mode!="daily" && $mode!="weekly" && $mode!="monthly") return false;
-        
+
         $start = intval($start/1000);
         $end = intval($end/1000);
-        $split = json_decode($split);  
+        $split = json_decode($split);
+
         if (gettype($split)!="array") return false;
-        if (count($split)>24) return false;     
-               
+        /* SP Increase to 48 points to allow a days worth of half hour readings */
+        if (count($split)>48) return false;
+
         // If meta data file does not exist exit
         if (!$meta = $this->get_meta($id)) return array('success'=>false, 'message'=>"Error reading meta data feedid=$name");
         $meta->npoints = $this->get_npoints($id);
-        
+
         $data = array();
-        
+
+	/* Open file */
         $fh = fopen($this->dir.$id.".dat", 'rb');
-        
+
         $date = new DateTime();
         if ($timezone===0) $timezone = "UTC";
         $date->setTimezone(new DateTimeZone($timezone));
@@ -435,31 +438,31 @@ class PHPFina
         $date->modify("midnight");
         if ($mode=="weekly") $date->modify("this monday");
         if ($mode=="monthly") $date->modify("first day of this month");
-        
+
         $n = 0;
-        while($n<10000) // max itterations
+        while($n<10000) // max iterations allows for approx 7 months with 1 day granularity
         {
             $time = $date->getTimestamp();
             if ($time>$end) break;
-            
+
             $value = null;
-            
+
             $split_values = array();
-            
-            foreach ($split as $splitpoint) 
+
+            foreach ($split as $splitpoint)
             {
-                $splitpoint = (float) $splitpoint;
-                $split_offset = (int) $splitpoint * 3600;
-                
+                //Fix issue with rounding to nearest 30 minutes
+                $split_offset = (int) (((float)$splitpoint) * 3600.0);
+
                 $pos = round((($time+$split_offset) - $meta->start_time) / $meta->interval);
                 $value = null;
-                
+
                 if ($pos>=0 && $pos < $meta->npoints)
                 {
                     // read from the file
                     fseek($fh,$pos*4);
                     $val = unpack("f",fread($fh,4));
-                    
+
                     // add to the data array if its not a nan value
                     if (!is_nan($val[1])) {
                         $value = $val[1];
@@ -467,23 +470,18 @@ class PHPFina
                         $value = null;
                     }
                 }
-                
+
                 $split_values[] = $value;
-            
             }
-            
             if ($time>=$start && $time<$end) {
                 $data[] = array($time*1000,$split_values);
             }
-            
             if ($mode=="daily") $date->modify("+1 day");
             if ($mode=="weekly") $date->modify("+1 week");
             if ($mode=="monthly") $date->modify("+1 month");
             $n++;
         }
-        
         fclose($fh);
-        
         return $data;
     }
 


### PR DESCRIPTION
Hi, I've discovered a bug when requesting data from "get_data_DMY_time_of_day" on 30 minute split points, which causes duplicate data to be returned.   Looks like a simple Python floating point number rounding issue.

I've also increased maximum split points from 24 to 48 to allow a days worth of 30 minute data to be returned for a new energy cost comparison (time of use based) app for emoncms.