### PR TITLE
Removed warning in log file when creating phpfina feed

### DIFF
--- a/Modules/feed/engine/PHPFina.php
+++ b/Modules/feed/engine/PHPFina.php
@@ -37,8 +37,8 @@ class PHPFina implements engine_methods
         if ($interval<5) $interval = 5;
         
         // Check to ensure we dont overwrite an existing feed
-        
-        if (!$meta = $this->get_meta($feedid)) {
+        $feedname = "$feedid.meta";
+        if (!file_exists($this->dir.$feedname)) {
             // Set initial feed meta data
             $meta = new stdClass();
             $meta->interval = $interval;
@@ -62,7 +62,6 @@ class PHPFina implements engine_methods
             $this->log->info("create() feedid=$feedid");
         }
 
-        $feedname = "$feedid.meta";
         if (file_exists($this->dir.$feedname)) {
             return true;
         } else {


### PR DESCRIPTION
Hi,
Every now and again when checking the log file we found some warnings that seemed to have no reason and were worrying us:

`2018-09-11 12:44:29.099|WARN|PHPFina.php|get_meta() meta file does not exist '/var/lib/phpfina/130.meta'`

After having a look we noticed the warnings happened when we were creating the feeds. The warning was triggered by the the get_meta() method of the phpFINA engine that was used to check if the feed exists before creating it. I have changed it to just check the meta data file exists which is the first thing that get_meta() does
