### PR TITLE
Corrected reverse proxy support

### DIFF
--- a/core.php
+++ b/core.php
@@ -29,8 +29,8 @@ function get_application_path()
         $proto = "https";
     }
 
-    if( isset( $_SERVER['HTTP_X_FORWARDED_SERVER'] ))
-        $path = dirname("$proto://" . server('HTTP_X_FORWARDED_SERVER') . server('SCRIPT_NAME')) . "/";
+    if( isset( $_SERVER['HTTP_X_FORWARDED_HOST'] ))
+        $path = dirname("$proto://" . server('HTTP_X_FORWARDED_HOST') . server('SCRIPT_NAME')) . "/";
     else
         $path = dirname("$proto://" . server('HTTP_HOST') . server('SCRIPT_NAME')) . "/";
 


### PR DESCRIPTION
This addresses issue #1135 where putting emoncms behind reverse proxy breaks the website. It is due to incorrect header (HTTP_X_FORWARDED_SERVER) being used to identify the real host URL. The correct header is HTTP_X_FORWARDED_HOST. 