### PR TITLE
redis: support db selection via dbnum config

### DIFF
--- a/default.settings.php
+++ b/default.settings.php
@@ -15,6 +15,7 @@
     $redis_server = array( 'host'   => 'localhost',
                            'port'   => 6379,
                            'auth'   => '',
+                           'dbnum'   => '',
                            'prefix' => 'emoncms');
 
 

--- a/index.php
+++ b/index.php
@@ -39,6 +39,9 @@
                 echo "Can't connect to redis at ".$redis_server['host'].", autentication failed"; die;
             }
         }
+        if (!empty($redis_server['dbnum'])) {
+            $redis->select($redis_server['dbnum']);
+        }
     } else {
         $redis = false;
     }


### PR DESCRIPTION
Prefixes for keys are handy, but redis supports multiple separate dbs entirely,
via "select".  Expose that as a configuration setting.

Signed-off-by: Karl Palsson <karlp@tweak.net.au>

--

I didn't find any real place to add documentation for this, there's nothing for the auth option either?