### PR TITLE
Add 'none' to firmware type in admin

### DIFF
--- a/Modules/admin/admin_controller.php
+++ b/Modules/admin/admin_controller.php
@@ -222,7 +222,7 @@ function admin_controller()
                     // Get update argument e.g. 'emonpi' or 'rfm69pi'
                     $firmware="";
                     if (isset($_POST['firmware'])) $firmware = $_POST['firmware'];
-                    if (!in_array($firmware,array("emonpi","rfm69pi","rfm12pi","custom"))) return "Invalid firmware type";
+                    if (!in_array($firmware,array("none","emonpi","rfm69pi","rfm12pi","custom"))) return "Invalid firmware type";
                     // Type: all, emoncms, firmware
                     $type="";
                     if (isset($_POST['type'])) $type = $_POST['type'];

--- a/Modules/admin/admin_main_view.php
+++ b/Modules/admin/admin_main_view.php
@@ -140,6 +140,7 @@ listItem;
         </div>
         <div class="input-append">
             <select id="selected_firmware">
+                <option value="none">none</option>
                 <option value="emonpi">EmonPi</option>
                 <option value="rfm69pi">RFM69Pi</option>
                 <option value="rfm12pi">RFM12Pi</option>


### PR DESCRIPTION
For systems without any RFM or serial interface, a 'none' firmware type is needed to make updates cleaner.

Ideally there would be a means of setting the firmware type.
