### PR TITLE
Fix load_input_to_redis

### DIFF
--- a/Modules/input/input_model.php
+++ b/Modules/input/input_model.php
@@ -500,7 +500,7 @@ class Input
     {
         $result = $this->mysqli->query("SELECT id,nodeid,name,description,processList FROM input WHERE `id` = '$inputid' ORDER BY nodeid,name asc");
         if ($result->num_rows > 0) {
-            $row = $result->fetch_array();
+            $row = $result->fetch_object();
             $userid = $row->userid;
             
             $this->redis->sAdd("user:inputs:$userid", $row->id);


### PR DESCRIPTION
Well, the german word is verschlimmbessern for what happened here^^
I accidentally slipped a `fetch_array` instead of an `fetch_object` in, with #742 - breaking everything as bad as the missing userid did :)
Sorry for that.