### PR TITLE
Add ability to get account name from the userid

### DIFF
--- a/Modules/user/user_model.php
+++ b/Modules/user/user_model.php
@@ -440,6 +440,14 @@ class User
         return $row['username'];
     }
 
+    public function get_name($userid)
+    {
+        $userid = intval($userid);
+        $result = $this->mysqli->query("SELECT name FROM users WHERE id = '$userid';");
+        $row = $result->fetch_array();
+        return $row['name'];
+    }
+
     public function get_email($userid)
     {
         $userid = intval($userid);


### PR DESCRIPTION
This is similar to the `get_username($userid)` function except it returns the My Profile name rather than the user name.
This can be used in a bespoke Theme to add a friendly name (including spaces) to the nav bar for example.