### PR TITLE
Feature/issue 1282 log level style

### DIFF
--- a/Modules/admin/admin_controller.php
+++ b/Modules/admin/admin_controller.php
@@ -44,11 +44,7 @@ function admin_controller()
         2 =>'WARN', // default
         3 =>'ERROR'
     );
-    $log_level_css = array(
-        1 =>'danger',
-        2 =>'inverse', // default
-        3 =>'warning'
-    );
+
     $path_to_config = 'settings.php';
     
     if ($session['admin']) {
@@ -108,10 +104,8 @@ function admin_controller()
                     'disk_info'=> Admin::get_mountpoints($system['partitions']),
                     'v' => 2,
                     'log_levels' => $log_levels,
-                    'log_levels_css' => $log_level_css,
                     'log_level'=>$log_level,
                     'log_level_label' => $log_levels[$log_level],
-                    'log_level_css' => $log_level_css[$log_level],
                     'path_to_config'=> $path_to_config
                 );
                 
@@ -454,7 +448,6 @@ function admin_controller()
             else if ($route->action === 'loglevel' && $session['write']) {
                 // current values
                 $success = false;
-                $css_class = $log_level_css[$log_level];
                 $log_level_name = $log_levels[$log_level];
                 $message = '';
 
@@ -473,7 +466,6 @@ function admin_controller()
                                     file_put_contents($path_to_config, $file);
                                     $success = true;
                                     $log_level = $level;
-                                    $css_class = $log_level_css[$level];
                                     $log_level_name = $log_levels[$level];
                                     $log->error("Log level changed: $level");
                                     $message = _('Changes Saved');
@@ -495,7 +487,6 @@ function admin_controller()
 
                 $result = array(
                     'success' => $success,
-                    'css-class' => $css_class,
                     'log-level' => $log_level,
                     'log-level-name' => $log_level_name,
                     'message' => $message

--- a/Modules/admin/admin_main_view.php
+++ b/Modules/admin/admin_main_view.php
@@ -224,19 +224,20 @@ listItem;
         <pre id="logreply-bound"><div id="logreply"></div></pre>
         <?php if(is_writable($path_to_config)) { ?>
         <div id="log-level" class="dropup btn-group">
-            <a class="btn btn-small dropdown-toggle btn-<?php echo $log_level_css?> text-uppercase" data-toggle="dropdown" href="#" title="<?php echo _('Change the logging level') ?>">
+            <a class="btn btn-small dropdown-toggle btn-inverse text-uppercase" data-toggle="dropdown" href="#" title="<?php echo _('Change the logging level') ?>">
             <span class="log-level-name"><?php echo sprintf('Log Level: %s', $log_level_label) ?></span>
             <span class="caret"></span>
             </a>
             <ul class="dropdown-menu dropdown-menu-right">
                 <?php foreach ($log_levels as $key=>$value) {
                     $active = $key === $log_level ? ' active':'';
-                    echo sprintf('<li><a href="#" data-key="%s" class="btn btn-%s %s">%s</a></li>', $key, $log_levels_css[$key], $active, $value);
+                    printf('<li><a href="#" data-key="%s" class="btn %s">%s</a></li>', $key, $active, $value);
                 }?>
+
             </ul>
         </div>
         <?php } else { ?>
-            <span id="log-level" class="btn-small dropdown-toggle btn-<?php echo $log_level_css?> text-uppercase">
+            <span id="log-level" class="btn-small dropdown-toggle btn-inverse text-uppercase">
                 <?php echo sprintf('Log Level: %s', $log_level_label) ?>
             </span>
         <?php } ?>
@@ -833,10 +834,11 @@ $('#log-level ul li a').click(function(event){
     .done(function(response) {
         // make the dropdown toggle show the new setting
         if(response.hasOwnProperty('success') && response.success!==false) {
-            $toggle.removeClass('btn-warning btn-danger btn-inverse').addClass('btn-'+response['css-class']);
             $toggle.find('.log-level-name').text(_('log level: %s').replace('%s',response['log-level-name']));
             // highlight the current dropdown element as active
-            $btn.addClass('active').siblings().removeClass('active');
+            $btn.addClass('active');
+            $btn.parents('li').siblings().find('a').removeClass('active');
+
             notify(_('Log level set to: %s').replace('%s',response['log-level-name']),'success');
         } else {
             notify(_('Log level not set'), 'error', response.hasOwnProperty('message') ? response.message: '');

--- a/Modules/admin/static/admin_styles.css
+++ b/Modules/admin/static/admin_styles.css
@@ -84,13 +84,10 @@ dl.inline > dd {
     right: 0!important;
     left: initial;
 }
-#log-level{
+#log-level {
     position: absolute;
     right: .2rem;
     bottom: 0;
-}
-#log-level .dropdown-menu > li > a {
-    color: #FFF;
 }
 #log-level .dropdown-menu {
     background: 0;
@@ -100,32 +97,21 @@ dl.inline > dd {
     box-shadow: none;
     margin: 0;
 }
-#log-level .dropdown-menu > li > a,
-#log-level .dropdown-menu > li > a{
+#log-level .dropdown-menu .active {
+    font-weight: bold;
+}
+#log-level .dropdown-menu .btn {
+    border: 0;
     border-radius: 0;
-}
-#log-level .dropdown-menu > li:first-child > a{
-    border-radius: .2em .2em 0 0;
-}
-#log-level .dropdown-menu > li:last-child > a{
-    border-radius: 0 0 .2em .2em;
-}
-#log-level .dropdown-menu > li > a:hover,
-#log-level .dropdown-menu > li > a:focus{
     background-image: none;
 }
-#log-level .dropdown-menu > li > a.btn-danger:hover,
-#log-level .dropdown-menu > li > a.btn-danger:focus{
-    background-color: #bd362f;
+#log-level li:first-child .btn {
+    border-radius: .3em .3em 0 0;
 }
-#log-level .dropdown-menu > li > a.btn-inverse:hover,
-#log-level .dropdown-menu > li > a.btn-inverse:focus{
-    background-color: #2E2E2E;
+#log-level li:last-child .btn {
+    border-radius: 0 0 .3em .3em;
 }
-#log-level .dropdown-menu > li > a.btn-warning:hover,
-#log-level .dropdown-menu > li > a.btn-warning:focus{
-    background-color: #f89406;
-}
+
 dl dt{
   padding-left: .25em;
   box-sizing: border-box;

--- a/index.php
+++ b/index.php
@@ -340,7 +340,7 @@
                 )
             );
 
-            include ("Lib/misc/nav_functions.php");
+            include_once ("Lib/misc/nav_functions.php");
             sortMenu($menu);
             // debugMenu('sidebar');
             


### PR DESCRIPTION
fix #1282 

now looks like this if emoncms has write access to `/var/www/emoncms/settings.php`
![delwedd](https://user-images.githubusercontent.com/1466013/58165870-8e813000-7c80-11e9-832c-77a3d92cef36.png)

If you're OK with emoncms having write access to your `settings.php` file, you can allow write access to the file like so:
```
sudo chown pi:www-data /var/www/emoncms/settings.php
chmod g+w /var/www/emoncms/settings.php
```
enabling write access  discussion: https://community.openenergymonitor.org/t/write-to-settings-php-from-api/10897/2