### PR TITLE
Feature/issue 1245 tab nav

### DIFF
--- a/Theme/basic/menu_view.php
+++ b/Theme/basic/menu_view.php
@@ -58,7 +58,7 @@ endforeach; endif;
 
 
 
-<ul id="right-nav" class='nav d-flex align-items-stretch mr-0'>
+<ul id="right-nav" class='nav d-flex align-items-stretch mr-0 pull-right'>
 <?php
 $isBookmarked = currentPageIsBookmarked();
 $addBookmark = array(


### PR DESCRIPTION
fix #1245 

the hidden sidebar elements are now not accessible via the keyboard, therefore the user can "get to" all the relevant menu items via the keyboard.

the "top navbar menus" are the first in the "tab order" - so it takes 6 presses of the `tab` key before the sidebar menu items are accessed.

[screenshot with item tabindex overlayed]
![delwedd](https://user-images.githubusercontent.com/1466013/57661887-b6b7c180-75e4-11e9-93d7-221d08d69b87.png)
