### PR TITLE
Feature/test for empty view template

### DIFF
--- a/core.php
+++ b/core.php
@@ -66,10 +66,13 @@ function controller($controller_name)
 
 function view($filepath, array $args = array())
 {
-    extract($args);
-    ob_start();
-    include "$filepath";
-    $content = ob_get_clean();
+    $content = '';
+    if(file_exists($filepath)) {
+        extract($args);
+        ob_start();
+        include "$filepath";
+        $content = ob_get_clean();
+    }
     return $content;
 }
 

--- a/index.php
+++ b/index.php
@@ -340,7 +340,7 @@
                 )
             );
 
-            include ("Lib/misc/nav_functions.php");
+            include_once ("Lib/misc/nav_functions.php");
             sortMenu($menu);
             // debugMenu('sidebar');
             


### PR DESCRIPTION
if the `view()` function is called to render a template and that template does not exist return empty string. currently it returned an error.