### PR TITLE
added api endpoint to match api documentation

### DIFF
--- a/Modules/input/input_controller.php
+++ b/Modules/input/input_controller.php
@@ -175,6 +175,7 @@ function input_controller()
 
     else if ($route->action == "list") return $input->getlist($session['userid']);
     else if ($route->action == "getinputs") return $input->get_inputs($session['userid']);
+    else if ($route->action == "get_inputs") return $input->get_inputs($session['userid']);
 
     return array('content'=>$result);
 }


### PR DESCRIPTION
fix #1406 

@pb66 @borpin 
I thought it was best to add the both api endpoints rather than removing the incorrectly set version.
so now both these api endpoints work:
- `input/get_inputs`
- `input/getinputs`