### PR TITLE
Add admin page for viewing the current Settings object

### DIFF
--- a/Modules/admin/admin_controller.php
+++ b/Modules/admin/admin_controller.php
@@ -123,8 +123,13 @@ function admin_controller()
                     'log_level_label' => $log_levels[$settings['log']['level']],
                     'path_to_config'=> $path_to_config
                 );
-                
+
                 return view("Modules/admin/admin_main_view.php", $view_data);
+            }
+
+            else if ($route->action == 'settings')
+            {
+                return view("Modules/admin/settings_view.php");
             }
 
             else if ($route->action == 'db')

--- a/Modules/admin/admin_main_view.php
+++ b/Modules/admin/admin_main_view.php
@@ -275,6 +275,9 @@ listItem;
         </dl>
 
         <h4 class="text-info text-uppercase border-top pt-2 mt-0 px-1"><?php echo _('Emoncms'); ?></h4>
+        <div>
+            <a href="<?php echo $path; ?>admin/settings" class="btn btn-info"><?php echo _('View Emoncms Settings'); ?></a>
+        </div>
         <dl class="row">
             <?php echo row(_('Version'),$emoncms_version); ?>
             <?php echo row(_('Modules'), $emoncms_modules); ?>

--- a/Modules/admin/settings_view.php
+++ b/Modules/admin/settings_view.php
@@ -1,0 +1,16 @@
+<?php
+    defined('EMONCMS_EXEC') or die('Restricted access');
+    global $path, $settings;
+
+?>
+<h2><?php echo _("Current Emoncms Settings"); ?></h2>
+<pre>
+<?php
+
+print_r($settings);
+
+?>
+</pre>
+
+<a href="<?php echo $path; ?>admin/view" class="btn btn-info"><?php echo _('Return to Administration Page'); ?></a>
+<?php ?>


### PR DESCRIPTION
Extend the admin view capabilities with a separate page for viewing the current Settings object.

TODO
* Introduce copy txt/md buttons at top - not sure the best way to do this.
* In admin view, float button across to right - tried, but my CSS is not up to it 😢 

