### PR TITLE
fix feed delete modal layout

### DIFF
--- a/Modules/feed/Views/feedlist_view.php
+++ b/Modules/feed/Views/feedlist_view.php
@@ -312,7 +312,7 @@ body{padding:0!important}
         </h3>
     </div>
     <div class="modal-body">
-        <div class="clearfix">
+        <div class="clearfix d-flex row">
             <div id="clearContainer" class="span6">
                 <div style="min-height:12.1em; position:relative" class="well well-small">
                     <h4 class="text-info"><?php echo _('Clear') ?>:</h4>


### PR DESCRIPTION
the feed delete modal was incorrectly aligned

![delwedd](https://user-images.githubusercontent.com/1466013/61036821-c1fb5380-a3c1-11e9-9af2-49fdfb374b11.png)


now looks like this:
![delwedd](https://user-images.githubusercontent.com/1466013/61036886-e7885d00-a3c1-11e9-84dd-02064f43d5a7.png)
