### PR TITLE
Feature/issue 1199/remove url from js error messages

### DIFF
--- a/Theme/basic/theme.php
+++ b/Theme/basic/theme.php
@@ -129,7 +129,7 @@ if (!in_array($themecolor, ["blue", "sun", "standard"])) {
                     'EmonCMS Error',
                     '-------------',
                     'Message: ' + msg,
-                    'URL: ' + source,
+                    'Route: ' + source.replace('<?php echo $path; ?>',''),
                     'Line: ' + lineno,
                     'Column: ' + colno
                 ];

--- a/index.php
+++ b/index.php
@@ -298,7 +298,7 @@
         if ($embed == 1) {
             print view($themeDir . "embed.php", $output);
         } else {
-            $menu = load_menu();
+            $menu = function_exists('load_menu') ? load_menu(): array(); 
             $output['mainmenu'] = view($themeDir . "menu_view.php", array());
             print view($themeDir . "theme.php", $output);
         }


### PR DESCRIPTION
fix #1199 

I'm able to remove the full url and only show the relative path within the information shown in the alert, however, the alert title and button is controlled by the browser.

![delwedd](https://user-images.githubusercontent.com/1466013/54594552-ce315e80-4a28-11e9-82c9-0e571cf3a233.png)
