### PR TITLE
Use a persistent MQTT connection

### DIFF
--- a/scripts/phpmqtt_input.php
+++ b/scripts/phpmqtt_input.php
@@ -98,7 +98,8 @@
         $device = new Device($mysqli,$redis);
     }
     
-    $mqtt_client = new Mosquitto\Client();
+    // Currently uses the "userid 1" write apikey key as a client id for a "persistent" MQTT connection.
+    $mqtt_client = new Mosquitto\Client($id=$user->get_apikey_write($mqttsettings['userid'],$cleanSession=false));
     
     $connected = false;
     $last_retry = 0;


### PR DESCRIPTION
See the ["A question over whether emonCMS is compatible with MQTT "](https://community.openenergymonitor.org/t/a-question-over-whether-emoncms-is-compatible-with-mqtt/7180?u=pb66) OEM forum post.
Construct MQTT client to use a "persistent session" rather than a "clean session"

PLEASE DO NOT MERGE WITHOUT TESTING FIRST.