### PR TITLE
Initial comit of hierarchical ini files to replace settings.php

### DIFF
--- a/default-settings.ini
+++ b/default-settings.ini
@@ -1,0 +1,179 @@
+; 1 #### Mysql database settings
+[database]
+server   = "localhost"
+database = "emoncms"
+username = "_DB_USER_"
+password = "_DB_PASSWORD_"
+port     = "3306"
+;   Skip database setup test - set to false once database has been setup.
+dbtest = true;
+
+
+; 2 #### Redis
+[redis]
+redis_enabled = false
+redis_server[host] = 'localhost'
+redis_server[port] = 6379
+redis_server[auth] = ''
+redis_server[prefix] = 'emoncms'
+
+
+; 3 #### MQTT
+[MQTT]
+;   The 'subscriber' topic format is rx/* - where * is the emoncms input node number.
+;   The 'publisher' topic format is user selectable from the 'Publish to MQTT' input process, for example power/solar
+;   Activate MQTT by changing to true
+mqtt_enabled = false
+mqtt_server[host] = 'localhost'
+mqtt_server[port] = 1883
+mqtt_server[user] = ''
+mqtt_server[password] = ''
+mqtt_server[basetopic] = 'emon'
+
+
+; 4 #### Engine settings
+[engine_settings]
+;feed_settings = array(
+;   Supported engines. Uncommented engines will not be available for user to create a new feed using it. Existing feeds with a hidden engine still work.
+;   Place a ',' as the first character on all uncommented engines lines but first.
+;   If using emoncms in low-write mode, ensure that PHPFIWA is disabled by removing the leading ; , from the PHPFIWA entry
+;engines_hidden'=>array(
+;  Engine::MYSQL     ;   0  Mysql traditional
+;  Engine::MYSQLMEMORY   ;  8  Mysql with MEMORY tables on RAM. All data is lost on shutdown
+;  Engine::PHPTIMESERIES ;  2
+;  ,Engine::PHPFINA  ;   5
+;  ,Engine::PHPFIWA  ;   6
+;  ,Engine::CASSANDRA;   10 Apache Cassandra
+
+;   Redis Low-write mode
+;   If enabled is true, requires redis enabled and feedwriter service running
+redisbuffer[enabled] = false
+;   Number of seconds to wait before write buffer to disk - user selectable option
+redisbuffer[sleep] = 600
+
+;   Max csv download size in MB
+csvdownloadlimit_mb = 25
+
+;   Engines working folder. Default is /var/lib/phpfiwa,phpfina,phptimeseries
+;   On windows or shared hosting you will likely need to specify a different data directory--
+;   Make sure that emoncms has write permission's to the datadirectory folders
+phpfiwa[datadir] = '/var/lib/phpfiwa/'
+phpfina[datadir] = '/var/lib/phpfina/'
+phptimeseries[datadir] = '/var/lib/phptimeseries/'
+cassandra[keyspace] = 'emoncms'
+    
+;   For use with emoncms module that require installation in home directory
+;homedir = "/home/username"
+
+;   Max number of allowed different inputs per user. For limiting garbage rf data
+max_node_id_limit = 32
+
+
+; 5 #### User Interface settings
+[interface]
+;   gettext  translations are found under each Module's locale directory
+default_language = 'en_GB'
+    
+;   Theme location (folder located under Theme/, and must have the same structure as the basic one)
+theme = "basic"
+;   Theme colour options: "standard", "blue", "sun"
+themecolor = "blue"
+
+;   Favicon filenme in Theme/$theme
+favicon = "favicon.png"
+
+;   Use full screen width
+fullwidth = true
+
+;   Main menu collapses on lower screen widths
+menucollapses = false
+
+;   Enable multi user emoncms.
+;   If set to false, emoncms will automatically remove the register form and
+;   ability to create further users after the first user has been created
+enable_multi_user = false
+
+;   Enable remember me feature
+enable_rememberme = true
+
+;   Allow user to reset his password
+enable_password_reset = false
+
+;   Email address to email proccessed input values
+default_emailto = 'emrys@localhost'
+
+;   (OPTIONAL) Email SMTP, used for password reset or other email functions
+smtp_email_settings[host] = "smtp.gmail.com"
+;   Possible ports 25, 465, 587
+smtp_email_settings[port] = "465"
+smtp_email_settings[from_email] = 'noreply@emoncms.org'
+smtp_email_settings[from_name] = 'EmonCMS'
+;   comment lines below that dont apply
+;   ssl, tls
+smtp_email_settings[encryption] = "ssl"
+smtp_email_settings[username] = "yourusername@gmail.com"
+smtp_email_settings[password]= "yourpassword"
+
+;   Default controller and action if none are specified and user is anonymous
+default_controller = "user"
+default_action = "login"
+
+;   Default controller and action if none are specified and user is logged in
+default_controller_auth = "feed"
+default_action_auth = "list"
+
+;   Public profile functionality
+;   Allows http:; yourdomain.com/[username]/[dash alias] or ?id=[dash id]
+;   Alternative to http:; yourdomain.com/dashboard/view?id=[dash id]
+;   Add optional '&embed=1' in the end to remove header and footer
+public_profile_enabled = true
+public_profile_controller = "dashboard"
+public_profile_action = "view"
+
+;   Default feed viewer: "vis/auto?feedid=" or "graph/" - requires module https:; github.com/emoncms/graph
+feedviewpath = "vis/auto?feedid="
+
+
+; 6 #### Other settings
+[other]
+;   Log file configuration
+log_enabled = true
+;   On windows or shared hosting you will likely need to specify a different logfile directory
+log_filename = '/var/log/emoncms.log'
+;   Log Level: 1=INFO, 2=WARN, 3=ERROR
+log_level = 2
+
+;   If installed on Emonpi, allow admin menu tools
+allow_emonpi_admin = false
+
+;  experimental feature for virtual feeds average, default is true, set to false to activate average agregation with all data points, will be slower
+data_sampling = false
+
+;   Show all fatal PHP errors
+display_errors = true
+
+;   CSV export options for the number of decimal_places, decimal_place_separator and field_separator
+;   The thousands separator is not used (specified as "nothing")
+;   NOTE: don't make $csv_decimal_place_separator == $csv_field_separator
+;   Adjust as appropriate for your location
+;   number of decimal places
+csv_decimal_places = 2
+
+;   decimal place separator
+csv_decimal_place_separator = "."
+
+;   field separator
+csv_field_separator = ","
+
+;   set true on docker installations
+allow_config_env_vars = false
+
+;   Dont change - developer updates this when the config format changes
+config_file_version = "10"
+
+;   Set to true to run database update without logging in
+;   URL Example: http:; localhost/emoncms/admin/db
+updatelogin = false
+
+;   Applicaton name
+appname = "emoncms"

--- a/process_settings.php
+++ b/process_settings.php
@@ -14,6 +14,110 @@ defined('EMONCMS_EXEC') or die('Restricted access');
 
 require_once('Lib/enum.php');
 
+function ini_merge ($config_ini, $custom_ini) {
+    foreach ($custom_ini AS $k => $v):
+        if (is_array($v)):
+            $config_ini[$k] = ini_merge($config_ini[$k], $custom_ini[$k]);
+        else:
+            $config_ini[$k] = $v;
+        endif;
+    endforeach;
+    return $config_ini;
+};
+
+$CONFIG_INI = parse_ini_file("default-settings.ini");
+$CUSTOM_INI = parse_ini_file("settings.ini");
+$ini_array = ini_merge($CONFIG_INI, $CUSTOM_INI);
+
+//$ini_array = parse_ini_file("default-settings.ini");
+//$ini_array = parse_ini_file("settings.ini");
+//************************************************
+$server   = $ini_array['server'];
+$database = $ini_array['database'];
+$username = $ini_array['username'];
+$password = $ini_array['password'];
+$port     = $ini_array['port'];
+
+$dbtest = $ini_array['dbtest'];
+$redis_enabled = $ini_array['redis_enabled'];
+$redis_server = array( 'host'   => $ini_array['redis_server']['host'],
+                       'port'   => $ini_array['redis_server']['port'],
+                       'auth'   => $ini_array['redis_server']['auth'],
+                       'prefix' => $ini_array['redis_server']['prefix']);
+$mqtt_enabled = $ini_array['mqtt_enabled'];          // Activate MQTT by changing to true
+$mqtt_server = array( 'host'     => $ini_array['mqtt_server']['host'],
+                      'port'     => $ini_array['mqtt_server']['port'],
+                      'user'     => $ini_array['mqtt_server']['user'],
+                      'password' => $ini_array['mqtt_server']['password'],
+                      'basetopic'=> $ini_array['mqtt_server']['basetopic']);
+$feed_settings = array(
+    'engines_hidden'=>array(
+        //Engine::MYSQL         // 0  Mysql traditional
+        //Engine::MYSQLMEMORY   // 8  Mysql with MEMORY tables on RAM. All data is lost on shutdown
+        //Engine::PHPTIMESERIES // 2
+        //,Engine::PHPFINA      // 5
+        //,Engine::PHPFIWA      // 6
+        //,Engine::CASSANDRA    // 10 Apache Cassandra
+    ),
+    'redisbuffer'=>array(
+        'enabled' => $ini_array['redisbuffer']['enabled']      // If enabled is true, requires redis enabled and feedwriter service running
+        ,'sleep' => $ini_array['redisbuffer']['sleep']),       // Number of seconds to wait before write buffer to disk - user selectable option
+    'csvdownloadlimit_mb' => $ini_array['csvdownloadlimit_mb'],     // Max csv download size in MB
+    'phpfiwa'=>array(
+        'datadir' => $ini_array['phpfiwa']['datadir']),
+    'phpfina'=>array(
+        'datadir' => $ini_array['phpfina']['datadir']),
+    'phptimeseries'=>array(
+        'datadir' => $ini_array['phptimeseries']['datadir']),
+    'cassandra'=>array(
+        'keyspace' => $ini_array['cassandra']['datadir'])
+);
+
+$max_node_id_limit = $ini_array['max_node_id_limit'];
+$default_language = $ini_array['default_language'];
+$theme = $ini_array['theme'];
+$themecolor = $ini_array['themecolor'];
+$favicon = $ini_array['favicon'];
+$fullwidth = $ini_array['fullwidth'];
+$menucollapses = $ini_array['menucollapses'];
+$enable_multi_user = $ini_array['enable_multi_user'];
+$enable_rememberme = $ini_array['enable_rememberme'];
+$enable_password_reset = $ini_array['enable_password_reset'];
+$default_emailto = $ini_array['default_emailto'];
+$smtp_email_settings = array(
+  'host'=> $ini_array['smtp_email_settings']['host'],
+  'port'=> $ini_array['smtp_email_settings']['port'],  // 25, 465, 587
+  'from'=> array(
+      $ini_array['smtp_email_settings']['from_email'] => $ini_array['smtp_email_settings']['from_name']),
+  'encryption'=> $ini_array['smtp_email_settings']['encryption'], // ssl, tls
+  'username'=> $ini_array['smtp_email_settings']['username'],
+  'password'=>$ini_array['smtp_email_settings']['password']);
+
+$default_controller = $ini_array['default_controller'];
+$default_action = $ini_array['default_action'];
+$default_controller_auth = $ini_array['default_controller_auth'];
+$default_action_auth = $ini_array['default_action_auth'];
+$public_profile_enabled = $ini_array['public_profile_enabled'];
+$public_profile_controller = $ini_array['public_profile_controller'];
+$public_profile_action = $ini_array['public_profile_action'];
+$feedviewpath = $ini_array['feedviewpath'];
+$log_enabled = $ini_array['log_enabled'];
+$log_filename = $ini_array['log_filename'];
+$log_level = $ini_array['log_level'];
+$allow_emonpi_admin = $ini_array['allow_emonpi_admin'];
+$data_sampling = $ini_array['data_sampling'];
+$display_errors = $ini_array['display_errors'];
+$csv_decimal_places = $ini_array['csv_decimal_places'];
+$csv_decimal_place_separator = $ini_array['csv_decimal_place_separator'];
+$csv_field_separator = $ini_array['csv_field_separator'];
+$allow_config_env_vars = $ini_array['allow_config_env_vars'];
+$config_file_version = $ini_array['config_file_version'];
+$updatelogin = $ini_array['updatelogin'];
+$appname = $ini_array['appname'];
+
+//echo "<h3>Got here</h3>";
+
+//************************************************
 // Check if settings.php file exists
 if(file_exists(dirname(__FILE__)."/settings.php"))
 {


### PR DESCRIPTION
Relates to #923 

This commit converts the settings.php to a settings.ini structure.

WARNING - ini files in root folder are a BAD idea. Location is just for testing.

To test, copy default-settings.ini to a settings.ini.  Add in your specific settings to the ini file (delete any left unchanged to test concept).  Delete the contents of your settings.php and refresh.

Not finished yet but works.

* Could make it look for other ini files.
* Does not cover emonpi settings.
* location of settings files to be discussed (must not be in root folder).
* Is there a better way to assign each variable.
* do we need to maintain the Environmental variables?
