### PR TITLE
replaced hard coded limit for variable in settings.php

### DIFF
--- a/Modules/feed/engine/CassandraEngine.php
+++ b/Modules/feed/engine/CassandraEngine.php
@@ -168,6 +168,8 @@ class CassandraEngine implements engine_methods
      */
     public function get_data($feedid,$start,$end,$interval,$skipmissing,$limitinterval)
     {
+        global $max_datapoints;
+
         $feedid = (int) $feedid;
         $start = round($start/1000);
         $end = round($end/1000);
@@ -177,7 +179,7 @@ class CassandraEngine implements engine_methods
         if ($interval<1) $interval = 1;
         // Maximum request size
         $req_dp = round(($end-$start) / $interval);
-        if ($req_dp > DATAPOINT_LIMIT) return array('success'=>false, 'message'=>"Request datapoint limit reached (" . DATAPOINT_LIMIT . "), increase request interval or time range, requested datapoints = $req_dp");
+        if ($req_dp > $max_datapoints) return array('success'=>false, 'message'=>"Request datapoint limit reached (" . $max_datapoints . "), increase request interval or time range, requested datapoints = $req_dp");
 
         $day_range = range($this->unixtoday($start), $this->unixtoday($end));
         $data = array();

--- a/Modules/feed/engine/CassandraEngine.php
+++ b/Modules/feed/engine/CassandraEngine.php
@@ -177,7 +177,7 @@ class CassandraEngine implements engine_methods
         if ($interval<1) $interval = 1;
         // Maximum request size
         $req_dp = round(($end-$start) / $interval);
-        if ($req_dp>8928) return array('success'=>false, 'message'=>"Request datapoint limit reached (8928), increase request interval or time range, requested datapoints = $req_dp");
+        if ($req_dp > DATAPOINT_LIMIT) return array('success'=>false, 'message'=>"Request datapoint limit reached (" . DATAPOINT_LIMIT . "), increase request interval or time range, requested datapoints = $req_dp");
 
         $day_range = range($this->unixtoday($start), $this->unixtoday($end));
         $data = array();

--- a/Modules/feed/engine/PHPFina.php
+++ b/Modules/feed/engine/PHPFina.php
@@ -395,7 +395,7 @@ class PHPFina implements engine_methods
         if ($end<=$start) return array('success'=>false, 'message'=>"request end time before start time");
         // Maximum request size
         $req_dp = round(($end-$start) / $interval);
-        if ($req_dp>8928) return array('success'=>false, 'message'=>"Request datapoint limit reached (8928), increase request interval or time range, requested datapoints = $req_dp");
+        if ($req_dp > DATAPOINT_LIMIT) return array('success'=>false, 'message'=>"Request datapoint limit reached (" . DATAPOINT_LIMIT . "), increase request interval or time range, requested datapoints = $req_dp");
         
         // If meta data file does not exist exit
         if (!$meta = $this->get_meta($name)) return array('success'=>false, 'message'=>"Error reading meta data feedid=$name");
@@ -949,7 +949,7 @@ class PHPFina implements engine_methods
         if ($interval<1) $interval = 1;
         // Maximum request size
         $req_dp = round(($end-$start) / $interval);
-        if ($req_dp>8928) return array('success'=>false, 'message'=>"Request datapoint limit reached (8928), increase request interval or time range, requested datapoints = $req_dp");
+        if ($req_dp > DATAPOINT_LIMIT) return array('success'=>false, 'message'=>"Request datapoint limit reached (" . DATAPOINT_LIMIT . "), increase request interval or time range, requested datapoints = $req_dp");
         
         $layer_interval = 0;
         //if ($interval>=600) $layer_interval = 600;

--- a/Modules/feed/engine/PHPFina.php
+++ b/Modules/feed/engine/PHPFina.php
@@ -383,6 +383,8 @@ class PHPFina implements engine_methods
     */
     public function get_data($name,$start,$end,$interval,$skipmissing,$limitinterval)
     {
+        global $max_datapoints;
+        
         $skipmissing = (int) $skipmissing;
         $limitinterval = (int) $limitinterval;
         $start = intval($start/1000);
@@ -395,7 +397,7 @@ class PHPFina implements engine_methods
         if ($end<=$start) return array('success'=>false, 'message'=>"request end time before start time");
         // Maximum request size
         $req_dp = round(($end-$start) / $interval);
-        if ($req_dp > DATAPOINT_LIMIT) return array('success'=>false, 'message'=>"Request datapoint limit reached (" . DATAPOINT_LIMIT . "), increase request interval or time range, requested datapoints = $req_dp");
+        if ($req_dp > $max_datapoints) return array('success'=>false, 'message'=>"Request datapoint limit reached (" . $max_datapoints . "), increase request interval or time range, requested datapoints = $req_dp");
         
         // If meta data file does not exist exit
         if (!$meta = $this->get_meta($name)) return array('success'=>false, 'message'=>"Error reading meta data feedid=$name");
@@ -941,6 +943,8 @@ class PHPFina implements engine_methods
         
     public function get_average($id,$start,$end,$interval)
     {
+        global $max_datapoints;
+
         $start = intval($start/1000);
         $end = intval($end/1000);
         $interval= (int) $interval;
@@ -949,7 +953,7 @@ class PHPFina implements engine_methods
         if ($interval<1) $interval = 1;
         // Maximum request size
         $req_dp = round(($end-$start) / $interval);
-        if ($req_dp > DATAPOINT_LIMIT) return array('success'=>false, 'message'=>"Request datapoint limit reached (" . DATAPOINT_LIMIT . "), increase request interval or time range, requested datapoints = $req_dp");
+        if ($req_dp > $max_datapoints) return array('success'=>false, 'message'=>"Request datapoint limit reached (" . $max_datapoints . "), increase request interval or time range, requested datapoints = $req_dp");
         
         $layer_interval = 0;
         //if ($interval>=600) $layer_interval = 600;

--- a/Modules/feed/engine/PHPTimeSeries.php
+++ b/Modules/feed/engine/PHPTimeSeries.php
@@ -232,7 +232,7 @@ class PHPTimeSeries implements engine_methods
         if ($end<=$start) return array("success"=>false, "message"=>"request end time before start time");
         // Maximum request size
         $req_dp = round(($end-$start) / $interval);
-        if ($req_dp>8928) return array("success"=>false, "message"=>"request datapoint limit reached (8928), increase request interval or time range, requested datapoints = $req_dp");
+        if ($req_dp > DATAPOINT_LIMIT) return array("success"=>false, "message"=>"request datapoint limit reached (" . DATAPOINT_LIMIT . "), increase request interval or time range, requested datapoints = $req_dp");
         
         $fh = fopen($this->dir."feed_$feedid.MYD", 'rb');
         $filesize = filesize($this->dir."feed_$feedid.MYD");

--- a/Modules/feed/engine/PHPTimeSeries.php
+++ b/Modules/feed/engine/PHPTimeSeries.php
@@ -222,6 +222,8 @@ class PHPTimeSeries implements engine_methods
     */
     public function get_data($feedid,$start,$end,$interval,$skipmissing,$limitinterval)
     {
+        global $max_datapoints;
+
         $start = intval($start/1000);
         $end = intval($end/1000);
         $interval= (int) $interval;
@@ -232,7 +234,7 @@ class PHPTimeSeries implements engine_methods
         if ($end<=$start) return array("success"=>false, "message"=>"request end time before start time");
         // Maximum request size
         $req_dp = round(($end-$start) / $interval);
-        if ($req_dp > DATAPOINT_LIMIT) return array("success"=>false, "message"=>"request datapoint limit reached (" . DATAPOINT_LIMIT . "), increase request interval or time range, requested datapoints = $req_dp");
+        if ($req_dp > $max_datapoints) return array("success"=>false, "message"=>"request datapoint limit reached (" . $max_datapoints . "), increase request interval or time range, requested datapoints = $req_dp");
         
         $fh = fopen($this->dir."feed_$feedid.MYD", 'rb');
         $filesize = filesize($this->dir."feed_$feedid.MYD");

--- a/default.emonpi.settings.php
+++ b/default.emonpi.settings.php
@@ -75,7 +75,8 @@
     // Max number of allowed different inputs per user. For limiting garbage rf data
     $max_node_id_limit = 32;
     // Datapoint limit. Increasing this effects system performance but allows for more data points to be read from one api call
-    define('DATAPOINT_LIMIT', 8928);
+    $max_datapoints = 8928;
+
 
 //5 #### User Interface settings
     // gettext  translations are found under each Module's locale directory

--- a/default.emonpi.settings.php
+++ b/default.emonpi.settings.php
@@ -74,7 +74,8 @@
 
     // Max number of allowed different inputs per user. For limiting garbage rf data
     $max_node_id_limit = 32;
-
+    // Datapoint limit. Increasing this effects system performance but allows for more data points to be read from one api call
+    define('DATAPOINT_LIMIT', 8928);
 
 //5 #### User Interface settings
     // gettext  translations are found under each Module's locale directory

--- a/default.settings.php
+++ b/default.settings.php
@@ -78,6 +78,8 @@
 
     // Max number of allowed different inputs per user. For limiting garbage rf data
     $max_node_id_limit = 32;
+    // Datapoint limit. Increasing this effects system performance but allows for more data points to be read from one api call
+    define('DATAPOINT_LIMIT', 8928);
 
 
 //5 #### User Interface settings

--- a/default.settings.php
+++ b/default.settings.php
@@ -79,7 +79,7 @@
     // Max number of allowed different inputs per user. For limiting garbage rf data
     $max_node_id_limit = 32;
     // Datapoint limit. Increasing this effects system performance but allows for more data points to be read from one api call
-    define('DATAPOINT_LIMIT', 8928);
+    $max_datapoints = 8928;
 
 
 //5 #### User Interface settings

--- a/process_settings.php
+++ b/process_settings.php
@@ -107,6 +107,9 @@ if(file_exists(dirname(__FILE__)."/settings.php"))
     if (!isset($feed_settings['engines_hidden'])) $error_out .= "<p>feed setting for engines_hidden is not configured, check settings: settings['engines_hidden']";
 
     if (!isset($feed_settings['csvdownloadlimit_mb'])) $feed_settings['csvdownloadlimit_mb'] = 10; // default
+
+    if (!isset($max_datapoints)) $max_datapoints = 8928; // default
+
     if (!isset($data_sampling)) $data_sampling = true; // default
 
     if (!isset($fullwidth)) $fullwidth = false;


### PR DESCRIPTION
fix #1184 

Added `DATAPOINT_LIMIT` to `default.settings.php` & `default.emonpi.settings.php`

Replaced fixed value (`8928`) with `DATAPOINT_LIMIT` in **PHPFina.php**, **PHPTimeSeries.php** and **CassandraEngine.php**

[screenshot showing datapoint limit. limit has been incresed to 9999 in `settings.php`]
![image](https://user-images.githubusercontent.com/1466013/62271048-84716f80-b42f-11e9-8b7c-3787f368a160.png)
