### PR TITLE
Fix cookie path restriction when running on domain root

### DIFF
--- a/Modules/user/user_model.php
+++ b/Modules/user/user_model.php
@@ -146,7 +146,10 @@ class User
         //name of cookie 
         session_name('EMONCMS_SESSID'); 
         //get subdir installation 
-        $cookie_params['path'] = dirname($_SERVER['SCRIPT_NAME'])."/"; 
+        $cookie_params['path'] = dirname($_SERVER['SCRIPT_NAME']);
+        // Add a slash if the last character isn't already a slash
+        if (substr($cookie_params['path'], -1) !== '/')
+            $cookie_params['path'] .= '/';
         //not pass cookie to javascript 
         $cookie_params['httponly'] = 1; 
         


### PR DESCRIPTION
#918 introduced a fix for cookies so that if emoncms is running at e.g. domain.net/emoncms, then cookies it saves would be restricted to that path and below.  However it also broke logins if Emon is running not in a subdirectory because it set a restriction to the path `//` rather than `/`.  This pull request fixes that behaviour.