### PR TITLE
removed rpi SoC from admin view

### DIFF
--- a/Modules/admin/admin_main_view.php
+++ b/Modules/admin/admin_main_view.php
@@ -376,7 +376,7 @@ listItem;
         <h4 class="text-info text-uppercase border-top pt-2 mt-0 px-1"><?php echo _('Pi'); ?></h4>
         <dl class="row">
             <?php echo row(sprintf('<span class="align-self-center">%s</span>',_('Model')), $rpi_info['model'].'<div>'.RebootBtn().ShutdownBtn().'</div>','d-flex','d-flex align-items-center justify-content-between') ?>
-            <?php echo row(_('SoC'), $rpi_info['hw']) ?>
+            <!-- <?php echo row(_('SoC'), $rpi_info['hw']) ?> -->
             <?php echo row(_('Serial num.'), strtoupper(ltrim($rpi_info['sn'], '0'))) ?>
             <?php echo row(_('Temperature'), sprintf('%s - %s', $rpi_info['cputemp'], $rpi_info['gputemp'])) ?>
             <?php echo row(_('emonpiRelease'), $rpi_info['emonpiRelease']) ?>

--- a/Modules/admin/admin_model.php
+++ b/Modules/admin/admin_model.php
@@ -201,12 +201,13 @@ class Admin {
 
     /**
      * get an array of raspberry pi properites
-     *
-     * @return array has keys hw,rev,sn,model
+     * 
+     * @see: SoC 'hw' now not required - https://github.com/emoncms/emoncms/issues/1364
+     * @return array has keys [hw,]rev,sn,model     * @return array has keys hw,rev,sn,model
      */
     public static function get_rpi_info() {
         // create empty array with all the required keys
-        $rpi_info = array_map(function($n) {return '';},array_flip(explode(',','hw,rev,sn,model,emonpiRelease,cputemp,gputemp,currentfs')));
+        $rpi_info = array_map(function($n) {return '';},array_flip(explode(',','rev,sn,model,emonpiRelease,cputemp,gputemp,currentfs')));
         // exit with empty array if not a raspberry pi
         if ( !Admin::is_Pi()) return $rpi_info;
         // add the rpi details
@@ -226,7 +227,7 @@ class Admin {
             preg_match_all('/^(revision|serial|hardware)\\s*: (.*)/mi', file_get_contents("/proc/cpuinfo"), $matches);
             $matches = array_filter($matches);
             if(!empty($matches)) {
-                $rpi_info['hw'] = "Broadcom ".$matches[2][0];
+                // $rpi_info['hw'] = "Broadcom ".$matches[2][0];
                 $rpi_info['rev'] = $matches[2][1];
                 $rpi_info['sn'] = $matches[2][2];
                 $rpi_info['model'] = '';


### PR DESCRIPTION
fix #1364 
- removed 'hw' from `admin_model->get_rpi_info()`
- commented out the line in `admin_main_view()`

[screenshot of admin screen with raspberry pi's SoC removed]
![image](https://user-images.githubusercontent.com/1466013/64322673-f3a42b80-cfba-11e9-96a8-c2ca117db003.png)

> "...what might be useful is to have the RAM on a separate line..."
> @pb66, https://github.com/emoncms/emoncms/issues/1364


@pb66 - I haven't broken out the RAM from the RPi Model name as there is already a much more detailed Memory section in the admin view:
![image](https://user-images.githubusercontent.com/1466013/64322777-1f271600-cfbb-11e9-8baa-727bf7cee652.png)

Please reply if you think the work is still required to split the lines by Model Name/Memory