### PR TITLE
added new option to realtime graph in dashboard

### DIFF
--- a/Modules/vis/vis_langjs.php
+++ b/Modules/vis/vis_langjs.php
@@ -129,4 +129,5 @@ LANG_JS_VIS["Units to show"] = '<?php echo addslashes(dgettext('vis_messages',"U
 LANG_JS_VIS["Week"] = '<?php echo addslashes(dgettext('vis_messages',"Week")); ?>';
 LANG_JS_VIS["Year"] = '<?php echo addslashes(dgettext('vis_messages',"Year")); ?>';
 LANG_JS_VIS["Zoom"] = '<?php echo addslashes(dgettext('vis_messages',"Zoom")); ?>';
+LANG_JS_VIS["Display power as kW"] = '<?php echo addslashes(dgettext('vis_messages',"Display power as kW")); ?>';
 //END 

--- a/Modules/vis/vis_object.php
+++ b/Modules/vis/vis_object.php
@@ -20,6 +20,7 @@
         'realtime' => array('label'=>dgettext('vis_messages','RealTime'), 'options'=>array(
             array('feedid',dgettext('vis_messages','feed'),1),
             array('colour',dgettext('vis_messages','colour'),9,'EDC240'),
+            array('kw',dgettext('vis_messages','kW'),4,false),
             )
         ),
         

--- a/Modules/vis/visualisations/realtime.php
+++ b/Modules/vis/visualisations/realtime.php
@@ -1,4 +1,4 @@
- <?php
+<?php
 /*
    All Emoncms code is released under the GNU Affero General Public License.
    See COPYRIGHT.txt and LICENSE.txt.
@@ -35,6 +35,7 @@
     var path = "<?php echo $path; ?>";
     var apikey = "<?php echo $apikey; ?>";  
     var embed = <?php echo $embed; ?>;
+    var is_kw = <?php echo $kw === 1 ? 'true': 'false'; ?>;
     var data = [];
     var timerget;
     var fast_update_fps = 10;
@@ -60,7 +61,7 @@
     var end = now;                     // end time
     var interval = parseInt(((end*0.001+10) - (start*0.001-10)) / 800);
     data = get_feed_data(feedid,(start-10000),(end+10000),interval,1,1);
-    
+
     timerget = setInterval(getdp,7500);
     gpu_fast();
     //setInterval(fast,150);
@@ -98,16 +99,25 @@
         dataType: 'json', 
         async: true, 
         success: function(result) {
-          if (data.length==0 || data[data.length-1][0]!=result.time*1000) {
+          if (data[data.length-1] && data.length==0 || data[data.length-1][0]!=result.time*1000) {
             data.push([result.time*1000,parseFloat(result.value)]);
           }
-          if (data.length>0 && data[1][0]<(start)) data.splice(0, 1);
+          if (data.length>0 && data[1] && data[1][0]<(start)) data.splice(0, 1);
           data.sort();
         }
      });
     }
 
     function plot(){
+        if(is_kw) {
+            var word = 'converted';
+            for(n in data) {
+                if(data[n] && data[n][1] && typeof data[n][2] === 'undefined' && typeof data[n][2] !== word) {
+                    data[n][1] = data[n][1] / 1000;
+                    data[n][2] = word
+                }
+            }
+        }
       $.plot(graph,[{data: data, color: plotColour}],
       {
         canvas: true,

--- a/Modules/vis/widget/vis_render.js
+++ b/Modules/vis/widget/vis_render.js
@@ -16,11 +16,11 @@ function vis_widgetlist(){
     {
       "offsetx":0,"offsety":0,"width":400,"height":300,
       "menu":"Visualisations",
-      "options":["feedid","colour","initzoom"],
-      "optionstype":["feedid","colour_picker","dropbox"],
-      "optionsname":[_Tr_Vis("Feed"),_Tr_Vis("Colour"),_Tr_Vis("Zoom")],
-      "optionshint":[_Tr_Vis("Feed source"),_Tr_Vis("Line colour in hex. Blank is use default."),_Tr_Vis("Default visible window interval")],
-      "optionsdata": [ , , [["1", "1 "+_Tr_Vis("minute")],["5", "5 "+_Tr_Vis("minutes")],["15", "15 "+_Tr_Vis("minutes")],["30", "30 "+_Tr_Vis("minutes")],["60", "1 "+ _Tr_Vis("hour")]] ],
+      "options":["feedid","colour","initzoom","kw"],
+      "optionstype":["feedid","colour_picker","dropbox","boolean"],
+      "optionsname":[_Tr_Vis("Feed"),_Tr_Vis("Colour"),_Tr_Vis("Zoom"),'kW'],
+      "optionshint":[_Tr_Vis("Feed source"),_Tr_Vis("Line colour in hex. Blank is use default."),_Tr_Vis("Default visible window interval"),_Tr_Vis("Display power as kW")],
+      "optionsdata": [ , , [["1", "1 "+_Tr_Vis("minute")],["5", "5 "+_Tr_Vis("minutes")],["15", "15 "+_Tr_Vis("minutes")],["30", "30 "+_Tr_Vis("minutes")],["60", "1 "+ _Tr_Vis("hour")]], ],
       "html":""
     },
 


### PR DESCRIPTION
added translation placeholder label "display as kw"
added default false in $visualisations array() vis_object.php
passed the $is_kw property to the realtime embed
divided data value by 1000 if $is_kw == true

fix #1394 

![display-realtime-as-kw](https://user-images.githubusercontent.com/1466013/64124459-fb878400-cd9e-11e9-8f52-8dda3a47b741.gif)

original issue was posted in the `dashboard` repository
related to emoncms/dashboard#230