### PR TITLE
Remove null=true from database schema, fixing #1016

### DIFF
--- a/Modules/user/user_schema.php
+++ b/Modules/user/user_schema.php
@@ -19,11 +19,11 @@ $schema['users'] = array(
     'language' => array('type' => 'varchar(5)', 'default'=>'en_EN'),
     'bio' => array('type' => 'text', 'default'=>''),
 
-    'tags' => array('type' => 'text', 'default'=>NULL, 'Null'=>true),
+    'tags' => array('type' => 'text', 'default'=>NULL),
     'startingpage' => array('type'=>'varchar(64)', 'default'=>'feed/list'),
     'email_verified' => array('type' => 'int(11)', 'default'=>0),
     'verification_key' => array('type' => 'varchar(64)', 'default'=>''),
-    'preferences' => array('type' => 'varchar(255)', 'default'=>NULL, 'Null'=>true)
+    'preferences' => array('type' => 'varchar(255)', 'default'=>NULL)
 );
 
 $schema['rememberme'] = array(


### PR DESCRIPTION
As a stopgap, this fixes #1016, which prevents a new instance of EmonCMS on a blank database being created.  It is caused by a bug in the database schema code but this is a good stopgap fix.