### PR TITLE
Update command to get correct git branch

### DIFF
--- a/Modules/admin/admin_main_view.php
+++ b/Modules/admin/admin_main_view.php
@@ -267,7 +267,7 @@ if ($allow_emonpi_admin) {
               <tr><td><b>Emoncms</b></td><td>Version</td><td><?php echo $emoncms_version; ?></td></tr>
               <tr><td class="subinfo"></td><td>Modules</td><td><?php echo $system['emoncms_modules']; ?></td></tr>
               <tr><td class="subinfo"></td><td>Git URL</td><td><?php echo $system['git_URL']; ?></td></tr>
-              <tr><td class="subinfo"></td><td>Branch</td><td><?php echo $system['git_branch']; ?></td></tr>
+              <tr><td class="subinfo"></td><td>Git Branch</td><td><?php echo $system['git_branch']; ?></td></tr>
 <?php
 if ($feed_settings['redisbuffer']['enabled']) {
 ?>


### PR DESCRIPTION
Issue #1012 identified an issue with the command to retrieve the current branch in that it did not always get the right branch.

The git branch command retrieved all branches not just the current one.

2 solutions were identified git branch --contains HEAD and git rev-parse --abbrev-ref HEAD.

I have chosen the former.