### PR TITLE
Tidy feedwriter, service-runner and mqtt_input services

### DIFF
--- a/scripts/mqtt_input.service
+++ b/scripts/mqtt_input.service
@@ -29,7 +29,7 @@
 
 [Unit]
 Description=Emoncms MQTT Input Script
-After=mosquitto.service mysql.service redis.service
+After=mosquitto.service mysql.service redis-server.service
 Documentation=https://github.com/emoncms/emoncms/blob/master/docs/RaspberryPi/MQTT.md
 
 [Service]

--- a/scripts/services/feedwriter/feedwriter.service
+++ b/scripts/services/feedwriter/feedwriter.service
@@ -1,7 +1,6 @@
 # Systemd unit file for feedwriter script
 
 # INSTALL:
-
 # sudo ln -s /var/www/emoncms/scripts/services/feedwriter/feedwriter.service /lib/systemd/system
 
 # RUN AT STARTUP
@@ -35,9 +34,9 @@
 
 [Unit]
 Description=Emoncms feedwriter script
-Wants=mysql.service redis.service
-After=mysql.service redis.service
-Documentation=https://github.com/emoncms/emoncms
+Wants=mysql.service redis-server.service
+After=mysql.service redis-server.service
+Documentation=https://github.com/emoncms/emoncms/blob/master/scripts/services/install-service-feedwriter.md
 
 # Uncomment this line to use a dedicated log file for StdOut and StdErr.
 # NOTE: only works in systemd v236+

--- a/scripts/services/install-service-feedwriter.md
+++ b/scripts/services/install-service-feedwriter.md
@@ -10,8 +10,6 @@ The feedwriter service writes emoncms feed data to disk when redisbuffer is enab
 
 ## Install feedwriter service
 
-If you are not running EmonCMS on Raspbian, modify the .service file to run the service
-as an appropriate user. The service is configured to run as the user 'pi' by default.
 Install the service using the following commands:
 ```
 sudo ln -s /var/www/emoncms/scripts/services/feedwriter/feedwriter.service /lib/systemd/system

--- a/scripts/services/install-service-runner-update.md
+++ b/scripts/services/install-service-runner-update.md
@@ -11,14 +11,11 @@ The process is as follows:
 3. Service runner starts the update and logs to a file which the web application reads
 
 ## Install python systemd service
-
-If you are not running EmonCMS on Raspbian, modify the .service file to run the service
-as an appropriate user. The service is configured to run as the user 'pi' by default.
+**Check the old version has been uninstalled**
 Install the service using the following commands:
 ```
 sudo pip install redis
 sudo ln -s /var/www/emoncms/scripts/services/service-runner/service-runner.service /lib/systemd/system
-sudo systemctl daemon-reload
 sudo systemctl enable service-runner.service
 sudo systemctl start service-runner.service
 systemctl status service-runner.service
@@ -35,3 +32,11 @@ service runner to consume 100% of the CPU.
 This version was written by @greeebs using python and systemd instead of bash and cron, see
 https://github.com/emoncms/emoncms/pull/1025 for the discussion.
 The python service is far more efficient as a constant connection to redis can be kept open.
+
+To check which service is installed check `crontab -l`.  if there is an entry pointing to the bash script it is running the earlier version.
+
+To remove the old version (prior to installing the new version)
+```
+sudo crontab -e
+```
+Comment out the service-runner entry.

--- a/scripts/services/install-service-runner-update.md
+++ b/scripts/services/install-service-runner-update.md
@@ -12,8 +12,8 @@ The process is as follows:
 
 ## Install python systemd service
 **Check the old version has been uninstalled**
-Install the service using the following commands:
-```
+Install the service using the following commands (if redis is already installed skip that command):
+```bash
 sudo pip install redis
 sudo ln -s /var/www/emoncms/scripts/services/service-runner/service-runner.service /lib/systemd/system
 sudo systemctl enable service-runner.service
@@ -26,6 +26,23 @@ View the log with:
 
 Tested on Raspiban Stretch
 
+## Non Raspbian setup ##
+If you are not using Raspbian as your base OS you will need to change the **User** the service runs as.
+To do that;
+```
+sudo systemctl edit service-runner.service
+```
+this opens a blank file. Add the following lines and save the file (the user can be blank for root or any other user you wish to use)
+```
+[Service]
+User=
+```
+Then
+```
+sudo systemctl daemon-reload
+sudo systemctl restart service-runner.service
+```
+### Old systems ##
 Prior to September 2018 the service runner ran as a bash script triggered by cron. The
 bash script had to connect to redis every iteration of the loop which on a RPi 3 caused
 service runner to consume 100% of the CPU.

--- a/scripts/services/service-runner/service-runner.service
+++ b/scripts/services/service-runner/service-runner.service
@@ -47,9 +47,10 @@ Documentation=https://github.com/emoncms/emoncms/blob/master/scripts/services/in
 [Service]
 Type=idle
 ExecStart=/usr/bin/python /var/www/emoncms/scripts/services/service-runner/service-runner.py
+User=pi
 
 # Restart script if stopped on a failure. Will not restart if not configured correctly
-Restart=on-failure
+Restart=always
 # Wait 30s before restart
 RestartSec=30s
 

--- a/scripts/services/service-runner/service-runner.service
+++ b/scripts/services/service-runner/service-runner.service
@@ -1,9 +1,5 @@
 # Systemd unit file for mqtt input script
 
-# ***** NOTE: RUNS AS USER "pi" BY DEFAULT *****
-#  If running on a non-Raspbian environment, change "User=pi" in the [Service] section
-#  to the user of your choice (user must exist and should be the "emoncms" admin account)
-
 # INSTALL:
 # sudo ln -s /var/www/emoncms/scripts/services/service-runner/service-runner.service /lib/systemd/system
 
@@ -41,7 +37,7 @@ Description=Emoncms service-runner Input Script
 Wants=redis-server.service
 After=redis-server.service
 StartLimitIntervalSec=5
-#Documentation=https://github.com/emoncms/emoncms/blob/master/docs/service-runner.md
+Documentation=https://github.com/emoncms/emoncms/blob/master/scripts/services/install-service-runner-update.md
 
 # Uncomment this line to use a dedicated log file for StdOut and StdErr.
 # NOTE: only works in systemd v236+
@@ -51,11 +47,10 @@ StartLimitIntervalSec=5
 [Service]
 Type=idle
 ExecStart=/usr/bin/python /var/www/emoncms/scripts/services/service-runner/service-runner.py
-User=pi
 
-# Restart script if stopped
-Restart=always
-# Wait 60s before restart
+# Restart script if stopped on a failure. Will not restart if not configured correctly
+Restart=on-failure
+# Wait 30s before restart
 RestartSec=30s
 
 # Tag things in the log

--- a/scripts/services/service-runner/service-runner.service
+++ b/scripts/services/service-runner/service-runner.service
@@ -49,7 +49,7 @@ Type=idle
 ExecStart=/usr/bin/python /var/www/emoncms/scripts/services/service-runner/service-runner.py
 User=pi
 
-# Restart script if stopped on a failure. Will not restart if not configured correctly
+# Restart script if stopped
 Restart=always
 # Wait 30s before restart
 RestartSec=30s


### PR DESCRIPTION
Changes made for sake of consistency (mostly).

Service-runner
* remove user Pi (#1069 refers). Document and comments updated.
* Restart on failure (same as feedwriter)
* documentation link updated
* Update instructions to uninstall/disable old service-runner

feedwriter
* had a 'wants' entry of `redis.service` corrected to `redis-server.service`
* documentation updated.