### PR TITLE
try to fix mqtt issue with concurrent connections

### DIFF
--- a/scripts/phpmqtt_input.php
+++ b/scripts/phpmqtt_input.php
@@ -129,23 +129,23 @@
                 $log->info("Subscribing to: ".$topic);
                 $mqtt_client->subscribe($topic,2);
 
-                // PUBLISH
-                // loop through all queued items in redis
-                $queue_topic = 'mqtt-pub-queue';
-                for ($i=0; $i<$redis->llen($queue_topic); $i++) {
-                    if ($data = filter_var_array(json_decode($redis->lpop($queue_topic), true))) {
-                        // publish values to 
-                        $mqtt_client->publish($data['topic'], $data['value']);
-                    }
-                }
-
             } catch (Exception $e) {
                 $log->error($e);
             }
             //echo "Not connected, retrying connection\n";
             $log->warn("Not connected, retrying connection");
         }
-        
+
+        // PUBLISH
+        // loop through all queued items in redis
+        $queue_topic = 'mqtt-pub-queue';
+        for ($i=0; $i<$redis->llen($queue_topic); $i++) {
+            if ($data = filter_var_array(json_decode($redis->lpop($queue_topic), true))) {
+                // publish values to 
+                $mqtt_client->publish($data['topic'], $data['value']);
+            }
+        }
+
         if ((time()-$last_heartbeat)>300) {
             $last_heartbeat = time();
             $log->info("$count Messages processed in last 5 minutes");


### PR DESCRIPTION
## !!need to test my changes on a rpi to see performance issues!!

- removed mqtt->loopForever()
- moved mqtt->disconnect() out of the mqtt->onConnect() callback
- new Mosquitto\Client() now randomises the clientID and cleans out connections

not 100% sure these changes will fix the issue? not totally sure what the issue is.. **can't re-create it** !?

1. https://community.openenergymonitor.org/t/mqtt-log-entries/7784
1. https://community.openenergymonitor.org/t/mqtt-too-much-subscriptions-to-local-broker/2202
1. https://community.openenergymonitor.org/t/strange-emoncms-mqtt-publish-phenomena-not-solved-but-the-reasons-understood-see-https-community-openenergymonitor-org-t-mqtt-log-entries-7784/7793
1. https://community.openenergymonitor.org/t/another-emonpi-stopped-logging-thread/7267/21?u=borpin

could be..
- mqtt publish clientid conflict on multiple requests ?
- php not holding the connection open long enough ?
- mosquito closing the connection too early ?
- mqtt broker concurrent connection issue ?

I averaged 30ms delay, on my laptop, between php publishing to the mqtt broker and the script completing  (for each 50 iterations) - so I set the php script to hold for 2000ms to ensure all done for slower devices...

## THIS APPROACH WILL MAKE THE INPUT PROCESS MUCH SLOWER!
the fixed delay will keep a connection open for 2s (10x200ms), however using the loopForever() with the disconnect()  function disconnects once the publish is done. (1.2s for 50 publishes)

**The test I ran as a GIST** https://gist.github.com/emrysr/d7342a262efdaf2ba61ffd1208fc0d28
clone it with:
`git clone https://gist.github.com/d7342a262efdaf2ba61ffd1208fc0d28.git`

> *just the example from [mosquitto's website](http://mosquitto-php.readthedocs.io/en/latest/overview.html#general-operation) (using loopForever()) to run **50** times (total **1.1s** on my laptop) - and some comments*