### PR TITLE
defined string constant to check for when no route found

### DIFF
--- a/Modules/admin/admin_controller.php
+++ b/Modules/admin/admin_controller.php
@@ -15,8 +15,8 @@ defined('EMONCMS_EXEC') or die('Restricted access');
 function admin_controller()
 {
     global $mysqli,$session,$route,$updatelogin,$allow_emonpi_admin, $log_filename, $log_enabled, $redis, $homedir, $admin_show_update, $log_level, $log;
-    $result = "#UNDEFINED#";// display missing route message by default
-    $message = '';
+    $result = EMPTY_ROUTE;// display missing route message by default
+    $message = _('406: Route not found');
     
     if(!$session['write']) {
         $result = ''; // empty result shows login page (now redirects once logged in)

--- a/Modules/feed/feed_controller.php
+++ b/Modules/feed/feed_controller.php
@@ -45,7 +45,7 @@ function feed_controller()
         }
         else if ($route->action == "api" && $session['write']) return view("Modules/feed/Views/feedapi_view.php",array());
         else if (!$session['read']) return ''; // empty strings force user back to login
-        else return "#UNDEFINED#"; // this string displays error
+        else return EMPTY_ROUTE; // this string displays error
     }
 
     else if ($route->format == 'json')
@@ -276,5 +276,5 @@ function feed_controller()
         }
     }
 
-    return array('content'=>'#UNDEFINED#');
+    return array('content'=>EMPTY_ROUTE);
 }

--- a/core.php
+++ b/core.php
@@ -46,7 +46,7 @@ function db_check($mysqli,$database)
 
 function controller($controller_name)
 {
-    $output = array('content'=>"#UNDEFINED#");
+    $output = array('content'=>EMPTY_ROUTE);
 
     if ($controller_name)
     {


### PR DESCRIPTION
checked for the new constant at output
checked for the new constant when receiving controller response
added x-emoncms-message header on json errors
added not authenticated message to error log
used the new constant as the feed controller's default output

this doesn't relate to an issue. I'd noticed the string `#UNDEFINED#` being used in many places. just made one version of it.