### PR TITLE
Updated pi-model.json with new rpi models

### DIFF
--- a/Modules/admin/pi-model.json
+++ b/Modules/admin/pi-model.json
@@ -1,265 +1,301 @@
 [
  {
-   "date": "20190130",
-   "from": "https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md"
+   "date": "2019-06-24",
+   "source": "https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md",
+   "generator": "https://github.com/gablau/rpi-revision-codes-utility"
  },
  {
    "Code": "0002",
    "Model": "B",
    "Revision": "1.0",
-   "RAM": "256 MB",
+   "RAM": "256MB",
    "Manufacturer": "Egoman"
  },
  {
    "Code": "0003",
    "Model": "B",
    "Revision": "1.0",
-   "RAM": "256 MB",
+   "RAM": "256MB",
    "Manufacturer": "Egoman"
  },
  {
    "Code": "0004",
    "Model": "B",
    "Revision": "2.0",
-   "RAM": "256 MB",
+   "RAM": "256MB",
    "Manufacturer": "Sony UK"
  },
  {
    "Code": "0005",
    "Model": "B",
    "Revision": "2.0",
-   "RAM": "256 MB",
+   "RAM": "256MB",
    "Manufacturer": "Qisda"
  },
  {
    "Code": "0006",
    "Model": "B",
    "Revision": "2.0",
-   "RAM": "256 MB",
+   "RAM": "256MB",
    "Manufacturer": "Egoman"
  },
  {
    "Code": "0007",
    "Model": "A",
    "Revision": "2.0",
-   "RAM": "256 MB",
+   "RAM": "256MB",
    "Manufacturer": "Egoman"
  },
  {
    "Code": "0008",
    "Model": "A",
    "Revision": "2.0",
-   "RAM": "256 MB",
+   "RAM": "256MB",
    "Manufacturer": "Sony UK"
  },
  {
    "Code": "0009",
    "Model": "A",
    "Revision": "2.0",
-   "RAM": "256 MB",
+   "RAM": "256MB",
    "Manufacturer": "Qisda"
  },
  {
    "Code": "000d",
    "Model": "B",
    "Revision": "2.0",
-   "RAM": "512 MB",
+   "RAM": "512MB",
    "Manufacturer": "Egoman"
  },
  {
    "Code": "000e",
    "Model": "B",
    "Revision": "2.0",
-   "RAM": "512 MB",
+   "RAM": "512MB",
    "Manufacturer": "Sony UK"
  },
  {
    "Code": "000f",
    "Model": "B",
    "Revision": "2.0",
-   "RAM": "512 MB",
+   "RAM": "512MB",
    "Manufacturer": "Egoman"
  },
  {
    "Code": "0010",
    "Model": "B+",
-   "Revision": "1.0",
-   "RAM": "512 MB",
+   "Revision": "1.2",
+   "RAM": "512MB",
    "Manufacturer": "Sony UK"
  },
  {
    "Code": "0011",
    "Model": "CM1",
    "Revision": "1.0",
-   "RAM": "512 MB",
+   "RAM": "512MB",
    "Manufacturer": "Sony UK"
  },
  {
    "Code": "0012",
    "Model": "A+",
    "Revision": "1.1",
-   "RAM": "256 MB",
+   "RAM": "256MB",
    "Manufacturer": "Sony UK"
  },
  {
    "Code": "0013",
    "Model": "B+",
    "Revision": "1.2",
-   "RAM": "512 MB",
+   "RAM": "512MB",
    "Manufacturer": "Embest"
  },
  {
    "Code": "0014",
    "Model": "CM1",
    "Revision": "1.0",
-   "RAM": "512 MB",
+   "RAM": "512MB",
    "Manufacturer": "Embest"
  },
  {
    "Code": "0015",
    "Model": "A+",
    "Revision": "1.1",
-   "RAM": "256 MB / 512 MB",
+   "RAM": "256MB/512MB",
    "Manufacturer": "Embest"
  },
  {
    "Code": "900021",
    "Model": "A+",
    "Revision": "1.1",
-   "RAM": "512 MB",
+   "RAM": "512MB",
    "Manufacturer": "Sony UK"
  },
  {
    "Code": "900032",
    "Model": "B+",
    "Revision": "1.2",
-   "RAM": "512 MB",
+   "RAM": "512MB",
    "Manufacturer": "Sony UK"
  },
  {
    "Code": "900092",
    "Model": "Zero",
    "Revision": "1.2",
-   "RAM": "512 MB",
+   "RAM": "512MB",
    "Manufacturer": "Sony UK"
  },
  {
    "Code": "900093",
    "Model": "Zero",
    "Revision": "1.3",
-   "RAM": "512 MB",
+   "RAM": "512MB",
    "Manufacturer": "Sony UK"
  },
  {
    "Code": "9000c1",
    "Model": "Zero W",
    "Revision": "1.1",
-   "RAM": "512 MB",
+   "RAM": "512MB",
    "Manufacturer": "Sony UK"
  },
  {
    "Code": "9020e0",
    "Model": "3A+",
    "Revision": "1.0",
-   "RAM": "512 MB",
+   "RAM": "512MB",
    "Manufacturer": "Sony UK"
  },
  {
    "Code": "920092",
    "Model": "Zero",
    "Revision": "1.2",
-   "RAM": "512 MB",
+   "RAM": "512MB",
    "Manufacturer": "Embest"
  },
  {
    "Code": "920093",
    "Model": "Zero",
    "Revision": "1.3",
-   "RAM": "512 MB",
+   "RAM": "512MB",
    "Manufacturer": "Embest"
+ },
+ {
+   "Code": "900061",
+   "Model": "CM",
+   "Revision": "1.1",
+   "RAM": "512MB",
+   "Manufacturer": "Sony UK"
  },
  {
    "Code": "a01040",
    "Model": "2B",
    "Revision": "1.0",
-   "RAM": "1 GB",
+   "RAM": "1GB",
    "Manufacturer": "Sony UK"
  },
  {
    "Code": "a01041",
    "Model": "2B",
    "Revision": "1.1",
-   "RAM": "1 GB",
+   "RAM": "1GB",
    "Manufacturer": "Sony UK"
  },
  {
    "Code": "a02082",
    "Model": "3B",
    "Revision": "1.2",
-   "RAM": "1 GB",
+   "RAM": "1GB",
    "Manufacturer": "Sony UK"
  },
  {
    "Code": "a020a0",
    "Model": "CM3",
    "Revision": "1.0",
-   "RAM": "1 GB",
+   "RAM": "1GB",
    "Manufacturer": "Sony UK"
  },
  {
    "Code": "a020d3",
    "Model": "3B+",
    "Revision": "1.3",
-   "RAM": "1 GB",
+   "RAM": "1GB",
    "Manufacturer": "Sony UK"
  },
  {
    "Code": "a21041",
    "Model": "2B",
    "Revision": "1.1",
-   "RAM": "1 GB",
+   "RAM": "1GB",
    "Manufacturer": "Embest"
  },
  {
    "Code": "a22042",
    "Model": "2B (with BCM2837)",
    "Revision": "1.2",
-   "RAM": "1 GB",
+   "RAM": "1GB",
    "Manufacturer": "Embest"
  },
  {
    "Code": "a22082",
    "Model": "3B",
    "Revision": "1.2",
-   "RAM": "1 GB",
+   "RAM": "1GB",
    "Manufacturer": "Embest"
- }, 
+ },
  {
    "Code": "a220a0",
    "Model": "CM3",
    "Revision": "1.0",
-   "RAM": "1 GB",
+   "RAM": "1GB",
    "Manufacturer": "Embest"
  },
  {
    "Code": "a32082",
    "Model": "3B",
    "Revision": "1.2",
-   "RAM": "1 GB",
+   "RAM": "1GB",
    "Manufacturer": "Sony Japan"
  },
  {
    "Code": "a52082",
    "Model": "3B",
    "Revision": "1.2",
-   "RAM": "1 GB",
+   "RAM": "1GB",
    "Manufacturer": "Stadium"
+ },
+ {
+   "Code": "a22083",
+   "Model": "3B",
+   "Revision": "1.3",
+   "RAM": "1GB",
+   "Manufacturer": "Embest"
  },
  {
    "Code": "a02100",
    "Model": "CM3+",
    "Revision": "1.0",
-   "RAM": "1 GB",
+   "RAM": "1GB",
+   "Manufacturer": "Sony UK"
+ },
+ {
+   "Code": "a03111",
+   "Model": "4B",
+   "Revision": "1.1",
+   "RAM": "1GB",
+   "Manufacturer": "Sony UK"
+ },
+ {
+   "Code": "b03111",
+   "Model": "4B",
+   "Revision": "1.1",
+   "RAM": "2GB",
+   "Manufacturer": "Sony UK"
+ },
+ {
+   "Code": "c03111",
+   "Model": "4B",
+   "Revision": "1.1",
+   "RAM": "4GB",
    "Manufacturer": "Sony UK"
  }
 ]


### PR DESCRIPTION
Updated pi-model.json with new rpi models, of course detect the new Raspberry Pi 4 too!
If you need it here is the generator: [https://github.com/gablau/rpi-revision-codes-utility](https://github.com/gablau/rpi-revision-codes-utility)