### PR TITLE
fix / added include_once to allow nav_functions.php to be used in controllers

### DIFF
--- a/index.php
+++ b/index.php
@@ -340,7 +340,7 @@
                 )
             );
 
-            include ("Lib/misc/nav_functions.php");
+            include_once ("Lib/misc/nav_functions.php");
             sortMenu($menu);
             // debugMenu('sidebar');
             


### PR DESCRIPTION
to use the functions within another part of the system (eg Module controller) I needed to modify the index.php to use the `include_once` and not the `include` statement to clear out errors in modules that also use these functions.