### PR TITLE
Update editdaily.php

### DIFF
--- a/Modules/vis/visualisations/editdaily.php
+++ b/Modules/vis/visualisations/editdaily.php
@@ -71,7 +71,7 @@
   function vis_feed_data() {
     start = Math.floor(start / 86400000) * 86400000;
     end = Math.ceil(end / 86400000) * 86400000;
-    var graph_data = get_feed_data(feedid,start,end,3600*24,1,1);
+    var graph_data = get_feed_data(feedid,start,end,3600*24,1,0);
     //var stats = power_stats(graph_data);
     //$("#stats").html("Average: "+stats['average'].toFixed(0)+"W | "+stats['kwh'].toFixed(2)+" kWh");
 


### PR DESCRIPTION
limitinterval set to 0 when calling the js function get_feed_data(feedID,start,end,interval,skipmissing,limitinterval) in Modules/vis/Modules/vis/visualisations/editdaily.php

This permits to correctly perform writes on MYD files with data from the REDIS buffer...

with limitinterval equal to 1, the timestamps are slightly different from the timestamps in the.MYD file and the update method of the PHPTimeSeries engine does nothing since the dichotomous algorithm of binarysearch_exact does not converge and always returns -1

when you don't really dive into the code, it is not easy to understand the function of this parameter limitinterval....

in the doc of the get_data($feedid,$start,$end,$interval,$skipmissing,$limitinterval) method of the PHPTimeSeries engine, it is written :

> @param integer $limitinterval Limit datapoints returned to this value (used by somes engines)

https://github.com/emoncms/emoncms/blob/master/Modules/feed/engine/PHPTimeSeries.php

shouldn't the wording be more like that :

>@param integer $limitinterval : when set to 1 , return the calculated timestamp if the difference between the calculated timestamp and the timestamp hardcoded of the timeseries datafile is less than $interval
when set top 0, return the harcoded timestamp of the timeseries datafile


??