### PR TITLE
Prevent MQTT Client exception

### DIFF
--- a/scripts/phpmqtt_input.php
+++ b/scripts/phpmqtt_input.php
@@ -123,15 +123,17 @@
             try {
                 $mqtt_client->setCredentials($mqtt_server['user'],$mqtt_server['password']);
                 $mqtt_client->connect($mqtt_server['host'], $mqtt_server['port'], 5);
-                $topic = $mqtt_server['basetopic']."/#";
-                //echo "Subscribing to: ".$topic."\n";
-                $log->info("Subscribing to: ".$topic);
-                $mqtt_client->subscribe($topic,2);
+                // check and see if the onConnect callback was successful.
+                if ($connected) {
+                    $topic = $mqtt_server['basetopic']."/#";
+                    $log->info("Subscribing to: ".$topic);
+                    $mqtt_client->subscribe($topic,2);
+                } else {
+                    $log->warn("Not connected, retrying connection");
+                }
             } catch (Exception $e) {
                 $log->error($e);
             }
-            //echo "Not connected, retrying connection\n";
-            $log->warn("Not connected, retrying connection");
         }
         
         if ((time()-$last_heartbeat)>300) {
@@ -145,15 +147,13 @@
                 die;
             }
         }
-        
         usleep(1000);
     }
     
-
     function connect($r, $message) {
         global $log, $connected;
-        $connected = true;
-        //echo "Connected to MQTT server with code {$r} and message {$message}\n";
+        // set connected flag if CONNACK is 0 (success)
+        $connected = ($r == 0);
         $log->warn("Connecting to MQTT server: {$message}: code: {$r}");
     }
 

--- a/scripts/phpmqtt_input.php
+++ b/scripts/phpmqtt_input.php
@@ -167,18 +167,18 @@
     function subscribe() {
         global $log, $topic;
         //echo "Subscribed to topic: ".$topic."\n";
-//        $log->info("Subscribed to topic: ".$topic);
+        $log->info("Callback subscribed to topic: ".$topic);
     }
 
     function unsubscribe() {
-        global $log, $topic;
+        global $log, $topic, $subscribed;
         //echo "Unsubscribed from topic:".$topic."\n";
         $subscribed = 0;
         $log->error("Unsubscribed from topic: ".$topic);
     }
 
     function disconnect() {
-        global $connected, $log;
+        global $connected, $log, $subscribed;
         $subscribed = 0;
         $connected = false;
         //echo "Disconnected cleanly\n";

--- a/scripts/phpmqtt_input.php
+++ b/scripts/phpmqtt_input.php
@@ -98,9 +98,10 @@
         $device = new Device($mysqli,$redis);
     }
     
-    $mqtt_client = new Mosquitto\Client();
-    
+    $mqtt_client = new Mosquitto\Client($id=$user->get_apikey_write($mqttsettings['userid'],$cleanSession=false));
+
     $connected = false;
+    $subscribed = 0;
     $last_retry = 0;
     $last_heartbeat = time();
     $count = 0;
@@ -119,23 +120,29 @@
         }
         
         if (!$connected && (time()-$last_retry)>5.0) {
+            $subscribed = 0;
             $last_retry = time();
             try {
+                $log->warn("Not connected, retrying connection");
                 $mqtt_client->setCredentials($mqtt_server['user'],$mqtt_server['password']);
                 $mqtt_client->connect($mqtt_server['host'], $mqtt_server['port'], 5);
-                // check and see if the onConnect callback was successful.
-                if ($connected) {
-                    $topic = $mqtt_server['basetopic']."/#";
-                    $log->info("Subscribing to: ".$topic);
-                    $mqtt_client->subscribe($topic,2);
-                } else {
-                    $log->warn("Not connected, retrying connection");
-                }
             } catch (Exception $e) {
                 $log->error($e);
             }
         }
-        
+
+        if ($connected && ($subscribed == 0)) {
+            try {
+                $topic = $mqtt_server['basetopic']."/#";
+                $log->info("Subscribing to: ".$topic);
+                $subscribed = $mqtt_client->subscribe($topic,2);
+                $log->info("Subscribed to: ".$topic." ID - ".$subscribed);
+            } catch (Exception $e) {
+                $log->error($e);
+                $subscribed = 0;
+            }
+        }
+
         if ((time()-$last_heartbeat)>300) {
             $last_heartbeat = time();
             $log->info("$count Messages processed in last 5 minutes");
@@ -160,17 +167,19 @@
     function subscribe() {
         global $log, $topic;
         //echo "Subscribed to topic: ".$topic."\n";
-        $log->info("Subscribed to topic: ".$topic);
+//        $log->info("Subscribed to topic: ".$topic);
     }
 
     function unsubscribe() {
         global $log, $topic;
         //echo "Unsubscribed from topic:".$topic."\n";
+        $subscribed = 0;
         $log->error("Unsubscribed from topic: ".$topic);
     }
 
     function disconnect() {
         global $connected, $log;
+        $subscribed = 0;
         $connected = false;
         //echo "Disconnected cleanly\n";
         $log->info("Disconnected cleanly");


### PR DESCRIPTION
Issue - subscribing to a topic when the MQTT client was not connected caused an exception; not fatal but not nice.  This has been noticed on a number of topics recently on the Forum.

[Documentation](http://mosquitto-php.readthedocs.io/en/latest/client.html)

The onConnect callback is only called if there is a CONNACK from the MQTT server.

The onConnect callback assumed than any call to it meant a successful connection.  This is not correct, only a response of '0' means success, so $connected now set as such.

The reconnect try, did not check the connected flag before attempting to subscribe to the topic.  By doing so the exception can be avoided.