### PR TITLE
Add module.json to core modules?

### DIFF
--- a/Modules/admin/module.json
+++ b/Modules/admin/module.json
@@ -1,0 +1,4 @@
+{
+    "name"         : "Administration",
+    "version"      : ""
+}

--- a/Modules/eventp/module.json
+++ b/Modules/eventp/module.json
@@ -1,0 +1,4 @@
+{
+    "name"         : "EventProcesses",
+    "version"      : ""
+}

--- a/Modules/feed/module.json
+++ b/Modules/feed/module.json
@@ -1,0 +1,4 @@
+{
+    "name"         : "Feed",
+    "version"      : ""
+}

--- a/Modules/input/module.json
+++ b/Modules/input/module.json
@@ -1,0 +1,4 @@
+{
+    "name"         : "Input",
+    "version"      : ""
+}

--- a/Modules/process/module.json
+++ b/Modules/process/module.json
@@ -1,0 +1,4 @@
+{
+    "name"         : "CoreProcess",
+    "version"      : ""
+}

--- a/Modules/schedule/module.json
+++ b/Modules/schedule/module.json
@@ -1,4 +1,4 @@
 {
-    "name"         : "Process",
+    "name"         : "Schedule",
     "version"      : ""
 }

--- a/Modules/schedule/module.json
+++ b/Modules/schedule/module.json
@@ -1,0 +1,4 @@
+{
+    "name"         : "Process",
+    "version"      : ""
+}

--- a/Modules/time/module.json
+++ b/Modules/time/module.json
@@ -1,0 +1,4 @@
+{
+    "name"         : "Time",
+    "version"      : ""
+}

--- a/Modules/user/module.json
+++ b/Modules/user/module.json
@@ -1,0 +1,4 @@
+{
+    "name"         : "User",
+    "version"      : ""
+}

--- a/Modules/vis/module.json
+++ b/Modules/vis/module.json
@@ -1,0 +1,4 @@
+{
+    "name"         : "Visualisation",
+    "version"      : ""
+}


### PR DESCRIPTION
As a number of the modules are included in the main emoncms repo (& unlikely to be moved) it has created a mismatch of capitalized and lower-case names in the module list.
By adding a module.json file to each of the core modules too (minus the versioning), we can create capitalized 'friendly' name for all modules.
Let me know if you want me to progress this.

Example;

Before -
![event](https://user-images.githubusercontent.com/973580/28543953-79279660-70b9-11e7-93cc-8477ce1c0d9e.PNG)

After -
![event1](https://user-images.githubusercontent.com/973580/28543962-81ab17f8-70b9-11e7-86c0-43329f924732.PNG)


