### PR TITLE
hidden controls when list is empty

### DIFF
--- a/Modules/input/Views/device_view.php
+++ b/Modules/input/Views/device_view.php
@@ -65,7 +65,7 @@ input[type="checkbox"] { margin:0px; }
         <h2><?php echo _('Inputs'); ?></h2>
     </div>
     
-    <div class="controls" data-spy="affix" data-offset-top="100">
+    <div id="feedlist-controls" class="controls" data-spy="affix" data-offset-top="100">
         <button id="expand-collapse-all" class="btn" title="<?php echo _('Collapse') ?>" data-alt-title="<?php echo _('Expand') ?>"><i class="icon icon-resize-small"></i></button>
         <button id="select-all" class="btn" title="<?php echo _('Select all') ?>" data-alt-title="<?php echo _('Unselect all') ?>"><i class="icon icon-check"></i></button>
         <button class="btn input-delete hide" title="Delete"><i class="icon-trash" ></i></button>
@@ -287,10 +287,12 @@ function draw_devices()
         $("#input-header").hide();
         $("#input-footer").show();
         $("#input-none").show();
+        $("#feedlist-controls").hide();
     } else {
         $("#input-header").show();
         $("#input-footer").show();
         $("#input-none").hide();
+        $("#feedlist-controls").show();
     }
 
     if(typeof $.fn.collapse == 'function'){


### PR DESCRIPTION
fix #1154 

[screenshot of hidden buttons when device list empty]
![image](https://user-images.githubusercontent.com/1466013/51169603-3be3d180-18a4-11e9-8c5e-5a827e4021a9.png)
