### PR TITLE
added apache 2.4 access restriction to php-info.php

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -211,9 +211,9 @@ AddDefaultCharset utf-8
 
 # protect phpinfo, only allow localhost and local network access
 <Files php-info.php>
-	Order Deny,Allow
-	Deny from all
-	Allow from 10
-	Allow from 172
-	Allow from 192
+    # LOCAL ACCESS ONLY
+    # Require local 
+
+    # LOCAL AND LAN ACCESS
+    Require ip 10 172 192.168
 </Files>


### PR DESCRIPTION
fix #1220 
I've tested this on my laptop using the loopback network device... other systems may be different? 
Feedback of this pull request failing to restrict access to the `php-info.php` would be usefull (along with host machine details) *I'm testing on a dell laptop with ubuntu 18.04 running apache 2.4*


thanks @djh42 for the `.htaccess` code:
> https://community.openenergymonitor.org/t/installing-emoncms-redis-problem/10323/47
```
<Files php-info.php>
    Require ip 10 172 192.168
</Files>
```
This requires any requests to `php-info.php` come from an IP address starting with:
```
- 10.❓.❓.❓
- 172.❓.❓.❓
- 192.168.❓.❓
```
this covers most local networks and local machine access.

## Testing
As I'm on the local network and have one of the "whitelist" addresses I don't see the restriction. There might be a better way to test this (comments appreciated), however I use the ubuntu `curl` and `ip` commands to do this.*(unsure of how to test on other platforms)*

To test this worked I had to add a temporary "blacklist" IP address to my system:
```
sudo ip address add 169.254.1.0/24 dev lo
```
then I requested `php-info.php` using this new ip address: *(probably possible in web browser?)*
```
curl --interface 169.254.1.0 -I http://localhost/emoncms/php-info.php
```
## Responses
blocked requests should get this response:
```
HTTP/1.1 403 Forbidden
```

successful requests should get this response:
```
HTTP/1.1 200 OK
```