### PR TITLE
Feature/issue 1033 timestamp in tooltip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ Modules/*/
 Theme/*
 Theme/*/
 !Theme/basic/
+
+/vendor/

--- a/Modules/feed/Views/feedlist_view_v2.php
+++ b/Modules/feed/Views/feedlist_view_v2.php
@@ -398,10 +398,15 @@ body{padding:0!important}
               
               for (var feed in nodes[node]) {
                   var feedid = nodes[node][feed].id;
-                  var row_title = ["Feed ID: "+feedid,
-                                    "Feed Interval: "+(nodes[node][feed].interval||'')+'s',
-                                    "Feed Start Time: "+format_time(nodes[node][feed].start_time,'LLLL')
-                  ].join("\n")
+                  var title_lines = ["Feed ID: "+feedid,
+                                    "Feed Interval: "+(nodes[node][feed].interval||'')+'s'
+                  ]
+                  // show the start time if available
+                  if(nodes[node][feed].start_time > 0){
+                      title_lines.push("Feed Start Time: "+format_time(nodes[node][feed].start_time,'LLLL'))
+                      title_lines.push("Timestamp:  "+nodes[node][feed].start_time)
+                  }
+                  row_title = title_lines.join("\n")
 
                   out += "<div class='node-feed feed-graph-link' feedid="+feedid+" title='"+row_title+"'>";
                   var checked = ""; if (selected_feeds[feedid]) checked = "checked";

--- a/Modules/feed/Views/feedlist_view_v2.php
+++ b/Modules/feed/Views/feedlist_view_v2.php
@@ -35,9 +35,9 @@ document.head.appendChild(script);
  * @see date format options - https://momentjs.com/docs/#/displaying/
  */
 function format_time(time,format){
-    time = time || (new Date().valueOf() / 1000)
-    format = format || ''
-    formatted_date = moment.unix(time).format(format)
+    if(!Number.isInteger(time)) return time
+    format = format || 'YYYY-MM-DD'
+    formatted_date = moment.unix(time).utc().format(format)
     return formatted_date
 }
 </script>
@@ -403,8 +403,8 @@ body{padding:0!important}
                   ]
                   // show the start time if available
                   if(nodes[node][feed].start_time > 0){
-                      title_lines.push("Feed Start Time: "+format_time(nodes[node][feed].start_time,'LLLL'))
-                      title_lines.push("Timestamp:  "+nodes[node][feed].start_time)
+                      title_lines.push("Feed Start Time:  "+nodes[node][feed].start_time)
+                      title_lines.push("("+format_time(nodes[node][feed].start_time,'LL LTS')+" UTC)")
                   }
                   row_title = title_lines.join("\n")
 


### PR DESCRIPTION
fixes #1033 
The timestamp now shows in the feed list tooltips:
![image](https://user-images.githubusercontent.com/1466013/45947002-9356ec80-bfea-11e8-8be0-55332975d828.png)
