### PR TITLE
Replace colons in MQTT Topics

### DIFF
--- a/scripts/phpmqtt_input.php
+++ b/scripts/phpmqtt_input.php
@@ -221,6 +221,9 @@
 
             global $mqtt_server, $user, $input, $process, $device, $log, $count;
 
+            //remove characters that emoncms topics cannot handle
+            $topic = str_replace(":","",$topic);
+
             //Check and see if the input is a valid JSON and when decoded is an array. A single number is valid JSON.
             $jsondata = json_decode($value,true,2);
             if ((json_last_error() === JSON_ERROR_NONE) && is_array($jsondata)) {


### PR DESCRIPTION
Quick fix to replace colons in MQTT topic names as EmonCMS cannot handle them in node names.

This should be reviewed and any other characters that are legal for MQTT topics, that EmonCMS cannot handle in node names, also replaced.

Ref #1106 that I accidentally closed
Issue #1105 