### PR TITLE
 Change get_data_DMY() to return all requested values

### DIFF
--- a/Modules/feed/engine/PHPFina.php
+++ b/Modules/feed/engine/PHPFina.php
@@ -350,7 +350,10 @@ class PHPFina
     public function get_data_DMY($id,$start,$end,$mode,$timezone) 
     {
         if ($mode!="daily" && $mode!="weekly" && $mode!="monthly") return false;
-        
+
+        $increment="+1 day";
+        if ($mode=="weekly") $increment="+1 week";
+        if ($mode=="monthly") $increment="+1 month";
         $start = intval($start/1000);
         $end = intval($end/1000);
                
@@ -371,7 +374,7 @@ class PHPFina
         if ($mode=="monthly") $date->modify("first day of this month");
         
         $n = 0;
-        while($n<10000) // max itterations
+        while($n<10000) // max iterations
         {
             $time = $date->getTimestamp();
             if ($time>$end) break;
@@ -392,13 +395,11 @@ class PHPFina
                     $value = null;
                 }
             }
-            if ($time>=$start && $time<$end) {
+            if ($time>=$start) {
                 $data[] = array($time*1000,$value);
             }
-            
-            if ($mode=="daily") $date->modify("+1 day");
-            if ($mode=="weekly") $date->modify("+1 week");
-            if ($mode=="monthly") $date->modify("+1 month");
+
+            $date->modify($increment);
             $n++;
         }
         

--- a/Modules/feed/engine/PHPFina.php
+++ b/Modules/feed/engine/PHPFina.php
@@ -351,9 +351,6 @@ class PHPFina
     {
         if ($mode!="daily" && $mode!="weekly" && $mode!="monthly") return false;
 
-        $increment="+1 day";
-        if ($mode=="weekly") $increment="+1 week";
-        if ($mode=="monthly") $increment="+1 month";
         $start = intval($start/1000);
         $end = intval($end/1000);
                
@@ -370,8 +367,9 @@ class PHPFina
         $date->setTimezone(new DateTimeZone($timezone));
         $date->setTimestamp($start);
         $date->modify("midnight");
-        if ($mode=="weekly") $date->modify("this monday");
-        if ($mode=="monthly") $date->modify("first day of this month");
+        $increment="+1 day";
+        if ($mode=="weekly") { $date->modify("this monday"); $increment="+1 week"; }
+        if ($mode=="monthly") { $date->modify("first day of this month"); $increment="+1 month"; }
         
         $n = 0;
         while($n<10000) // max iterations

--- a/Theme/basic/emon-standard.css
+++ b/Theme/basic/emon-standard.css
@@ -106,7 +106,7 @@ input[type=text][class=variable-name-edit] {
 
 .scrollable-menu {
   height: auto;
-  max-height: 250px;
+  max-height: 290px;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
Changed the logic in PHPFina.php for get_data_DMY() to:
1. When storing the value in the array, remove the "$time<$end" as this was preventing the return of the last value and is also not required as the 'break' will prevent going past the end. This was also causing disparity with get_data() for the same date ranges
2. 'streamlined' the loop by making $increment a value which is defined once outside of the loop