### PR TITLE
Correction to swift_required.php path

### DIFF
--- a/Lib/email.php
+++ b/Lib/email.php
@@ -13,7 +13,7 @@ class Email {
 
         $this->message = null;
         // include SwiftMailer. path from a PEAR install,
-        $this->have_swift = @include_once ("Swift/swift_required.php");
+        $this->have_swift = @include_once ("swift_required.php");
         // path from module lib
         if (!$this->have_swift) {
            $this->have_swift = @include_once ("Lib/swiftmailer/swift_required.php");


### PR DESCRIPTION
This comes up a lot on the forum. The PEAR PECL installer installs the swift_required.php file to the same location as the Swift folder not in the Swift folder, since the PEAR PECL installer is the recommended install method this is where emoncms is most likely to find it.
(for example forum mention see https://community.openenergymonitor.org/t/emoncms-org-email-reports/4519/6?u=pb66)