### PR TITLE
No error or output shown when json_encode() returns an error.

### DIFF
--- a/index.php
+++ b/index.php
@@ -248,6 +248,28 @@
         } else {
             header('Content-Type: application/json');
             print json_encode($output['content']);
+            if (json_last_error()!=JSON_ERROR_NONE) {
+                switch (json_last_error()) {
+                    case JSON_ERROR_DEPTH:
+                        $log->error("json_encode - $route->controller: Maximum stack depth exceeded");
+                        break;
+                    case JSON_ERROR_STATE_MISMATCH:
+                        $log->error("json_encode - $route->controller: Underflow or the modes mismatch");
+                        break;
+                    case JSON_ERROR_CTRL_CHAR:
+                        $log->error("json_encode - $route->controller: Unexpected control character found");
+                        break;
+                    case JSON_ERROR_SYNTAX:
+                        $log->error("json_encode - $route->controller: Syntax error, malformed JSON");
+                        break;
+                    case JSON_ERROR_UTF8:
+                        $log->error("json_encode - $route->controller: Malformed UTF-8 characters, possibly incorrectly encoded");
+                        break;
+                    default:
+                        $log->error("json_encode - $route->controller: Unknown error");
+                        break;
+                }
+            }
         }
     }
     else if ($route->format == 'html')


### PR DESCRIPTION
Bugfix for: "No error or output shown when json_encode() returns an error."
This error causes a lot of searching when debugging, for example when there is an invalid character in a string.