### PR TITLE
checked for rpi-rw script to identify older version

### DIFF
--- a/Modules/admin/admin_main_view.php
+++ b/Modules/admin/admin_main_view.php
@@ -408,7 +408,10 @@ if ( @exec('ifconfig | grep b8:27:eb:') ) {
                      $btnactionfs = "<button id=\"fs-ro\" class=\"btn btn-info btn-small pull-right\">"._('Read-Only')."</button>";
                  } 
                  echo "<tr><td class=\"subinfo\"></td><td>Release</td><td>".$emonpiRelease."</td></tr>\n";
-                 echo "<tr><td class=\"subinfo\"></td><td>File-system</td><td>Current: ".$currentfs." - Set root file-system temporarily to read-write, (default read-only) ".$btnactionfs."</td></tr>\n";
+                 
+                 if (file_exists('/usr/bin/rpi-rw')) {
+                    echo "<tr><td class=\"subinfo\"></td><td>File-system</td><td>Current: ".$currentfs." - Set root file-system temporarily to read-write, (default read-only) ".$btnactionfs."</td></tr>\n";
+                 }
                }
       
       }


### PR DESCRIPTION
fix #1129 

this line will now be hidden (`/emonmcms/admin/view`) on the newer images of emoncms that don't have the filesystem read only restriction:
![delwedd](https://user-images.githubusercontent.com/1466013/51746534-613fbf00-209e-11e9-9d62-c543dcb61fa3.png)


```
if (file_exists('/usr/bin/rpi-rw')) {
```
