### PR TITLE
fix padding spikes where input feed has null value

### DIFF
--- a/scripts/feedwriter.php
+++ b/scripts/feedwriter.php
@@ -17,7 +17,7 @@
     if (!$feed_settings['redisbuffer']['sleep'] || (int)$feed_settings['redisbuffer']['sleep'] < 1) { echo "Error: setting must be > 0 : feed_settings['redisbuffer']['sleep']\n"; die; }
 
     $log = new EmonLogger(__FILE__);
-    $log->info("Starting feedwriter script");
+    $log->error("Starting feedwriter script");
 
     $mysqli = @new mysqli($server,$username,$password,$database,$port);
     if ($mysqli->connect_error) { $log->error("Can't connect to database:". $mysqli->connect_error);  die('Check log\n'); }


### PR DESCRIPTION
This is to fix the issue highlighted in the forum thread here: https://community.openenergymonitor.org/t/getting-spikes-in-emoncms-graph/9494/26

@chaveiro for some reason the use of static $lastvalue_static_cache did not store the last value as expected. Changing to a private variable array seems to work much better. Can you see any issue with this approach?