### PR TITLE
Add options for changing settings file location

### DIFF
--- a/process_settings.php
+++ b/process_settings.php
@@ -14,11 +14,28 @@ defined('EMONCMS_EXEC') or die('Restricted access');
 
 require_once('Lib/enum.php');
 
-// Check if settings.php file exists
-if(file_exists(dirname(__FILE__)."/settings.php"))
+// Locate settings.php file location
+// RaspberryPi
+        if(file_exists("/home/pi/.emoncms/settings.php"))
+        {
+        $settingsPath = "/home/pi/.emoncms";
+        }
+// Emonpi
+        elseif(file_exists("/home/pi/settings.php"))
+        {
+        $settingsPath = "/home/pi";
+        }
+// Fallback & compatibility
+        elseif(file_exists(dirname(__FILE__)."/settings.php"))
+        {
+        $settingsPath = (dirname(__FILE__));
+        }
+
+// Check if the settings path exists
+if(file_exists($settingsPath))
 {
     // Load settings.php
-    require_once('settings.php');
+    require_once($settingsPath ."/settings.php");
 
     if (!isset($allow_config_env_vars)) $allow_config_env_vars = false;
     if ($allow_config_env_vars) {

--- a/process_settings.php
+++ b/process_settings.php
@@ -16,14 +16,9 @@ require_once('Lib/enum.php');
 
 // Locate settings.php file location
 // RaspberryPi
-        if(file_exists("/home/pi/.emoncms/settings.php"))
+        if(file_exists("/home/data/emondata/settings.php"))
         {
-        $settingsPath = "/home/pi/.emoncms";
-        }
-// Emonpi
-        elseif(file_exists("/home/pi/settings.php"))
-        {
-        $settingsPath = "/home/pi";
+        $settingsPath = "/home/data/emondata";
         }
 // Fallback & compatibility
         elseif(file_exists(dirname(__FILE__)."/settings.php"))


### PR DESCRIPTION
Enables the settings.php file to be moved outside of HTML route.
See [this quick video.](http://www.youtube.com/embed/ksIDDfz7igM?rel=0&autoplay=1)
This PR accomodates the following paths, but others could be very easily added for different operating systems, such as DietPi, etc;

- home/pi/.emoncms/
- home/pi/
- or compatibility fallback of emoncms installation directory

Main advantages are;
- Makes it easy to import/export as most things are in one directory
- Moves settings file out of html path
- Makes it easy to delete emoncms & reinstall afresh from git
- Backwards compatible