### PR TITLE
Remove test-failing PHP versions from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 php:
-  - '5.4'
-  - '5.5'
   - '5.6'
   - '7.0'
+  - '7.1'
+  - '7.2'
 
 before_script:
   - if find . -name "*.php" ! -path "./vendor/*" -exec php -l {} 2>&1 \; | grep "syntax error, unexpected"; then exit 1; fi


### PR DESCRIPTION
PHP 5.4 is older than the version listed under 'requirements' in the README and the PHPFina tests always fail on it, so I removed it and 5.5 from the Travis php version list and replaced them with 7.1 and 7.2.