### PR TITLE
only display user menu items to logged in users

### DIFF
--- a/Modules/user/user_menu.php
+++ b/Modules/user/user_menu.php
@@ -1,7 +1,7 @@
 <?php
 
 global $session;
-if($session['userid']>0){
+if($session['read']){
 
     $menu['right'][] = array(
         'text' => _("Add Bookmark"),

--- a/Theme/basic/menu_view.php
+++ b/Theme/basic/menu_view.php
@@ -14,29 +14,13 @@ if (!isset($session['profile'])) {
 ?>
 <?php
 // if not logged in show login button top right
-$nav_layout = $session['read'] ? 'justify-content-between': 'justify-content-end';
+$nav_layout = 'justify-content-between';
 ?>
 <div class="navbar-inner bg-primary text-dark d-flex flex-nowrap <?php echo $nav_layout ?>">
-
-<?php
-if ($session['read']) {
-?>
 
 <ul id="left-nav" class="nav mr-0 d-flex">
 
 <?php
-// $menu['tabs'][] = array(
-//     'title'=> _("Open/Close Sidebar"),
-//     'id' => 'sidebar-toggle',
-//     'href' => '#',
-//     'icon' => 'icon-menu',
-//     'order' => -1,
-//     'li_style' => 'width:0; overflow:hidden; visibility:hidden',
-//     'data'=> array(
-//         'toggle' => 'slide-collapse',
-//         'target' => '#sidebar'
-//     )
-// );
 
 // top level menu icons (MAIN MENU)
 if(!empty($menu['tabs'])) {
@@ -57,8 +41,6 @@ if(!empty($menu['left'])): foreach ($menu['left'] as $item):
 endforeach; endif;
 ?>
 </ul>
-
-<?php } ?>
 
 <ul id="right-nav" class='nav d-flex align-items-stretch mr-0 pull-right'>
 

--- a/Theme/basic/theme.php
+++ b/Theme/basic/theme.php
@@ -40,7 +40,9 @@ if (!in_array($themecolor, ["blue", "sun", "standard"])) {
     <link href="<?php echo $path; ?>Lib/misc/sidebar.css?v=<?php echo $v; ?>" rel="stylesheet">
 
     <script type="text/javascript" src="<?php echo $path; ?>Lib/jquery-1.11.3.min.js"></script>
+    <?php if ($session['read']): ?>
     <script type="text/javascript" src="<?php echo $path; ?>Lib/misc/sidebar.js?v=<?php echo $v; ?>"></script>
+    <?php endif; ?>
 
     <script>
         window.onerror = function(msg, source, lineno, colno, error) {


### PR DESCRIPTION
show top nav on login screen
stop sidebar.js from loading for non-logged in users

fix #1312 

public pages now show the same top nav as the login page:
![delwedd](https://user-images.githubusercontent.com/1466013/59602879-d53b3c00-90ff-11e9-9c60-1058c0b16c97.png)
