### PR TITLE
bumped css version

### DIFF
--- a/Theme/basic/embed.php
+++ b/Theme/basic/embed.php
@@ -10,7 +10,7 @@
   http://openenergymonitor.org
 */
 global $path,$theme,$themecolor;
-$v = 7;
+$v = 8;
 if (!is_dir("Theme/".$theme)) $theme = "basic";
 if (!in_array($themecolor, ["blue", "sun", "standard"])) $themecolor = "standard";
 ?>


### PR DESCRIPTION
original issue was posted in the `app` repository.
related to https://github.com/emoncms/app/issues/95

I've "bumped" the css version to clear any cached stylesheets. I cannot re-produce the error as the "old" css has not been cached on my laptop

my screenshot has no data.. however you do see that the layout and text colours are correct:
![delwedd](https://user-images.githubusercontent.com/1466013/64125240-44403c80-cda1-11e9-9021-10e804ea01bd.png)
