### PR TITLE
Allow access to .well-known for certbot (#952)

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -18,6 +18,7 @@ DirectoryIndex index.php
   # Skip rewrites for known files, folders and 4xx/5xx errors so we know if something is wrong
   RewriteCond %{REQUEST_URI} !=/favicon.ico
   RewriteCond %{REQUEST_URI} !=/robots.txt
+  RewriteCond %{REQUEST_URI} !^/.well-known/.$
   RewriteCond %{REQUEST_URI} !^/?docs.*$
   RewriteCond %{REQUEST_URI} !^/?Lib.*$
   RewriteCond %{REQUEST_URI} !^/?Modules.*$


### PR DESCRIPTION
This is required to use Let's Encrypt SSL certificates.