### PR TITLE
require_once feed and input models in delete_user

### DIFF
--- a/Modules/user/deleteuser.php
+++ b/Modules/user/deleteuser.php
@@ -10,10 +10,10 @@ function delete_user($userid,$mode) {
     if ($user_row = $result1->fetch_object()){
         $result = "User $userid\n";
         
-        require "Modules/feed/feed_model.php";
+        require_once "Modules/feed/feed_model.php";
         $feed = new Feed($mysqli,$redis,$feed_settings);
 
-        require "Modules/input/input_model.php";
+        require_once "Modules/input/input_model.php";
         $input = new Input($mysqli,$redis,$feed);
     
         $result .= "Feeds:\n";


### PR DESCRIPTION
After a while we are using in the Group module the delete_user function to fully remove users. We call this function from inside the group_model where the feed and input models have already been required