### PR TITLE
user/gettimezones doesn't require authentication

### DIFF
--- a/Modules/user/user_controller.php
+++ b/Modules/user/user_controller.php
@@ -95,7 +95,7 @@ function user_controller()
 
         if ($route->action == 'timezone' && $session['read']) $result = $user->get_timezone_offset($session['userid']); // to maintain compatibility but in seconds
         if ($route->action == 'gettimezone' && $session['read']) $result = $user->get_timezone($session['userid']);
-        if ($route->action == 'gettimezones' && $session['read']) $result = $user->get_timezones();
+        if ($route->action == 'gettimezones') $result = $user->get_timezones();
         
         if ($route->action == "deleteall" && $session['write']) {
             $route->format = "text";


### PR DESCRIPTION
related to https://github.com/emoncms/graph/issues/83

user module endpoint `user/gettimezones` doesn't expose any personal information so doesn't require authentication before returning a value. removed the check for the `$session['read']` variable.