### PR TITLE
auto fill feed unit created by process

### DIFF
--- a/Modules/feed/feed.js
+++ b/Modules/feed/feed.js
@@ -3,9 +3,17 @@ var feed = {
 
   apikey: "",
   
-  'create':function(tag, name, datatype, engine, options){
+  'create':function(tag, name, datatype, engine, options, process){
     var result = {};
-    $.ajax({ url: path+"feed/create.json", data: "tag="+tag+"&name="+name+"&datatype="+datatype+"&engine="+engine+"&options="+JSON.stringify(options), dataType: 'json', async: false, success: function(data){result = data;} });
+    var data = {
+      tag: tag,
+      name: name,
+      datatype: datatype,
+      engine: engine,
+      options: JSON.stringify(options),
+      process: process || ''
+    }
+    $.ajax({ url: path+"feed/create.json", data: data, dataType: 'json', async: false, success: function(data){result = data;} });
     return result;
   },
   

--- a/Modules/feed/feed.js
+++ b/Modules/feed/feed.js
@@ -3,7 +3,7 @@ var feed = {
 
   apikey: "",
   
-  'create':function(tag, name, datatype, engine, options, process){
+  'create':function(tag, name, datatype, engine, options, unit){
     var result = {};
     var data = {
       tag: tag,
@@ -11,7 +11,7 @@ var feed = {
       datatype: datatype,
       engine: engine,
       options: JSON.stringify(options),
-      process: process || ''
+      unit: unit || ''
     }
     $.ajax({ url: path+"feed/create.json", data: data, dataType: 'json', async: false, success: function(data){result = data;} });
     return result;

--- a/Modules/feed/feed_controller.php
+++ b/Modules/feed/feed_controller.php
@@ -52,7 +52,7 @@ function feed_controller()
             $route->format = "text";
             $result = $feed->get_id($session['userid'],get("name"));
         } elseif ($route->action == "create" && $session['write']) {
-            $result = $feed->create($session['userid'],get('tag'),get('name'),get('datatype'),get('engine'),json_decode(get('options')));
+            $result = $feed->create($session['userid'],get('tag'),get('name'),get('datatype'),get('engine'),json_decode(get('options')),get('process'));
         } elseif ($route->action == "updatesize" && $session['write']) {
             $result = $feed->update_user_feeds_size($session['userid']);
         } elseif ($route->action == "buffersize" && $session['write']) {

--- a/Modules/feed/feed_controller.php
+++ b/Modules/feed/feed_controller.php
@@ -52,7 +52,7 @@ function feed_controller()
             $route->format = "text";
             $result = $feed->get_id($session['userid'],get("name"));
         } elseif ($route->action == "create" && $session['write']) {
-            $result = $feed->create($session['userid'],get('tag'),get('name'),get('datatype'),get('engine'),json_decode(get('options')),get('process'));
+            $result = $feed->create($session['userid'],get('tag'),get('name'),get('datatype'),get('engine'),json_decode(get('options')),get('unit'));
         } elseif ($route->action == "updatesize" && $session['write']) {
             $result = $feed->update_user_feeds_size($session['userid']);
         } elseif ($route->action == "buffersize" && $session['write']) {

--- a/Modules/feed/feed_model.php
+++ b/Modules/feed/feed_model.php
@@ -97,7 +97,7 @@ class Feed
     Configurations operations
     create, delete, exist, update_user_feeds_size, get_buffer_size, get_meta
     */
-    public function create($userid,$tag,$name,$datatype,$engine,$options_in,$process=null)
+    public function create($userid,$tag,$name,$datatype,$engine,$options_in,$unit='')
     {
         $userid = (int) $userid;
         if (preg_replace('/[^\p{N}\p{L}_\s-:]/u','',$name)!=$name) return array('success'=>false, 'message'=>'invalid characters in feed name');
@@ -105,35 +105,7 @@ class Feed
         $datatype = (int) $datatype;
         $engine = (int) $engine;
         $public = false;
-        $units = array(
-            'log_to_feed'=>'',//Log to feed 
-            'power_to_kwh'=>'kWh',//Power to kWh
-            'power_to_kwhd'=>'kWh',//Power to kWh/d
-            'whinc_to_kwhd'=>'Wh',//Wh increments to kWh/d
-            'kwh_to_kwhd_old'=>'',//kWh to kWh/d (OLD)
-            'update_feed_data'=>'',//Upsert feed at day
-            'ratechange'=>'',//Rate of change
-            'histogram'=>'',//Histogram
-            'average'=>'',//Daily Average
-            'heat_flux'=>'',//Heat flux
-            'power_acc_to_kwhd'=>'',//Power gained to kWh/d
-            'pulse_diff'=>'',//Total pulse count to pulse increment
-            'kwh_to_kwhd'=>'',//kWh to kWh/d
-            'min_value'=>'',//Min daily value
-            'sub_feed'=>'',// - feed
-            'multiply_by_feed'=>'',// * feed
-            'divide_by_feed'=>'',// / feed
-            'wh_accumulator'=>'Wh',//Wh Accumulator
-            'source_feed_data_time'=>'',//Source Feed
-            //'get_feed_data_day'=>'',//Source Daily (TBD)
-            'add_source_feed'=>'',// + source feed
-            'sub_source_feed'=>'',// - source feed
-            'multiply_by_source_feed'=>'',// * source feed
-            'divide_by_source_feed'=>'',// / source feed
-            'reciprocal_by_source_feed'=>'',//1/ source feed
-        );
-        $unit = !empty($units[$process]) ? $units[$process] : '';
-
+    
         if (!ENGINE::is_valid($engine)) {
             $this->log->error("Engine id '".$engine."' is not supported.");
             return array('success'=>false, 'message'=>"ABORTED: Engine id $engine is not supported.");

--- a/Modules/process/Views/process_ui.js
+++ b/Modules/process/Views/process_ui.js
@@ -336,7 +336,35 @@ var processlist_ui =
               return false;
             }
 
-            var result = feed.create(feedtag,feedname,datatype,engine,options,process[2]);
+            units = {
+              'log_to_feed':'',//Log to feed 
+              'power_to_kwh':'kWh',//Power to kWh
+              'power_to_kwhd':'kWh',//Power to kWh/d
+              'whinc_to_kwhd':'Wh',//Wh increments to kWh/d
+              'kwh_to_kwhd_old':'',//kWh to kWh/d (OLD)
+              'update_feed_data':'',//Upsert feed at day
+              'ratechange':'',//Rate of change
+              'histogram':'',//Histogram
+              'average':'',//Daily Average
+              'heat_flux':'',//Heat flux
+              'power_acc_to_kwhd':'',//Power gained to kWh/d
+              'pulse_diff':'',//Total pulse count to pulse increment
+              'kwh_to_kwhd':'',//kWh to kWh/d
+              'min_value':'',//Min daily value
+              'sub_feed':'',// - feed
+              'multiply_by_feed':'',// * feed
+              'divide_by_feed':'',// / feed
+              'wh_accumulator':'Wh',//Wh Accumulator
+              'source_feed_data_time':'',//Source Feed
+              //'get_feed_data_day':'',//Source Daily (TBD)
+              'add_source_feed':'',// + source feed
+              'sub_source_feed':'',// - source feed
+              'multiply_by_source_feed':'',// * source feed
+              'divide_by_source_feed':'',// / source feed
+              'reciprocal_by_source_feed':''//1/ source feed
+            };
+            unit = units[process[2]] || ''
+            var result = feed.create(feedtag,feedname,datatype,engine,options,unit);
             feedid = result.feedid;
 
             if (!result.success || feedid<1) {

--- a/Modules/process/Views/process_ui.js
+++ b/Modules/process/Views/process_ui.js
@@ -336,7 +336,7 @@ var processlist_ui =
               return false;
             }
 
-            var result = feed.create(feedtag,feedname,datatype,engine,options);
+            var result = feed.create(feedtag,feedname,datatype,engine,options,process[2]);
             feedid = result.feedid;
 
             if (!result.success || feedid<1) {


### PR DESCRIPTION
feed created from input process now passes process name. 
process name is used to autofill the feed's unit column
fixes issue #916 

@TrystanLea - can you take a look at the **$units** array in **feed_controller.php** and let me know if there should be any changes to which unit you think should be shown for each process
```

        $units = array(
            'log_to_feed'=>'',//Log to feed 
            'power_to_kwh'=>'kWh',//Power to kWh
            'power_to_kwhd'=>'kWh',//Power to kWh/d
            'whinc_to_kwhd'=>'Wh',//Wh increments to kWh/d
            'kwh_to_kwhd_old'=>'',//kWh to kWh/d (OLD)
            'update_feed_data'=>'',//Upsert feed at day
            'ratechange'=>'',//Rate of change
            'histogram'=>'',//Histogram
            'average'=>'',//Daily Average
            'heat_flux'=>'',//Heat flux
            'power_acc_to_kwhd'=>'',//Power gained to kWh/d
            'pulse_diff'=>'',//Total pulse count to pulse increment
            'kwh_to_kwhd'=>'',//kWh to kWh/d
            'min_value'=>'',//Min daily value
            'sub_feed'=>'',// - feed
            'multiply_by_feed'=>'',// * feed
            'divide_by_feed'=>'',// / feed
            'wh_accumulator'=>'Wh',//Wh Accumulator
            'source_feed_data_time'=>'',//Source Feed
            //'get_feed_data_day'=>'',//Source Daily (TBD)
            'add_source_feed'=>'',// + source feed
            'sub_source_feed'=>'',// - source feed
            'multiply_by_source_feed'=>'',// * source feed
            'divide_by_source_feed'=>'',// / source feed
            'reciprocal_by_source_feed'=>'',//1/ source feed
        );
```