### PR TITLE
remove ntp, ufw from package list; clean up sudo-code

### DIFF
--- a/docs/LinuxInstall.md
+++ b/docs/LinuxInstall.md
@@ -10,11 +10,11 @@ You may need to start by updating the system repositories
 
 **For Ubuntu 14.04:**
 
-    sudo apt-get install apache2 mysql-server mysql-client php5 libapache2-mod-php5 php5-mysql php5-curl php-pear php5-dev php5-mcrypt php5-json git-core redis-server build-essential ufw ntp -y
+    sudo apt-get install apache2 mysql-server mysql-client php5 libapache2-mod-php5 php5-mysql php5-curl php-pear php5-dev php5-mcrypt php5-json git-core redis-server build-essential -y
 
 **For Ubuntu 16.04:**
 
-    sudo apt-get install apache2 mysql-server mysql-client php libapache2-mod-php php-mysql php-curl php-pear php-dev php-mcrypt php-json git-core redis-server build-essential ufw ntp -y
+    sudo apt-get install apache2 mysql-server mysql-client php libapache2-mod-php php-mysql php-curl php-pear php-dev php-mcrypt php-json git-core redis-server build-essential -y
 
 ### Install PHP pecl dependencies
 

--- a/docs/LinuxInstall.md
+++ b/docs/LinuxInstall.md
@@ -38,18 +38,21 @@ You may need to start by updating the system repositories
 Emoncms uses a front controller to route requests, modrewrite needs to be configured:
 
 ```
- sudo a2enmod rewrite
- sudo sh -c "echo '<Directory /var/www/html/emoncms>' >> /etc/apache2/sites-available/emoncms.conf"
- sudo sh -c "echo '  Options FollowSymLinks' >> /etc/apache2/sites-available/emoncms.conf"
- sudo sh -c "echo '  AllowOverride All' >> /etc/apache2/sites-available/emoncms.conf"
- sudo sh -c "echo '  DirectoryIndex index.php' >> /etc/apache2/sites-available/emoncms.conf"
- sudo sh -c "echo '  Order allow,deny' >> /etc/apache2/sites-available/emoncms.conf"
- sudo sh -c "echo '  Allow from all' >> /etc/apache2/sites-available/emoncms.conf"
- sudo sh -c "echo '</Directory>' >> /etc/apache2/sites-available/emoncms.conf"
- sudo sh -c "echo 'ServerName localhost' >> /etc/apache2/apache2.conf"
- sudo ln -s /etc/apache2/sites-available/emoncms.conf /etc/apache2/sites-enabled/
- sudo a2ensite emoncms
- sudo service apache2 reload
+ sudo su
+ a2enmod rewrite
+ cat <<EOF >> /etc/apache2/sites-available/emoncms.conf
+ <Directory /var/www/html/emoncms>
+	Options FollowSymLinks
+	AllowOverride All
+	DirectoryIndex index.php
+	Order allow,deny
+	Allow from all
+ </Directory>
+ EOF
+ echo 'ServerName localhost' >> /etc/apache2/apache2.conf
+ a2ensite emoncms
+ service apache2 reload
+ exit
 ```
 
 ## Install Emoncms
@@ -100,13 +103,15 @@ Exit mysql by:
     
 ### Create data repositories for emoncms feed engines
 
-    sudo mkdir /var/lib/phpfiwa
-    sudo mkdir /var/lib/phpfina
-    sudo mkdir /var/lib/phptimeseries
+    sudo su
+    mkdir /var/lib/phpfiwa
+    mkdir /var/lib/phpfina
+    mkdir /var/lib/phptimeseries
 
-    sudo chown www-data:root /var/lib/phpfiwa
-    sudo chown www-data:root /var/lib/phpfina
-    sudo chown www-data:root /var/lib/phptimeseries
+    chown www-data:root /var/lib/phpfiwa
+    chown www-data:root /var/lib/phpfina
+    chown www-data:root /var/lib/phptimeseries
+    exit
 
 ## Setup Emoncms settings
 

--- a/docs/LinuxInstall.md
+++ b/docs/LinuxInstall.md
@@ -38,19 +38,19 @@ You may need to start by updating the system repositories
 Emoncms uses a front controller to route requests, modrewrite needs to be configured:
 
 ```
- sudo a2enmod rewrite
- sudo cat <<EOF >> /etc/apache2/sites-available/emoncms.conf
- <Directory /var/www/html/emoncms>
-	Options FollowSymLinks
-	AllowOverride All
-	DirectoryIndex index.php
-	Order allow,deny
-	Allow from all
- </Directory>
- EOF
- sudo echo 'ServerName localhost' >> /etc/apache2/apache2.conf
- sudo a2ensite emoncms
- sudo service apache2 reload
+sudo a2enmod rewrite
+sudo cat <<EOF >> /etc/apache2/sites-available/emoncms.conf
+<Directory /var/www/html/emoncms>
+    Options FollowSymLinks
+    AllowOverride All
+    DirectoryIndex index.php
+    Order allow,deny
+    Allow from all
+</Directory>
+EOF
+sudo echo 'ServerName localhost' >> /etc/apache2/apache2.conf
+sudo a2ensite emoncms
+sudo service apache2 reload
 ```
 
 ## Install Emoncms

--- a/docs/LinuxInstall.md
+++ b/docs/LinuxInstall.md
@@ -38,9 +38,8 @@ You may need to start by updating the system repositories
 Emoncms uses a front controller to route requests, modrewrite needs to be configured:
 
 ```
- sudo su
- a2enmod rewrite
- cat <<EOF >> /etc/apache2/sites-available/emoncms.conf
+ sudo a2enmod rewrite
+ sudo cat <<EOF >> /etc/apache2/sites-available/emoncms.conf
  <Directory /var/www/html/emoncms>
 	Options FollowSymLinks
 	AllowOverride All
@@ -49,10 +48,9 @@ Emoncms uses a front controller to route requests, modrewrite needs to be config
 	Allow from all
  </Directory>
  EOF
- echo 'ServerName localhost' >> /etc/apache2/apache2.conf
- a2ensite emoncms
- service apache2 reload
- exit
+ sudo echo 'ServerName localhost' >> /etc/apache2/apache2.conf
+ sudo a2ensite emoncms
+ sudo service apache2 reload
 ```
 
 ## Install Emoncms
@@ -103,15 +101,13 @@ Exit mysql by:
     
 ### Create data repositories for emoncms feed engines
 
-    sudo su
-    mkdir /var/lib/phpfiwa
-    mkdir /var/lib/phpfina
-    mkdir /var/lib/phptimeseries
+    sudo mkdir /var/lib/phpfiwa
+    sudo mkdir /var/lib/phpfina
+    sudo mkdir /var/lib/phptimeseries
 
-    chown www-data:root /var/lib/phpfiwa
-    chown www-data:root /var/lib/phpfina
-    chown www-data:root /var/lib/phptimeseries
-    exit
+    sudo chown www-data:root /var/lib/phpfiwa
+    sudo chown www-data:root /var/lib/phpfina
+    sudo chown www-data:root /var/lib/phptimeseries
 
 ## Setup Emoncms settings
 


### PR DESCRIPTION
ntp and ufw aren't related to the functionality of emoncms; i.e. they are not dependencies. NTP already was removed from the Raspberry Pi installation instructions with 6eddfdd1ee6111607a5bbb4d14502dc8c8951381

General cleanup of sudo-code blocks to make them more readable. Removed unnecessary linking of the site configuration as this is handled by `a2enmod`