### PR TITLE
added CORS complient preflight headers

### DIFF
--- a/route.php
+++ b/route.php
@@ -132,6 +132,13 @@ class Route
         } elseif(in_array($requestMethod, array('POST', 'DELETE', 'PUT'))) {
             $this->method = $requestMethod;
         }
+        if($requestMethod === 'OPTIONS') {
+            // "CORS PREFLIGHT REQUESTS" EXPECT THESE HEADERS. no content required
+            header('Access-Control-Allow-Origin: *');
+            header('Access-Control-Allow-Headers: Authorization');
+            header('Access-Control-Allow-Methods: GET');
+            exit();
+        }
     }
 
     /**

--- a/route.php
+++ b/route.php
@@ -131,8 +131,7 @@ class Route
             $this->method = 'PUT';
         } elseif(in_array($requestMethod, array('POST', 'DELETE', 'PUT'))) {
             $this->method = $requestMethod;
-        }
-span class="pl-s1">         elseif($requestMethod === 'OPTIONS') {
+        } elseif($requestMethod === 'OPTIONS') {
             // "CORS PREFLIGHT REQUESTS" EXPECT THESE HEADERS. no content required
             header('Access-Control-Allow-Origin: *');
             header('Access-Control-Allow-Headers: Authorization');

--- a/route.php
+++ b/route.php
@@ -132,7 +132,7 @@ class Route
         } elseif(in_array($requestMethod, array('POST', 'DELETE', 'PUT'))) {
             $this->method = $requestMethod;
         }
-        if($requestMethod === 'OPTIONS') {
+span class="pl-s1">         elseif($requestMethod === 'OPTIONS') {
             // "CORS PREFLIGHT REQUESTS" EXPECT THESE HEADERS. no content required
             header('Access-Control-Allow-Origin: *');
             header('Access-Control-Allow-Headers: Authorization');


### PR DESCRIPTION
while testing the `Authorization: Bearer APIKEY` as per the emoncms `/feed/api` in the browser I got issues with the [CORS preflight request](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) not returning the expected headers

**used during development the remote calls to the api**
before this is pulled in, we'll need to discuss the pros and cons of the `allow-origin` header being set to `*` (all). 
``` 
'Access-Control-Allow-Origin: *'
```
might be better to be set to `openenergymonitor.org` if that is where the requests will be originating from?


These are the HTTP headers I'm returning when a HTTP `OPTIONS` request  is made to the API. 
_(my changes don't effect GET or POST requests)_
```
            header('Access-Control-Allow-Origin: *');
            header('Access-Control-Allow-Headers: Authorization');
            header('Access-Control-Allow-Methods: GET');
```

this will not be required until the branch i'm working on now is pulled in and requests are made to a different domain