### PR TITLE
Feature/global js path

### DIFF
--- a/Lib/emoncms.js
+++ b/Lib/emoncms.js
@@ -13,7 +13,7 @@
 "use strict";
 
 var _SETTINGS = {
-    show_errors: true // false to allow errors to be handled by browser developer console
+    showErrors: true // false to allow errors to be handled by browser developer console
 }
 
 /**
@@ -24,10 +24,10 @@ var _SETTINGS = {
  * each <script> is loaded in order so this <script> would always be the last one in the parent <html>
  */
 if(!document.currentScript) {
-    document.currentScript = (function() {
-        var scripts = document.getElementsByTagName('script');
+    document.currentScript = (function () { 
+        var scripts = document.getElementsByTagName("script");
         return scripts[scripts.length - 1];
-    })();
+    }());
 }
 /**
  * Set the passed path as a constant that cannot be changed by other scripts
@@ -42,7 +42,7 @@ if(!document.currentScript) {
  */
 var path = (function() {
     // if [data-path] not in initial <script> tag, this file is in the /Lib directory
-    const filePath = 'Lib/emoncms.js'
+    const filePath = "Lib/emoncms.js"
     var _path = document.currentScript.dataset.path
     /**
      * remove the filePath from given url
@@ -50,68 +50,70 @@ var path = (function() {
      * @returns url and path of emoncms system
      */
     function getPathFromScript(src) {
-        var regex = new RegExp('(.*)' + filePath)
-        var match = src.match(regex)
-        return match[1]
+        var regex = new RegExp("(.*)" + filePath);
+        var match = src.match(regex);
+        return match[1];
     }
     // if path not set as [data-path] of <script> tag get the path from emoncms.js url
     // @todo: more testing ond different devices/browsers
     if (!_path) {
-        _path = getPathFromScript(document.currentScript.src)
+        _path = getPathFromScript(document.currentScript.src);
     }
-    return _path
+    return _path;
 })();
 
 // on JQuery Ready...
 $(function(){
     // trigger jquery "window.resized" custom event after debounce delay
-    var resizeTimeout = false
+    var resizeTimeout = false;
     window.addEventListener('resize', function(event) {
         clearTimeout(resizeTimeout)
         resizeTimeout = setTimeout(function() {
-            $.event.trigger('window.resized')
+            $.event.trigger("window.resized");
         }, 200);
     })
-})
+});
 
 // Display alert if js error encountered
 window.onerror = function(msg, source, lineno, colno, error) {
-    if (_SETTINGS && !_SETTINGS.show_errors) return false;
-    if (msg.toLowerCase().indexOf("script error") > -1) {
-        alert('Script Error: See Browser Console for Detail');
-    }
-    else {
-        // REMOVE API KEY FROM ALERT
-        // ----------------------------
-        var maskedSource = source
-        var pattern = /(([\?&])?apikey=)([\w]*)/
-        // pattern match result examples:
-        //  0 = ?apikey=abc123
-        //  1 = ?apikey=
-        //  2 = ?
-        //  3 = abc123
-        var match = source.match(pattern)
-        if (match) {
-            // if apikey first parameter replace with '?'
-            // if apikey not first parameter replace with ''
-            if(match[2]==='&') {
-                maskedSource = source.replace(match[0], '')
-            } else {
-                maskedSource = source.replace(match[0], '?')
+    if (_SETTINGS && !_SETTINGS.showErrors) {
+        return false;
+    } else {
+        if (msg.toLowerCase().indexOf("script error") > -1) {
+            alert("Script Error: See Browser Console for Detail");
+        } else {
+            // REMOVE API KEY FROM ALERT
+            // ----------------------------
+            var maskedSource = source;
+            var pattern = /(([\?&])?apikey=)([\w]*)/;
+            // pattern match result examples:
+            //  0 = ?apikey=abc123
+            //  1 = ?apikey=
+            //  2 = ?
+            //  3 = abc123
+            var match = source.match(pattern);
+            if (match) {
+                // if apikey first parameter replace with '?'
+                // if apikey not first parameter replace with ''
+                if(match[2]==="&") {
+                    maskedSource = source.replace(match[0], "")
+                } else {
+                    maskedSource = source.replace(match[0], "?")
+                }
             }
+            var messages = [
+                "EmonCMS Error",
+                '-------------',
+                "Message: " + msg,
+                "Route: " + maskedSource.replace(path,""),
+                "Line: " + lineno,
+                "Column: " + colno
+            ];
+            if (Object.keys(error).length > 0) {
+                messages.push("Error: " + JSON.stringify(error));
+            }
+            alert(messages.join("\n"));
         }
-        var messages = [
-            'EmonCMS Error',
-            '-------------',
-            'Message: ' + msg,
-            'Route: ' + maskedSource.replace(path,''),
-            'Line: ' + lineno,
-            'Column: ' + colno
-        ];
-        if (Object.keys(error).length > 0) {
-            messages.push('Error: ' + JSON.stringify(error));
-        }
-        alert(messages.join("\n"));
-    }
-    return true; // true == prevents the firing of the default event handler.
+        return true; // true == prevents the firing of the default event handler.
+    };
 }

--- a/Lib/emoncms.js
+++ b/Lib/emoncms.js
@@ -13,7 +13,7 @@
 "use strict";
 
 var _SETTINGS = {
-    show_errors: false // false to allow errors to be handled by browser developer console
+    show_errors: true // false to allow errors to be handled by browser developer console
 }
 
 /**

--- a/Lib/emoncms.js
+++ b/Lib/emoncms.js
@@ -1,0 +1,117 @@
+/*
+  All Emoncms code is released under the GNU Affero General Public License.
+  See COPYRIGHT.txt and LICENSE.txt.
+
+  ---------------------------------------------------------------------
+  Emoncms - open source energy visualisation
+  Part of the OpenEnergyMonitor project:
+  http://openenergymonitor.org
+*/
+//
+// THIS IS LOADED IN <head> - DO NOT ADD SCRIPTS THAT WOULD BLOCK THE "time to first print"
+// ---------------------------------------------------------------------------------------
+"use strict";
+
+var _SETTINGS = {
+    show_errors: false // false to allow errors to be handled by browser developer console
+}
+
+/**
+ * POLYFILLS
+ * document.currentScript
+ *  - polyfill for IE browsers
+ * works by getting the last <script> in the document
+ * each <script> is loaded in order so this <script> would always be the last one in the parent <html>
+ */
+if(!document.currentScript) {
+    document.currentScript = (function() {
+        var scripts = document.getElementsByTagName('script');
+        return scripts[scripts.length - 1];
+    })();
+}
+/**
+ * Set the passed path as a constant that cannot be changed by other scripts
+ * reads the [data-path] param of the <script> tag loading this file.
+ * works by current filename if no [data-path] given
+ * 
+ * ## "Self-Executing Anonymous Functions" will not add to the window variable scope
+ * @return emoncms path
+ * @todo change "var path = ..." to "const path = ..." once all other modules have been updated to use this new js file
+ * this will prevent any future changes to `path` within any other modules.
+ * @todo look at adding this into a global `_SETTINGS` object for all js settings
+ */
+var path = (function() {
+    // if [data-path] not in initial <script> tag, this file is in the /Lib directory
+    const filePath = 'Lib/emoncms.js'
+    var _path = document.currentScript.dataset.path
+    /**
+     * remove the filePath from given url
+     * @param {string} src url of current file
+     * @returns url and path of emoncms system
+     */
+    function getPathFromScript(src) {
+        var regex = new RegExp('(.*)' + filePath)
+        var match = src.match(regex)
+        return match[1]
+    }
+    // if path not set as [data-path] of <script> tag get the path from emoncms.js url
+    // @todo: more testing ond different devices/browsers
+    if (!_path) {
+        _path = getPathFromScript(document.currentScript.src)
+    }
+    return _path
+})();
+
+// on JQuery Ready...
+$(function(){
+    // trigger jquery "window.resized" custom event after debounce delay
+    var resizeTimeout = false
+    window.addEventListener('resize', function(event) {
+        clearTimeout(resizeTimeout)
+        resizeTimeout = setTimeout(function() {
+            $.event.trigger('window.resized')
+        }, 200);
+    })
+})
+
+// Display alert if js error encountered
+window.onerror = function(msg, source, lineno, colno, error) {
+    if (_SETTINGS && !_SETTINGS.show_errors) return false;
+    if (msg.toLowerCase().indexOf("script error") > -1) {
+        alert('Script Error: See Browser Console for Detail');
+    }
+    else {
+        // REMOVE API KEY FROM ALERT
+        // ----------------------------
+        var maskedSource = source
+        var pattern = /(([\?&])?apikey=)([\w]*)/
+        // pattern match result examples:
+        //  0 = ?apikey=abc123
+        //  1 = ?apikey=
+        //  2 = ?
+        //  3 = abc123
+        var match = source.match(pattern)
+        if (match) {
+            // if apikey first parameter replace with '?'
+            // if apikey not first parameter replace with ''
+            if(match[2]==='&') {
+                maskedSource = source.replace(match[0], '')
+            } else {
+                maskedSource = source.replace(match[0], '?')
+            }
+        }
+        var messages = [
+            'EmonCMS Error',
+            '-------------',
+            'Message: ' + msg,
+            'Route: ' + maskedSource.replace(path,''),
+            'Line: ' + lineno,
+            'Column: ' + colno
+        ];
+        if (Object.keys(error).length > 0) {
+            messages.push('Error: ' + JSON.stringify(error));
+        }
+        alert(messages.join("\n"));
+    }
+    return true; // true == prevents the firing of the default event handler.
+}

--- a/Lib/misc/sidebar.js
+++ b/Lib/misc/sidebar.js
@@ -185,13 +185,8 @@ $(function(){
         let active_menu_name = active_menu.attr('id').split('-');
         active_menu_name.shift();
         
-        path = window.path; // e.g: http://localhost/emoncms
-        if(typeof path === 'undefined') {
-            console.log("Sidebar error: path undefined");
-            path = '';
-        }
         let relative_path = window.location.href.replace(path,''); // eg subtracts http://localhost/emoncms from http://localhost/emoncms/feed/list
-        let controller = relative_path.split('/')[0]; // eg. feed
+        let controller = relative_path.split('/')[0].replace(/(.*)#.*/,'$1'); // eg. feed
         let include_id = [active_menu_name,controller,'sidebar','include'].join('-'); // eg. setup-feed-sidebar-include
         let include = $('#' + include_id);
 

--- a/Modules/admin/userlist_view.php
+++ b/Modules/admin/userlist_view.php
@@ -62,7 +62,6 @@
 
 <script>
 
-var path = "<?php echo $path; ?>";
 var users = {};
 
 var admin = {

--- a/Modules/feed/Views/feedlist_view.php
+++ b/Modules/feed/Views/feedlist_view.php
@@ -389,7 +389,6 @@ body{padding:0!important}
 <!------------------------------------------------------------------------------------------------------------------------------------------------- -->
 <script>
 
-var path = "<?php echo $path; ?>";
 var feedviewpath = "<?php echo $feedviewpath; ?>";
 
 var feeds = {};

--- a/Modules/input/Views/input_view.php
+++ b/Modules/input/Views/input_view.php
@@ -138,7 +138,6 @@ input[type="checkbox"] { margin:0px; }
 
 <script src="<?php echo $path; ?>Lib/moment.min.js"></script>
 <script>
-    var path = "<?php echo $path; ?>";
     var device_module = <?php if ($device_module) echo 'true'; else echo 'false'; ?>;
     var _user = {};
     _user.lang = "<?php echo $_SESSION['lang']; ?>";

--- a/Modules/input/Views/schedule.php
+++ b/Modules/input/Views/schedule.php
@@ -28,7 +28,6 @@ $device = $_GET['node'];
 
 <script>
 
-var path = "<?php echo $path; ?>";
 var device = "<?php echo $device; ?>";
 $("#devicename").html(jsUcfirst(device));
 

--- a/Modules/schedule/Views/schedule_view.php
+++ b/Modules/schedule/Views/schedule_view.php
@@ -55,7 +55,6 @@
 </div>
 
 <script>
-  var path = "<?php echo $path; ?>";
 
   // Extend table library field types
   for (z in customtablefields) table.fieldtypes[z] = customtablefields[z];

--- a/Modules/user/Views/bookmarks.php
+++ b/Modules/user/Views/bookmarks.php
@@ -85,9 +85,7 @@
 </style>
 
 <script>
-var path = "<?php echo $path ?>";
 $(function(){
-    var path = "<?php echo $path ?>";
     // SHOW EDIT BOOKMARK FORM
     $(document).on('click', 'form[data-read] [data-title]', function(event) {
         event.preventDefault();

--- a/Modules/user/profile/profile.php
+++ b/Modules/user/profile/profile.php
@@ -205,7 +205,6 @@ function languagecode_to_name($langs) {
 
 <script>
 
-    var path = "<?php echo $path; ?>";
     var lang = <?php echo json_encode($languages); ?>;
     var lang_name = <?php echo json_encode($languages_name); ?>;
 

--- a/Modules/vis/Views/vis_main_view.php
+++ b/Modules/vis/Views/vis_main_view.php
@@ -71,7 +71,6 @@ Part of the OpenEnergyMonitor project: http://openenergymonitor.org
 <div id="visurl"></div>
 
 <script type="application/javascript">
-  var path = "<?php echo $path; ?>";
   var feedlist = <?php echo json_encode($feedlist); ?>;
   var widgets = <?php echo json_encode($visualisations); ?>;
   var embed = 0;

--- a/Modules/vis/visualisations/bargraph.php
+++ b/Modules/vis/visualisations/bargraph.php
@@ -60,7 +60,6 @@
 
     var feedid = <?php echo $feedid; ?>;
     var feedname = "<?php echo $feedidname; ?>";
-    var path = "<?php echo $path; ?>";
     var apikey = "<?php echo $apikey; ?>";
     var embed = <?php echo $embed; ?>;
     var valid = "<?php echo $valid; ?>";

--- a/Modules/vis/visualisations/compare.php
+++ b/Modules/vis/visualisations/compare.php
@@ -72,7 +72,6 @@
 
 <script id="source" language="javascript" type="text/javascript">
 
-  var path = "<?php echo $path; ?>";
   var apikey = "<?php echo $apikey; ?>";
   var valid = "<?php echo $valid; ?>";
 

--- a/Modules/vis/visualisations/comparison/comparison.php
+++ b/Modules/vis/visualisations/comparison/comparison.php
@@ -91,7 +91,6 @@
     <script type="text/javascript">
         var kwhd = <?php echo $kwhd; ?>;
         var power = <?php echo $power; ?>;
-        var path = "<?php echo $path; ?>";
         var apikey = "<?php echo $apikey; ?>";
         var price = <?php echo $pricekwh ?>;
         var currency = "<?php echo $currency ?>";

--- a/Modules/vis/visualisations/dailyhistogram/dailyhistogram.php
+++ b/Modules/vis/visualisations/dailyhistogram/dailyhistogram.php
@@ -73,7 +73,6 @@
     var kwhd = <?php echo $kwhd; ?>;
     var whw = <?php echo $whw; ?>;
     var power = <?php echo $power; ?>;
-    var path = "<?php echo $path; ?>";
     var apikey = "<?php echo $apikey; ?>";
 
     $('#placeholder').width($('#test').width()-60);

--- a/Modules/vis/visualisations/editdaily.php
+++ b/Modules/vis/visualisations/editdaily.php
@@ -59,7 +59,6 @@
   var feedid = <?php echo $feedid; ?>;
   var feedname = "<?php echo $feedidname; ?>";
   var type = "<?php echo $type; ?>";
-  var path = "<?php echo $path; ?>";
   var apikey = "<?php echo $write_apikey; ?>";
 
   var timeWindow = (3600000*24.0*7);        //Initial time window

--- a/Modules/vis/visualisations/editrealtime.php
+++ b/Modules/vis/visualisations/editrealtime.php
@@ -82,7 +82,6 @@
   var feedid = "<?php echo $feedid; ?>";
   var feedname = "<?php echo $feedidname; ?>";
   var type = "<?php echo $type; ?>";
-  var path = "<?php echo $path; ?>";
   var apikey = "<?php echo $write_apikey; ?>";
 
   var timeWindow = (3600000*24.0*7);        //Initial time window

--- a/Modules/vis/visualisations/graph.php
+++ b/Modules/vis/visualisations/graph.php
@@ -94,7 +94,6 @@
 </div>
 <script>
     app_graph.feedname = parseInt("<?php echo $feedid; ?>");
-    var path = "<?php echo $path; ?>";
     app_graph.init();
     app_graph.show();
 </script>

--- a/Modules/vis/visualisations/histgraph.php
+++ b/Modules/vis/visualisations/histgraph.php
@@ -43,7 +43,6 @@
 <script id="source" language="javascript" type="text/javascript">
   var barwidth = <?php echo $barwidth; ?>;       //Fetch table name
   var feedid = "<?php echo $feedid; ?>";         //Fetch table name
-  var path = "<?php echo $path; ?>";
   var apikey = "<?php echo $apikey; ?>";
   var valid = "<?php echo $valid; ?>";
   // Eventually We can store the plot colors in the DB, and use a php command to stick it here

--- a/Modules/vis/visualisations/multigraph.php
+++ b/Modules/vis/visualisations/multigraph.php
@@ -38,7 +38,6 @@
 <script id="source" language="javascript" type="text/javascript">
 
     var mid = <?php echo $mid; ?>;
-    var path = "<?php echo $path; ?>";
     var embed = <?php echo $embed; ?>;
     var apikey = "<?php echo $apikey; ?>";
     var multigraphFeedlist = {};

--- a/Modules/vis/visualisations/orderbars.php
+++ b/Modules/vis/visualisations/orderbars.php
@@ -33,7 +33,6 @@
 
   var feedid = "<?php echo $feedid; ?>";
   var feedname = "<?php echo $feedidname; ?>";
-  var path = "<?php echo $path; ?>";
   var apikey = "<?php echo $apikey; ?>";
   var delta = <?php echo $delta; ?>;
   

--- a/Modules/vis/visualisations/orderthreshold.php
+++ b/Modules/vis/visualisations/orderthreshold.php
@@ -45,7 +45,6 @@
   var thresholdA = <?php echo $thresholdA; ?>;
   var thresholdB = <?php echo $thresholdB; ?>;
 
-  var path = "<?php echo $path; ?>";
   var apikey = "<?php echo $apikey; ?>";
 
   var timeWindow = (3600000*24.0*7);        //Initial time window

--- a/Modules/vis/visualisations/rawdata.php
+++ b/Modules/vis/visualisations/rawdata.php
@@ -56,7 +56,6 @@
 
 var feedid = <?php echo $feedid; ?>;
 var feedname = "<?php echo $feedidname; ?>";
-var path = "<?php echo $path; ?>";
 var apikey = "<?php echo $apikey; ?>";
 var embed = <?php echo $embed; ?>;
 var valid = "<?php echo $valid; ?>";

--- a/Modules/vis/visualisations/realtime.php
+++ b/Modules/vis/visualisations/realtime.php
@@ -32,7 +32,6 @@
 
     <script id="source" language="javascript" type="text/javascript">
     var feedid = <?php echo $feedid; ?>;                //Fetch table name
-    var path = "<?php echo $path; ?>";
     var apikey = "<?php echo $apikey; ?>";  
     var embed = <?php echo $embed; ?>;
     var is_kw = <?php echo $kw === 1 ? 'true': 'false'; ?>;

--- a/Modules/vis/visualisations/simplezoom.php
+++ b/Modules/vis/visualisations/simplezoom.php
@@ -52,7 +52,6 @@
   $('#graph').height($('#graph_bound').height());
   if (embed) $('#graph').height($(window).height());
 
-  var path = "<?php echo $path; ?>";
   var apikey = "<?php echo $apikey; ?>";
 
   var power = "<?php echo $power; ?>";

--- a/Modules/vis/visualisations/smoothie.php
+++ b/Modules/vis/visualisations/smoothie.php
@@ -21,7 +21,6 @@
 
 <script id="source" language="javascript" type="text/javascript">
   var feedid = <?php echo $feedid; ?>;
-  var path = "<?php echo $path; ?>";
   var apikey = "<?php echo $apikey; ?>";
   var ufac = "<?php echo $ufac; ?>";
   var feedid2 = "<?php echo $feedid2; ?>";

--- a/Modules/vis/visualisations/stacked.php
+++ b/Modules/vis/visualisations/stacked.php
@@ -45,7 +45,6 @@
     colourt = "#" + colourt;
   }
 
-  var path = "<?php echo $path; ?>";
   var apikey = "<?php echo $apikey; ?>";
 
   var timeWindow = (3600000*24.0*365*5);   //Initial time window

--- a/Modules/vis/visualisations/stackedsolar.php
+++ b/Modules/vis/visualisations/stackedsolar.php
@@ -30,7 +30,6 @@
   var kwhdB = <?php echo $consumption; ?>;
   var delta = <?php echo $delta; ?>;
   
-  var path = "<?php echo $path; ?>";
   var apikey = "<?php echo $apikey?>";
 
   var timeWindow = (3600000*24.0*365*5);   //Initial time window

--- a/Modules/vis/visualisations/threshold.php
+++ b/Modules/vis/visualisations/threshold.php
@@ -53,7 +53,6 @@
   var thresholdA = <?php echo $thresholdA; ?>;
   var thresholdB = <?php echo $thresholdB; ?>;
 
-  var path = "<?php echo $path; ?>";
   var apikey = "<?php echo $apikey; ?>";
   
   var initzoom = urlParams.initzoom;

--- a/Modules/vis/visualisations/timecompare.php
+++ b/Modules/vis/visualisations/timecompare.php
@@ -33,7 +33,6 @@
 
 <script id="source" language="javascript" type="text/javascript">
 
-    var path = "<?php echo $path; ?>";
     var embed = <?php echo $embed; ?>;
     var apikey = "<?php echo $apikey; ?>";
     var feedid = "<?php echo $feedid; ?>";

--- a/Modules/vis/visualisations/timestoredaily.php
+++ b/Modules/vis/visualisations/timestoredaily.php
@@ -61,7 +61,6 @@ var interval = 3600*24;
 
 var top_offset = 0;
 
-var path = "<?php echo $path; ?>";
 var apikey = "";
 
 // var feedid = urlParams['feedid'];

--- a/Modules/vis/visualisations/zoom.php
+++ b/Modules/vis/visualisations/zoom.php
@@ -60,7 +60,6 @@
 <script id="source" language="javascript" type="text/javascript">
   var kwhd = <?php echo $kwhd; ?>;
   var power = <?php echo $power; ?>;
-  var path = "<?php echo $path; ?>";
   var apikey = "<?php echo $apikey; ?>";
   var embed = <?php echo $embed; ?>;
   var delta = <?php echo $delta; ?>;

--- a/Theme/basic/embed.php
+++ b/Theme/basic/embed.php
@@ -31,6 +31,7 @@ if (!in_array($themecolor, ["blue", "sun", "standard"])) $themecolor = "standard
         <link href="<?php echo $path; ?>Lib/misc/sidebar.css?v=<?php echo $v; ?>" rel="stylesheet">
         
         <script type="text/javascript" src="<?php echo $path; ?>Lib/jquery-1.11.3.min.js"></script>
+        <script type="text/javascript" src="<?php echo $path; ?>Lib/misc/gettext.js?v=<?php echo $v; ?>"></script>
         <script src="<?php echo $path; ?>Lib/emoncms.js?v=<?php echo $v; ?>"></script>
     </head>
     <body>

--- a/Theme/basic/embed.php
+++ b/Theme/basic/embed.php
@@ -31,20 +31,7 @@ if (!in_array($themecolor, ["blue", "sun", "standard"])) $themecolor = "standard
         <link href="<?php echo $path; ?>Lib/misc/sidebar.css?v=<?php echo $v; ?>" rel="stylesheet">
         
         <script type="text/javascript" src="<?php echo $path; ?>Lib/jquery-1.11.3.min.js"></script>
-
-        <script>
-            var path = "<?php echo $path ?>";
-            $(function(){
-                // trigger jquery window.resized custom event after debounce delay
-                var resizeTimeout = false
-                window.addEventListener('resize', function(event) {
-                    clearTimeout(resizeTimeout)
-                    resizeTimeout = setTimeout(function() {
-                        $.event.trigger('window.resized')
-                    }, 200);
-                })
-            })
-        </script>
+        <script src="<?php echo $path; ?>Lib/emoncms.js?v=<?php echo $v; ?>"></script>
     </head>
     <body>
         <div>

--- a/Theme/basic/theme.php
+++ b/Theme/basic/theme.php
@@ -20,7 +20,6 @@ if (!in_array($themecolor, ["blue", "sun", "standard"])) {
     $themecolor = "standard";
 }
 ?>
-
 <html>
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
@@ -41,47 +40,10 @@ if (!in_array($themecolor, ["blue", "sun", "standard"])) {
 
     <script type="text/javascript" src="<?php echo $path; ?>Lib/jquery-1.11.3.min.js"></script>
     <script type="text/javascript" src="<?php echo $path; ?>Lib/misc/sidebar.js?v=<?php echo $v; ?>"></script>
-
-    <script>
-        window.onerror = function(msg, source, lineno, colno, error) {
-            // return false;
-            if (msg.toLowerCase().indexOf("script error") > -1) {
-                alert('Script Error: See Browser Console for Detail');
-            }
-            else {
-                var messages = [
-                    'EmonCMS Error',
-                    '-------------',
-                    'Message: ' + msg,
-                    'Route: ' + source.replace('<?php echo $path; ?>',''),
-                    'Line: ' + lineno,
-                    'Column: ' + colno
-                ];
-                if (Object.keys(error).length > 0) {
-                    messages.push('Error: ' + JSON.stringify(error));
-                }
-                alert(messages.join("\n"));
-            }
-            return true; // true == prevents the firing of the default event handler.
-        }
-        var path = "<?php echo $path ?>";
-
-        $(function() {
-            // trigger jquery window.resized custom event after debounce delay
-            var resizeTimeout = false
-            window.addEventListener('resize', function(event) {
-                clearTimeout(resizeTimeout)
-                resizeTimeout = setTimeout(function() {
-                    $.event.trigger('window.resized')
-                }, 200);
-            })
-        })
-
-    </script>
+    <script src="<?php echo $path; ?>Lib/emoncms.js?v=<?php echo $v; ?>"></script>
 </head>
 <body class="fullwidth <?php if(isset($page_classes)) echo implode(' ', $page_classes) ?>">
     <div id="wrap">
-
         <div id="emoncms-navbar" class="navbar navbar-inverse navbar-fixed-top">
             <?php echo $mainmenu; ?>
         </div>
@@ -144,6 +106,5 @@ if (!in_array($themecolor, ["blue", "sun", "standard"])) {
     // end of module icons
     endif;
 ?>
-
 </body>
 </html>

--- a/Theme/basic/theme.php
+++ b/Theme/basic/theme.php
@@ -40,6 +40,7 @@ if (!in_array($themecolor, ["blue", "sun", "standard"])) {
 
     <script type="text/javascript" src="<?php echo $path; ?>Lib/jquery-1.11.3.min.js"></script>
     <script type="text/javascript" src="<?php echo $path; ?>Lib/misc/sidebar.js?v=<?php echo $v; ?>"></script>
+    <script type="text/javascript" src="<?php echo $path; ?>Lib/misc/gettext.js?v=<?php echo $v; ?>"></script>
     <script src="<?php echo $path; ?>Lib/emoncms.js?v=<?php echo $v; ?>"></script>
 </head>
 <body class="fullwidth <?php if(isset($page_classes)) echo implode(' ', $page_classes) ?>">


### PR DESCRIPTION
this pull request creates a new 'common' js file used within all the views `Lib/misc/emoncms.js`

this file is then loaded from the `Theme/basic/theme.php` and `Theme/basic/embed.php` templates

`emoncms.js` currently handles js errors, triggers a custom screen resize event and sets the `path` variable for all further scripts to use. 

I then removed all the references to `path` in the other views that re-defined it.

most of this code was already in the `theme.php` template however it can now be cached as it is a separate http request.

there is some code that can be moved from `Lib/misc/sidebar.js` that might not totally be required by the sidebar but was a convenient place to put the scripts until now - as there is a `emoncms.js` file