### PR TITLE
Update default-settings.ini

### DIFF
--- a/default-settings.ini
+++ b/default-settings.ini
@@ -38,6 +38,7 @@ host = 'localhost'
 port = 6379
 auth = ''
 dbnum = ''
+; Only a prefix of 'emoncms' or '' will be recognised by service-runner
 prefix = 'emoncms'
 
 


### PR DESCRIPTION
Note that only certain redis prefixes can be used.