### PR TITLE
Feature/issue 917 device module release

### DIFF
--- a/Modules/user/user_controller.php
+++ b/Modules/user/user_controller.php
@@ -113,6 +113,24 @@ function user_controller()
                 $result = "missing mode field";
             }
         }
+        // set user peferences for beta opt ins
+        if ($route->action == 'beta' && $session['read']) {
+            switch($route->method) {
+                case 'POST':
+                    if(!empty(post('optIn'))){
+                        $optIns = post('optIn');
+                        $result = $user->setBetaOptIn($optIns);
+                    } else {
+                        $result = array('success'=>false,'message'=>'Invalid parameters');
+                    }
+                    break;
+                case 'DELETE':
+                    $result = $user->removeBetaOptIn();
+                    break;
+                default:
+                    $result = $user->getBetaOptIn();
+            }
+        }
     }
 
     return array('content'=>$result);

--- a/index.php
+++ b/index.php
@@ -121,6 +121,9 @@
     } else {
         $session = $user->emon_session_start();
     }
+
+    $optIns = json_encode($user->getBetaOptIn()['optin'],true);
+    if (!empty($optIns['deviceModule']) && $optIns['deviceModule'] == true) $ui_version_2 = true;
     
     // 4) Language
     if (!isset($session['lang'])) $session['lang']='';

--- a/route.php
+++ b/route.php
@@ -124,8 +124,12 @@ class Route
         if (count($args) > 3) {
             $this->subaction2 = $args[3];
         }
-        
-        if (in_array($requestMethod, array('POST', 'DELETE', 'PUT'))) {
+        // allow for method to be added as post variable
+        if(post('_method')=='DELETE') {
+            $this->method = 'DELETE';
+        } elseif(post('_method')=='PUT') {
+            $this->method = 'PUT';
+        } elseif(in_array($requestMethod, array('POST', 'DELETE', 'PUT'))) {
             $this->method = $requestMethod;
         }
     }


### PR DESCRIPTION
Created ui for user to save opt in preferences for beta features. Checks for `$_COOKIE["EMONCMS_BETA_OPTIN"] `which is stored as JSON `{"deviceModule":"true"}`

`$user->setBetaOptIn()` sets a cookie with a expiry 2 years into the future.

Sets the `$ui_version_2` in **index.php** to `true` if the cookie value is "true" to allow the user to toggle on/off the new features. Defaults to false / Off

The JSON object key is created by getting the value of the ` "data-prop"` attribute of any element within the form that has the class "`controls`" in [user/profile/profile.php](https://github.com/emoncms/emoncms/compare/device-support...emrysr:feature/issue-917-device-module-release?expand=1#diff-cd18b294e9e3cb5763244200e1e46ad9R125)

`<div class="controls" data-prop="deviceModule">`

The **reset** button makes the cookie expire and looses all the saved settings (currently only one)

This includes loading indicators and error messages (translatable in the php) - adding possible other beta features opt ins will be easy using this ui. 

![image](https://user-images.githubusercontent.com/1466013/43146206-aa6fb9f0-8f58-11e8-853b-9344d2b781ef.png)
