### PR TITLE
Extended menu length to prevent confusion like …

### DIFF
--- a/Theme/basic/emon-standard.css
+++ b/Theme/basic/emon-standard.css
@@ -106,7 +106,7 @@ input[type=text][class=variable-name-edit] {
 
 .scrollable-menu {
   height: auto;
-  max-height: 250px;
+  max-height: 290px;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
As per the confusion cause here https://community.openenergymonitor.org/t/backup-option-not-available/4698
And also because the scroll bar is not appropriate for such a small menu, I've extended the menu length.

Before:
![image](https://user-images.githubusercontent.com/33792140/34796905-0c9a09da-f64f-11e7-9755-cfa3d38b191b.png)

After:
![image](https://user-images.githubusercontent.com/33792140/34797022-3b8c6256-f64f-11e7-9849-d23956b5b02b.png)
