### PR TITLE
decrease keepalive sensitivity to reduce disconnections

### DIFF
--- a/scripts/phpmqtt_input.php
+++ b/scripts/phpmqtt_input.php
@@ -122,7 +122,7 @@
             $last_retry = time();
             try {
                 $mqtt_client->setCredentials($mqtt_server['user'],$mqtt_server['password']);
-                $mqtt_client->connect($mqtt_server['host'], $mqtt_server['port'], 5);
+                $mqtt_client->connect($mqtt_server['host'], $mqtt_server['port'], 60);
                 $topic = $mqtt_server['basetopic']."/#";
                 //echo "Subscribing to: ".$topic."\n";
                 $log->info("Subscribing to: ".$topic);


### PR DESCRIPTION
See https://community.openenergymonitor.org/t/a-question-over-whether-emoncms-is-compatible-with-mqtt/7180/12?u=pb66

I suspect setting a keepalive of "5" is actually resulting in MORE disconnections than a more relaxed setting of "60". But it may be better to go for "180" or more to accomadate setups with just a couple of emonTH's.

**PLEASE DON'T MERGE WITHOUT DISCUSSION AND CONSIDERATION OF THE CLIENT ID PR TOO!**
