### PR TITLE
 added arrow to "configure your devices" alert for first timers

### DIFF
--- a/Modules/input/Views/device_view.php
+++ b/Modules/input/Views/device_view.php
@@ -182,7 +182,7 @@ function noProcessNotification(devices){
         }
     }
     if(processList.length<1 && Object.keys(devices).length > 0){
-        message = '<div class="alert pull-right">%s</div>'.replace('%s',"<?php echo _("Configure your devices here") ?>")
+        message = '<div class="alert pull-right">%s <i class="icon-arrow-down" style="opacity: .7;"></i></div>'.replace('%s',"<?php echo _("Configure your devices here") ?>")
     }
     $('#noprocesses').html(message)
 }


### PR DESCRIPTION
While I [was working on the device module](https://github.com/emoncms/device/pull/30) I noticed the `"Configure your device here"` message could direct the user better with an arrow pointing at the correct button:

![image](https://user-images.githubusercontent.com/1466013/47396499-f68b8a00-d722-11e8-9912-1f9033e62ebb.png)

the message disappears once a device has been initialized and is saving to a feed