### PR TITLE
user registration fails if no default for 'tags' is set

### DIFF
--- a/Modules/user/user_schema.php
+++ b/Modules/user/user_schema.php
@@ -18,7 +18,7 @@ $schema['users'] = array(
     'timezone' => array('type'=>'varchar(64)', 'default'=>'UTC'),
     'language' => array('type' => 'varchar(5)', 'default'=>'en_EN'),
     'bio' => array('type' => 'text', 'default'=>''),
-    'tags' => array('type' => 'text', 'Null'=>true),
+    'tags' => array('type' => 'text', 'default'=>NULL),
     'startingpage' => array('type'=>'varchar(64)', 'default'=>'feed/list')
 );
 


### PR DESCRIPTION
If 'tags' has no default value, the sql query for user registration will
silently fail.

Also see this thread regarding this issue:
https://community.openenergymonitor.org/t/emoncms-error-creating-user/6490/19
Thanks to @belba who found the culprit of the error.