### PR TITLE
Add Eclipse PDT files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .project
+.buildpath
+.settings*
 debian/emoncms*
 settings.php
 old.settings.php

--- a/Modules/schedule/schedule_menu.php
+++ b/Modules/schedule/schedule_menu.php
@@ -4,4 +4,4 @@
     bindtextdomain($domain, "Modules/schedule/locale");
     bind_textdomain_codeset($domain, 'UTF-8');
 
-    $menu_dropdown[] = array('name'=> dgettext($domain4, "Schedule"),'icon'=>'icon-time', 'path'=>"schedule/view" , 'session'=>"write", 'order' => 1);
+    $menu_dropdown[] = array('name'=> dgettext($domain4, "Schedule"),'icon'=>'icon-time', 'path'=>"schedule/view" , 'session'=>"write", 'order' => 10);


### PR DESCRIPTION
Hi guys,

with me using eclipse PDT to look into emoncms for years now and having these changes locally, I finally thought to maybe just start a PR about this.
Maybe these small changes to the gitignore do not clutter up too much? 😄 would be strongly apreciated

Further, I took the audacity to increased the schedule menu order from 1 to 10, reflecting the corresponding input order and allowing other modules to be placed at top.