### PR TITLE
Feature/issue 1150 service statuses

### DIFF
--- a/Modules/admin/admin_main_view.php
+++ b/Modules/admin/admin_main_view.php
@@ -20,11 +20,10 @@
     if ($status['LoadState'] === 'not-found') {
         $return = null;
     } else {
-        if ($status['ActiveState'] === 'active') {
-            return implode("|", array($status["LoadState"],$status["ActiveState"],$status["SubState"]));
-        } else {
-            return false;
-        }
+        return array(
+            'ActiveState' => $status["ActiveState"],
+            'SubState' => $status["SubState"]
+        );
     }
     return $return;
   }
@@ -303,9 +302,9 @@ if ($allow_emonpi_admin) {
             -->
               <?php foreach($system['services'] as $key=>$value): ?>
                 <?php if (!is_null($system['services'][$key])) { ?>
-                <tr class="<?php if ($system['services'][$key] !== false) echo "success"; else echo "error"; ?>">
+                <tr class="<?php if ($system['services'][$key]['ActiveState'] === 'active') echo "success"; else echo "error"; ?>">
                     <td class="subinfo"></td><td><?php echo $key ?></td>
-                    <td><?php echo $system['services'][$key] ? $system['services'][$key] : '<font color="red">' . $system['services'][$key]. '</font>'; ?>
+                    <td><strong><?php echo ucfirst($system['services'][$key]['ActiveState']); ?></strong> <?php echo ucfirst($system['services'][$key]['SubState']); ?>
                     </td>
                 </tr>
                 <?php } ?>

--- a/Modules/admin/admin_main_view.php
+++ b/Modules/admin/admin_main_view.php
@@ -20,7 +20,11 @@
     if ($status['LoadState'] === 'not-found') {
         $return = null;
     } else {
-        $return = $status['ActiveState'] === 'active';
+        if ($status['ActiveState'] === 'active') {
+            return implode("|", array($status["LoadState"],$status["ActiveState"],$status["SubState"]));
+        } else {
+            return false;
+        }
     }
     return $return;
   }
@@ -33,11 +37,12 @@
     @list($system, $host, $kernel) = preg_split('/[\s,]+/', php_uname('a'), 5);
 
     $services['emonhub'] = getServiceStatus('emonhub.service');
-    $services['mqtt'] = getServiceStatus('mosquitto.service');
+    $services['mqtt_input'] = getServiceStatus('mqtt_input.service');
     $services['feedwriter'] = getServiceStatus('feedwriter.service');
-    $services['servicerunner'] = getServiceStatus('service-runner.service');
-    $services['redis'] = getServiceStatus('redis-server.service');
-    $services['lcd'] = getServiceStatus('emonPiLCD.service');
+    $services['service-runner'] = getServiceStatus('service-runner.service');
+    $services['emonPiLCD'] = getServiceStatus('emonPiLCD.service');
+    $services['redis-server'] = getServiceStatus('redis-server.service');
+    $services['mosquitto'] = getServiceStatus('mosquitto.service');
 
     //@exec("hostname -I", $ip); $ip = $ip[0];
     $meminfo = false;
@@ -298,21 +303,13 @@ if ($allow_emonpi_admin) {
             -->
               <?php foreach($system['services'] as $key=>$value): ?>
                 <?php if (!is_null($system['services'][$key])) { ?>
-                <tr class="<?php if ($system['services'][$key] === true) echo "success"; else echo "error"; ?>">
+                <tr class="<?php if ($system['services'][$key] !== false) echo "success"; else echo "error"; ?>">
                     <td class="subinfo"></td><td><?php echo $key ?></td>
-                    <td><?php echo ($system['services'][$key] ? "Service is running" : "<font color='red'>Service is not running</font>"); ?>
+                    <td><?php echo $system['services'][$key] ? $system['services'][$key] : '<font color="red">' . $system['services'][$key]. '</font>'; ?>
                     </td>
                 </tr>
                 <?php } ?>
               <?php endforeach; ?>
-
-              <?php if ($feed_settings['redisbuffer']['enabled']) { ?>
-              <tr class="<?php if ($system['feedwriter']) echo "success"; else echo "error"; ?>">
-                <td class="subinfo"></td><td>feedwriter</td>
-                <td><?php echo ($system['feedwriter'] ? "Service is running with sleep ".$feed_settings['redisbuffer']['sleep'] . "s" : "<font color='red'>Service is not running</font>"); ?>, <span id="bufferused">loading...</span>
-                </td>
-              </tr>
-              <?php } ?>
 
               <tr><td><b>Emoncms</b></td><td>Version</td><td><?php echo $emoncms_version; ?></td></tr>
               <tr><td class="subinfo"></td><td>Modules</td><td><?php echo $system['emoncms_modules']; ?></td></tr>


### PR DESCRIPTION
fix #1150 

Added to this pr #1153 

Thanks @borpin for the suggestions regarding outputting usefull service statuses passed from:
```
systemctl show emonhub.service | grep State
```

Full service name now shown in list:
![image](https://user-images.githubusercontent.com/1466013/51250727-33b49080-198f-11e9-9251-e825c6f6cd7b.png)
