### PR TITLE
Input process list - tidy reordering arrows

### DIFF
--- a/Modules/process/Views/process_ui.js
+++ b/Modules/process/Views/process_ui.js
@@ -40,7 +40,7 @@ var processlist_ui =
         }
 
         if (i < this.contextprocesslist.length-1) {
-          out += '<a class="move-process" title="Move down" processid='+i+' moveby=1 ><i class="icon-arrow-down"></i></a>';
+          out += "<a class='move-process' title='Move down' processid="+i+" moveby=1 ><i class='icon-arrow-down'></i></a>";
         }
         out += '</td>';
 

--- a/Modules/process/Views/process_ui.js
+++ b/Modules/process/Views/process_ui.js
@@ -35,9 +35,12 @@ var processlist_ui =
         out += '<td>';
         if (i > 0) {
           out += '<a class="move-process" title="Move up" processid='+i+' moveby=-1 ><i class="icon-arrow-up"></i></a>';
+        } else {
+          out += "<span style='display: inline-block; width:14px; ' />";
         }
+
         if (i < this.contextprocesslist.length-1) {
-          out += '<a class="move-process" title="Move up" processid='+i+' moveby=1 ><i class="icon-arrow-down"></i></a>';
+          out += '<a class="move-process" title="Move down" processid='+i+' moveby=1 ><i class="icon-arrow-down"></i></a>';
         }
         out += '</td>';
 


### PR DESCRIPTION
Changed alignment of the first down arrow within the process reorder list within "emoncms/input/view" when editing the input process list so that it will align to the right hand column and thereby make it easier to follow.

Also the hover over text for the down arrow has been corrected from "up" to "down", example of both:

![image](https://user-images.githubusercontent.com/33792140/36274060-7388e42c-127e-11e8-893a-c9c0ca41174d.png)

