### PR TITLE
fixed get_name() in user model

### DIFF
--- a/Modules/user/user_model.php
+++ b/Modules/user/user_model.php
@@ -474,9 +474,9 @@ class User
     public function get_name($userid)
     {
         $userid = (int) $userid;
-        $result = $this->mysqli->query("SELECT name FROM users WHERE id = '$userid';");
+        $result = $this->mysqli->query("SELECT username FROM users WHERE id = '$userid';");
         $row = $result->fetch_array();
-        return $row['name'];
+        return $row['username'];
     }
 
     public function get_email($userid)


### PR DESCRIPTION
The get_name () method was trying to fetch the wrong column from the table. EMonCMS doesn't use this method anywhere but we use it in MyHomeEnergyPlanner, that's why I spotted it