### PR TITLE
Hooking system

### DIFF
--- a/Modules/user/deleteuser.php
+++ b/Modules/user/deleteuser.php
@@ -46,7 +46,7 @@ function delete_user($userid,$mode) {
             if ($mode=="permanentdelete") $redis->del("writeapikey:$apikey");
         }
         
-        $tables = array("app_config","autoconfig","dashboard","emailreport","graph","multigraph","myip","node","statico","rememberme","group_users","assessment","assessment_access","organisation_membership","mhep_library_access");
+        $tables = array("app_config","autoconfig","dashboard","emailreport","graph","multigraph","myip","node","statico","rememberme");
         foreach ($tables as $tablename) {
             $result .= delete_entry_in_table($tablename,$userid,$mode);
         }

--- a/Modules/user/deleteuser.php
+++ b/Modules/user/deleteuser.php
@@ -35,13 +35,13 @@ function delete_user($userid,$mode) {
         }
         
         $apikey = $user_row->apikey_read;
-        if ($redis->exists("readapikey:$apikey")) {
+        if ($redis!= false && $redis->exists("readapikey:$apikey")) {
             $result .= "- readapikey from redis\n";
             if ($mode=="permanentdelete") $redis->del("readapikey:$apikey");
         }
         
         $apikey = $user_row->apikey_write;
-        if ($redis->exists("writeapikey:$apikey")) {
+        if ($redis!= false && $redis->exists("writeapikey:$apikey")) {
             $result .= "- writeapikey from redis\n";
             if ($mode=="permanentdelete") $redis->del("writeapikey:$apikey");
         }

--- a/Modules/user/user_controller.php
+++ b/Modules/user/user_controller.php
@@ -95,6 +95,7 @@ function user_controller()
                         if ($hash == $row->password || $session['admin']==1) {
                             $result = "PERMANENT DELETE:\n";
                             $result .= delete_user($userid,"permanentdelete");
+                            $result .= call_hook('on_delete_user',['userid'=>$userid,'mode'=>'permanentdelete']);
                             
                             $user->logout();
                         } else {
@@ -106,6 +107,7 @@ function user_controller()
                 } else {
                     $result = "DRY RUN:\n";
                     $result .= delete_user($userid,"dryrun");
+                    $result .= call_hook('on_delete_user',['userid'=>$userid,'mode'=>'dryrun']);
                 }
             } else {
                 $result = "missing mode field";

--- a/core.php
+++ b/core.php
@@ -157,3 +157,20 @@ function emoncms_error($message) {
     return array("success"=>false, "message"=>$message);
 }
 
+function call_hook($function_name, $args){
+    $dir = scandir("Modules");
+    for ($i=2; $i<count($dir); $i++)
+    {
+        if (filetype("Modules/".$dir[$i])=='dir' || filetype("Modules/".$dir[$i])=='link')
+        {
+            if (is_file("Modules/".$dir[$i]."/".$dir[$i]."_hooks.php"))
+            {
+                require "Modules/".$dir[$i]."/".$dir[$i]."_hooks.php";
+                if (function_exists($dir[$i].'_'.$function_name)==true){
+                    $hook = $dir[$i].'_'.$function_name;
+                    return $hook($args);
+                }
+            }   
+        }
+    }
+}


### PR DESCRIPTION
In [this forum post](https://community.openenergymonitor.org/t/emoncms-org-terms-of-use-and-privacy-policy/7437/2?u=cagabi) it came up the need of a way to tell not core modules to delete user's data when the user deletes his/her account. 

The original implementation of "delete user" looks for the userid in handcoded tables but that will not work for other modules not included so far. In my case I need to implement this functionality for the task module. So the solution is a hooking system (this pull request :). An implementation of a hook can be found in [the group module](https://github.com/emoncms/group/blob/master/group_hooks.php#L20)
