### PR TITLE
decoded submitted special characters globally

### DIFF
--- a/Modules/admin/admin_controller.php
+++ b/Modules/admin/admin_controller.php
@@ -391,6 +391,7 @@ function admin_controller()
             {
                 $_SESSION['userid'] = intval(get('id'));
                 header("Location: ../user/view");
+                exit();
             }
             
             else if ($route->action == 'setuserfeed' && $session['write'])

--- a/Modules/admin/admin_controller.php
+++ b/Modules/admin/admin_controller.php
@@ -391,7 +391,6 @@ function admin_controller()
             {
                 $_SESSION['userid'] = intval(get('id'));
                 header("Location: ../user/view");
-                exit();
             }
             
             else if ($route->action == 'setuserfeed' && $session['write'])

--- a/core.php
+++ b/core.php
@@ -76,7 +76,7 @@ function view($filepath, array $args = array())
 function get($index)
 {
     $val = null;
-    if (isset($_GET[$index])) $val = $_GET[$index];
+    if (isset($_GET[$index])) $val = rawurldecode($_GET[$index]);
     
     if (get_magic_quotes_gpc()) $val = stripslashes($val);
     return $val;
@@ -85,7 +85,7 @@ function get($index)
 function post($index)
 {
     $val = null;
-    if (isset($_POST[$index])) $val = $_POST[$index];
+    if (isset($_POST[$index])) $val = rawurldecode($_POST[$index]);
     
     if (get_magic_quotes_gpc()) $val = stripslashes($val);
     return $val;


### PR DESCRIPTION
fix #1269 
now using `rawurldecode()` to decode submitted special characters before user logs in.

also cleanly quit the current call using `exit()` once headers set by admin/setuser (not part of this issue  - noticed during testing)
