### PR TITLE
Re-implement fix for input page not loading

### DIFF
--- a/Modules/input/input_model.php
+++ b/Modules/input/input_model.php
@@ -329,6 +329,7 @@ class Input
         for ($i=0; $i<count($result); $i+=2) {
             $row = $result[$i];
             $lastvalue = $result[$i+1];
+            $row["description"] = utf8_encode($row["description"]);
             if (!isset($lastvalue['time']) || !is_numeric($lastvalue['time']) || is_nan($lastvalue['time'])) {
                 $row['time'] = null;
             } else {


### PR DESCRIPTION
See https://github.com/emoncms/emoncms/commit/5ca10931f577dad65beb188c2a5f9f2bb4c74ce8 and OEM forum thread https://community.openenergymonitor.org/t/input-list-doesnt-load/3797/65?u=pb66.
It seems the fix has inadvertently been removed with this commit https://github.com/emoncms/emoncms/commit/a425e250f408c53c1cc1c6b0fbe690f6bd6091f8