### PR TITLE
restricted swipes to mobile devices

### DIFF
--- a/Theme/basic/theme.php
+++ b/Theme/basic/theme.php
@@ -194,9 +194,11 @@
                 // get the path as reported by server
                 path = "<?php echo $path; ?>",
                 // create a new instance of the hammerjs api
-                mc = new Hammer.Manager(container),
+                mc = new Hammer.Manager(container, {
+                    inputClass: Hammer.TouchInput
+                }),
                 // make swipes require more velocity
-                swipe = new Hammer.Swipe({ velocity: 1.1 }) // default 0.3
+                swipe = new Hammer.Swipe({ velocity: 1.1, direction: Hammer.DIRECTION_HORIZONTAL }) // default velocity 0.3
                 // CSV list of pages in the navigation
                 pages = "feed/list,input/view".split(',')
                 // strip off the domain/ip and just get the path


### PR DESCRIPTION
fix #985 
swiping to navigate between inputs and feeds only works on mobile now.

this is to stop unwanted navigation when highlighting text with a mouse