### PR TITLE
fixed menu sort function to increment with number

### DIFF
--- a/Lib/misc/nav_functions.php
+++ b/Lib/misc/nav_functions.php
@@ -363,8 +363,15 @@ function sortMenu (&$menus) {
                 }
             }
             // get next sort (max_order) for a menu
-            $next_order = !empty($orders) ? max($orders)+1: 0;
-            
+            try {
+                $sortedOrders = array_values($orders);
+                if(empty($sortedOrders)) $sortedOrders[] = 0;
+                asort($sortedOrders, SORT_NATURAL); // sort like this: 2, 11, a, a1, b
+                preg_match_all('!\d+!', array_slice($sortedOrders, -1)[0], $matches);
+                $next_order = implode(array_column($matches,0));
+            } catch (Exception $e) {
+                $next_order = 0;
+            }   
             // set order field for un-ordered menu items
             foreach($unordered as $index) {
                 // sort by title if available


### PR DESCRIPTION
fix: #1475 

now uses the `asort()` `SORT_NATURAL` function to sort correctly.
also increments the number part of the sorted keys:
```
'a'=>'First Item',
'a1'=>'Second Item'
```

previously it would have shown an error when text keys were used as it couldn't increment the array's key to the next item.