### PR TITLE
Update time validation for API and MQTT input

### DIFF
--- a/scripts/phpmqtt_input.php
+++ b/scripts/phpmqtt_input.php
@@ -182,7 +182,8 @@
             $jsoninput = false;
             $topic = $message->topic;
             $value = $message->payload;
-            
+            $time = time();
+
             global $mqtt_server, $user, $input, $process, $device, $log, $count;
 
             //Check and see if the input is a valid JSON and when decoded is an array. A single number is valid JSON.
@@ -194,21 +195,45 @@
                 //Create temporary array and change all keys to lower case to look for a 'time' key
                 $jsondataLC = array_change_key_case($jsondata);
 
-                #If JSON check to see if there is a time value else set to time now.
+                // If JSON, check to see if there is a time value else set to time now.
                 if (array_key_exists('time',$jsondataLC)){
-                    $time = $jsondataLC['time'];
-                    if (is_string($time)){
-                        if (($timestamp = strtotime($time)) === false) {
-                            //If time string is not valid, use system time.
-                            $time = time();
-                            $log->warn("Time string not valid ".$time);
+                    $inputtime = $jsondataLC['time'];
+
+                    // validate time
+                    if (is_numeric($inputtime)){
+                        // add zero to force a string to a number
+                        $inputtime +=0;
+                        if ($inputtime > time()){
+                            // check if time is milliseconds
+                            if ($inputtime/1000 > time()){
+                                #time is still in future
+                                $log->warn("Time not valid ".$inputtime);
+                                $time = time();
+                            } else {
+                                $log->info("Valid time in milliseconds used ".$inputtime);
+                                $time = $inputtime/1000;
+                            }
                         } else {
-                            $log->info("Valid time string used ".$time);
-                            $time = $timestamp;
+                            $log->info("Valid time in seconds used ".$inputtime);
+                            $time = $inputtime;
+                        }
+                    } elseif (is_string($inputtime)){
+                        if (($timestamp = strtotime($inputtime)) === false) {
+                            //If time string is not valid, use system time.
+                            $log->warn("Time string not valid ".$inputtime);
+                            $time = time();
+                        } else {
+                            if ($timestamp > time()){
+                                $log->warn("Time is in the future ".$inputtime);
+                                $time = time();
+                            } else {
+                                $log->info("Valid time string used ".$inputtime);
+                                $time = $timestamp;
+                            }
                         }
                     } else {
-                        $log->info("Valid time in seconds used ".$time);
-                        //Do nothings as it has been assigned to $time as a value
+                        $log->warn("Time not valid ".$inputtime);
+                        $time = time();
                     }
                 } else {
                     $log->info("No time element found in JSON - System time used");
@@ -216,7 +241,6 @@
                 }
             } else {
                 $jsoninput = false;
-                $log->info("No JSON found - System time used");
                 $time = time();
             }
 


### PR DESCRIPTION
Following on from issue #777 I have added in some validation of the time input value for both the API (less bulk input) and MQTT input.

This allows for the time be in ISO string, seconds and milliseconds.  It also checks the time is valid such that it is in the past and not future (if there is a TimeZone issue for instance).

I updated the validation I had previously done in the MQTT_input as I realised it was not robust.

Both sets of code are identical so could be included as a function somewhere (which is where my php skills end I'm afraid).