### PR TITLE
added the mousePos variable to the global scope to fix error

### DIFF
--- a/Modules/feed/Views/feedlist_view_v2.php
+++ b/Modules/feed/Views/feedlist_view_v2.php
@@ -529,7 +529,8 @@ function onTooltipShown(event){
     }
     $('#mouse-position').data('tooltip-shown',true)
 }
-
+// create global variable to store mouse position:
+var mousePos = {x: 0, y: 0}
 // store current mouse position in global scope
 document.onmousemove = function(event) {
     var dot, eventDoc, doc, body, pageX, pageY;


### PR DESCRIPTION
issue #1029 - Feed page hover-over info not clear as to which feed it belongs to
pr #1047 - issue 1029 feed tag in tooltip

fix for js error caused by pr #1047 - issue 1029 feed tag in tooltip