### PR TITLE
Fix/escaping slashes from gettext translation

### DIFF
--- a/Lib/user_locale.js
+++ b/Lib/user_locale.js
@@ -1,0 +1,24 @@
+(function(user){
+    if (!user) return;
+
+    // rework to fit the momentjs naming scheme for the locale files
+    momentjs_locales = {
+        da_DK:'da',
+        nl_BE:'nl-be',
+        nl_NL:'nl',
+        en_GB:'en-gb',
+        et_EE:'et',
+        fr_FR:'fr',
+        de_DE:'de',
+        it_IT:'it',
+        es_ES:'es',
+        cy_GB:'cy'
+    }
+    // match supported locales with momentjs file names
+    user.locale = momentjs_locales.hasOwnProperty(user.lang) ? momentjs_locales[user.lang] : 'en-gb'
+    // load the moment js locale file for the user's language
+    var script = document.createElement('script');
+    script.src = path + "Lib/momentjs-locales/%s.js".replace("%s",user.locale);
+    document.head.appendChild(script);
+
+})(typeof user !== 'undefined' ? user: null);

--- a/Modules/feed/Views/feedlist_view_v2.php
+++ b/Modules/feed/Views/feedlist_view_v2.php
@@ -1186,7 +1186,7 @@ $("#feedDelete-confirm").click(function(){
 });
 
 $("#refreshfeedsize").click(function(){
-    $.ajax({ url: path+"feed/updatesize.json", async: true, success: function(data){ update(); alert('<?php echo _("Total size of used space for feeds:"); ?>' + list_format_size(data)); } });
+    $.ajax({ url: path+"feed/updatesize.json", async: true, success: function(data){ update(); alert('<?php echo addslashes(_("Total size of used space for feeds:")); ?>' + list_format_size(data)); } });
 });
 
 // ---------------------------------------------------------------------------------------------

--- a/Modules/feed/Views/feedlist_view_v2.php
+++ b/Modules/feed/Views/feedlist_view_v2.php
@@ -7,26 +7,12 @@
 
 <script src="<?php echo $path; ?>Lib/moment.min.js"></script>
 <script>
-user.lang = "<?php echo $_SESSION['lang']; ?>"
-// rework to fit the momentjs naming scheme for the locale files
-momentjs_locales = {
-    da_DK:'da',
-    nl_BE:'nl-be',
-    nl_NL:'nl',
-    en_GB:'en-gb',
-    et_EE:'et',
-    fr_FR:'fr',
-    de_DE:'de',
-    it_IT:'it',
-    es_ES:'es',
-    cy_GB:'cy'
-}
-// match supported locales with momentjs file names
-user.locale = momentjs_locales.hasOwnProperty(user.lang) ? momentjs_locales[user.lang] : 'en-gb'
-// load the moment js locale file for the user's language
-var script = document.createElement('script');
-script.src = "<?php echo $path; ?>Lib/momentjs-locales/%s.js".replace("%s",user.locale);
-document.head.appendChild(script);
+    var user = {};
+    var path = "<?php echo $path; ?>";
+    user.lang = "<?php echo $_SESSION['lang']; ?>";
+</script>
+<script src="<?php echo $path; ?>Lib/user_locale.js"></script>
+<script>
 
 /**
  * uses moment.js to format to local time 


### PR DESCRIPTION
while testing another issue I'd found that if a gettext translation contains quotes and if that value was passed as a string to js it caused errors.

using php's `addslashes()` function to escape the single or double quotes from the string before using the resulting value as a javascript variable;
