### PR TITLE
added composer packages directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ Modules/*/
 Theme/*
 Theme/*/
 !Theme/basic/
+
+/vendor/


### PR DESCRIPTION
if `/vendor/` is not added to `.gitignore` all the dependent packages (including ones for development) will be added to the repository

Added composer to help with managing packages that parse static config files (#1001) ( pull request #1024 ) .

This line is already in the pull request branch `emrysr:feature/issue-1001-common-units`, however as this directory is ignored it is not removed when I switch branches.