### PR TITLE
added ini_check_envvars() to check all env vars

### DIFF
--- a/process_settings.php
+++ b/process_settings.php
@@ -29,9 +29,12 @@ if(file_exists(dirname(__FILE__)."/settings.php")) {
         $settings = array_replace_recursive($_settings,$settings);
     }
 } else if(file_exists(dirname(__FILE__)."/settings.ini")) {
-    $DEFAULT_INI = parse_ini_file("default-settings.ini", true);
-    $SETTINGS_INI = parse_ini_file("settings.ini", true);
-    $SETTINGS_ENV = ini_check_envvars(parse_ini_file("settings.env.ini", true));
+    $DEFAULT_INI = parse_ini_file("default-settings.ini", true, INI_SCANNER_TYPED);
+    $SETTINGS_INI = parse_ini_file("settings.ini", true, INI_SCANNER_TYPED);
+    $SUPPORTED_ENV = parse_ini_file("settings.env.ini", true, INI_SCANNER_TYPED);
+
+    $SETTINGS_ENV = ini_check_envvars($SUPPORTED_ENV);
+    // overwrite order: default-> settings-> env
     $settings = array_replace_recursive($DEFAULT_INI, $SETTINGS_INI, $SETTINGS_ENV);
 
 } else {


### PR DESCRIPTION
found that my setup didn't correctly overwrite the settings with my `$_ENV` counterparts.

added back the function `ini_check_envvars()` and used a php `array_replace_recursive()` to merge the settings in the different `.ini` files. This removed the need for a custom `ini_merge()` function (unless you think this provides other functionality)
