### PR TITLE
locked the swipe navigation to horizontal only.

### DIFF
--- a/Theme/basic/theme.php
+++ b/Theme/basic/theme.php
@@ -196,7 +196,7 @@
                 // create a new instance of the hammerjs api
                 mc = new Hammer.Manager(container),
                 // make swipes require more velocity
-                swipe = new Hammer.Swipe({ velocity: 1.1 }) // default 0.3
+                swipe = new Hammer.Swipe({ velocity: 1.1, direction: Hammer.DIRECTION_HORIZONTAL }) // default velocity 0.3
                 // CSV list of pages in the navigation
                 pages = "feed/list,input/view".split(',')
                 // strip off the domain/ip and just get the path


### PR DESCRIPTION
this will allow mobile users to still scroll / drag the page vertically

fix #1055 