### PR TITLE
Limit size of Mount point text

### DIFF
--- a/Modules/admin/admin_main_view.php
+++ b/Modules/admin/admin_main_view.php
@@ -475,8 +475,13 @@ if ($system['mem_info']) {
                         $diskPercentRaw = ($diskUsed / $diskTotal) * 100;
                         $diskPercent = sprintf('%.2f',$diskPercentRaw);
                         $diskPercentTable = number_format(round($diskPercentRaw, 2), 2, '.', '');
-
-                        echo "<tr><td class='subinfo'></td><td>".$fs['Partition']['text']."</td><td><div class='progress progress-info' style='margin-bottom: 0;'><div class='bar' style='width: ".$diskPercentTable."%;'>Used:&nbsp;".$diskPercent."%&nbsp;</div></div>";
+                        if (strlen($fs['Partition']['text'])>30) {
+                          $mountpoint = substr($fs['Partition']['text'],0,30)."...";
+                        } else {
+                          $mountpoint = $fs['Partition']['text'];
+                        }
+                        
+                        echo "<tr><td class='subinfo'></td><td>".$mountpoint."</td><td><div class='progress progress-info' style='margin-bottom: 0;'><div class='bar' style='width: ".$diskPercentTable."%;'>Used:&nbsp;".$diskPercent."%&nbsp;</div></div>";
                         echo "<b>Total:</b> ".formatSize($diskTotal)."<b> Used:</b> ".formatSize($diskUsed)."<b> Free:</b> ".formatSize($diskFree)."</td></tr>\n";
 
                       }


### PR DESCRIPTION
**Needs Testing**

Discussion https://community.openenergymonitor.org/t/long-mount-points-disrupt-server-information/10089

Long mount points disrupt server information on admin page.  This PR limits the display to 30 characters plus ellipse.  There may be something clever to display the full path when it is moused over.