### PR TITLE
Added user id to logged error messages

### DIFF
--- a/Modules/input/input_controller.php
+++ b/Modules/input/input_controller.php
@@ -54,7 +54,7 @@ function input_controller()
         } else {
             $result = '{"success": false, "message": "'.str_replace("\"","'",$result).'"}';
             $log = new EmonLogger(__FILE__);
-            $log->error($result);
+            $log->error($result." for User: ".$session['userid']);
         }
     }
     
@@ -68,7 +68,7 @@ function input_controller()
         } else {
             $result = '{"success": false, "message": "'.str_replace("\"","'",$result).'"}';
             $log = new EmonLogger(__FILE__);
-            $log->error($result);
+            $log->error($result." for User: ".$session['userid']);
         }
     }
     


### PR DESCRIPTION
I started getting some error messages in the logs, like below
```
2018-04-23 23:07:51.950|ERROR|input_controller.php|{"success": false, "message": "Format error, json string supplied is not valid"}
2018-04-24 09:07:56.114|ERROR|input_controller.php|{"success": false, "message": "Format error, json string supplied is not valid"}
```
But had no idea which of the many accounts I have logging data to this server the messages belonged to so I added a "userid" to the log message so that the log messages now read like so
```
2018-04-24 13:56:08.751|ERROR|input_controller.php|{"success": false, "message": "Format error, json string supplied is not valid"} for User: 12
```