### PR TITLE
added redis versions

### DIFF
--- a/Modules/admin/admin_controller.php
+++ b/Modules/admin/admin_controller.php
@@ -87,6 +87,15 @@ function admin_controller()
                     }
                     $services['feedwriter']['text'] .= $message . ' <span id="bufferused">loading...</span>';
                 }
+                $redis_info = array();
+                if($redis_enabled) {
+                    $redis_info = $redis->info();
+                    $redis_info['dbSize'] = $redis->dbSize();
+                    $phpRedisPattern = 'Redis Version =>';
+                    $redis_info['phpRedis'] = substr(shell_exec("php -i | grep '".$phpRedisPattern."'"), strlen($phpRedisPattern));
+                    $pipRedisPattern = "Version: ";
+                    $redis_info['pipRedis'] = substr(shell_exec("pip show redis --disable-pip-version-check | grep '".$pipRedisPattern."'"), strlen($pipRedisPattern));
+                }
 
                 $view_data = array(
                     'system'=>$system,
@@ -101,7 +110,7 @@ function admin_controller()
                     'path'=>$path,
                     'allow_emonpi_admin'=>$allow_emonpi_admin,
                     'emoncms_logfile'=>$emoncms_logfile,
-                    'redis'=>$redis,
+                    'redis_info'=>$redis_info,
                     'feed_settings'=>$feed_settings,
                     'emoncms_modules'=>$system['emoncms_modules'],
                     'php_modules'=>Admin::php_modules($system['php_modules']),

--- a/Modules/admin/admin_main_view.php
+++ b/Modules/admin/admin_main_view.php
@@ -348,12 +348,14 @@ listItem;
         <h4 class="text-info text-uppercase border-top pt-2 mt-0 px-1"><?php echo _('Redis'); ?></h4>
         <dl class="row">
             <?php
-            $git_details = sprintf('<dl class="row">%s</dl>',implode('', array(
-                row(_('Redis Server'), $redis_info['redis_version']),
-                row(_('Python Redis'), $redis_info['pipRedis']),
-                row(_('PHP Redis'), $redis_info['phpRedis'])
-            )));
-            echo row(_('Version'), $git_details); ?>
+            $redis_version_lines[] = row(_('Redis Server'), $redis_info['redis_version']);
+            if(!empty($redis_info['pipRedis'])) {
+                $redis_version_lines[] = row(_('Python Redis'), $redis_info['pipRedis']);
+            }
+            if(!empty($redis_info['phpRedis'])) {
+                $redis_version_lines[] = row(_('PHP Redis'), $redis_info['phpRedis']);
+            }
+            echo row(_('Version'), sprintf('<dl class="row">%s</dl>',implode('', $redis_version_lines))); ?>
             <?php echo row(_('Host'), $system['redis_server']); ?>
             <?php 
             $redis_flush_btn = sprintf('<button id="redisflush" class="btn btn-info btn-small pull-right">%s</button>',_('Flush'));

--- a/Modules/admin/admin_main_view.php
+++ b/Modules/admin/admin_main_view.php
@@ -347,14 +347,22 @@ listItem;
         <?php if ($redis_enabled) : ?>
         <h4 class="text-info text-uppercase border-top pt-2 mt-0 px-1"><?php echo _('Redis'); ?></h4>
         <dl class="row">
-            <?php echo row(_('Version'), $redis->info()['redis_version']); ?>
+            <?php
+            $git_details = sprintf('<dl class="row">%s</dl>',implode('', array(
+                row(_('Redis Server'), $redis_info['redis_version']),
+                row(_('Python Redis'), $redis_info['pipRedis']),
+                row(_('PHP Redis'), $redis_info['phpRedis'])
+            )));
+            echo row(_('Version'), $git_details); ?>
             <?php echo row(_('Host'), $system['redis_server']); ?>
             <?php 
             $redis_flush_btn = sprintf('<button id="redisflush" class="btn btn-info btn-small pull-right">%s</button>',_('Flush'));
-            $redis_keys = sprintf('%s keys',$redis->dbSize());
-            $redis_size = sprintf('(%s)',$redis->info()['used_memory_human']);
-            echo row(sprintf('<span class="align-self-center">%s</span>',_('Size')), sprintf('<span id="redisused">%s %s</span>%s',$redis_keys,$redis_size,$redis_flush_btn),'d-flex','d-flex align-items-center justify-content-between'); ?>
-            <?php echo row(_('Uptime'), sprintf(_("%s days"), $redis->info()['uptime_in_days'])); ?>
+            $redis_keys = sprintf('%s keys',$redis_info['dbSize']);
+            $redis_size = sprintf('(%s)',$redis_info['used_memory_human']);
+            echo row(sprintf('<span class="align-self-center">%s</span>',_('Size')), sprintf('<span id="redisused">%s %s</span>%s',$redis_keys,$redis_size,$redis_flush_btn),'d-flex','d-flex align-items-center justify-content-between');
+            ?>
+            <?php echo row(_('Uptime'), sprintf(_("%s days"), $redis_info['uptime_in_days'])); ?>
+            
         </dl>
         <?php endif; ?>
 


### PR DESCRIPTION
fix #1413 

only ran redis->info() once and reused the response
added python redis version
added php redis version

**needs some testing on other devices...**
...when running the command `pip show redis` via php the details are for all installed packages available to the `www-data` user. This works for my version as redis is installed system wide:
```
#> pip install redis --system
```
please let me know if your admin page (http://localhost/emoncms/admin/view) looks like this screenshot:


![delwedd](https://user-images.githubusercontent.com/1466013/65392596-77596880-dd6e-11e9-9489-f1b816f59c44.png)
[screenshot of admin screen showing Redis component version numbers]


