### PR TITLE
Update to service-runner.py for redis prefix

### DIFF
--- a/scripts/services/service-runner/service-runner.py
+++ b/scripts/services/service-runner/service-runner.py
@@ -42,9 +42,13 @@ server = connect_redis()
 while True:
   try:
     # Check for the existence of a redis 'service-runner' key
-    if server.exists('service-runner'):
+    if server.exists('service-runner') or server.exists('emoncms:service-runner'):
       # We've got one, now to turn it into a cmdline
-      flag = server.lpop('service-runner')
+      if server.exists('service-runner'):
+        flag = server.lpop('service-runner')
+      else:
+        flag = server.lpop('emoncms:service-runner')
+
       print("Got flag: %s\n" % flag)
       sys.stdout.flush()
       script, logfile = flag.split('>')


### PR DESCRIPTION
Resolve issue whereby the different default redis prefix used in emonpi default settings and default settings mean that service runner was unable to get the right item off the queue.

As discussed in #1167 

This is only a temporary fix as any prefix could actually be used.