### PR TITLE
Remove get magic quotes gpc()

### DIFF
--- a/core.php
+++ b/core.php
@@ -81,7 +81,7 @@ function get($index)
     $val = null;
     if (isset($_GET[$index])) $val = rawurldecode($_GET[$index]);
     
-    if (get_magic_quotes_gpc()) $val = stripslashes($val);
+    // if (get_magic_quotes_gpc()) $val = stripslashes($val);
     return $val;
 }
 /** 
@@ -104,7 +104,7 @@ function post($index)
             if(!empty($SANTIZED_POST[$index])) $val = $SANTIZED_POST[$index];
         }
     }
-    if (get_magic_quotes_gpc()) $val = stripslashes($val);
+    // if (get_magic_quotes_gpc()) $val = stripslashes($val);
     return $val;
 }
 

--- a/core.php
+++ b/core.php
@@ -80,9 +80,7 @@ function get($index)
 {
     $val = null;
     if (isset($_GET[$index])) $val = rawurldecode($_GET[$index]);
-    
-    // if (get_magic_quotes_gpc()) $val = stripslashes($val);
-    return $val;
+    return stripslashes($val);
 }
 /** 
  * strip slashes from POST values or null if not set
@@ -104,7 +102,8 @@ function post($index)
             if(!empty($SANTIZED_POST[$index])) $val = $SANTIZED_POST[$index];
         }
     }
-    // if (get_magic_quotes_gpc()) $val = stripslashes($val);
+    $val = stripslashes($val);
+    // FILTER_SANITIZE_MAGIC_QUOTES
     return $val;
 }
 
@@ -114,7 +113,7 @@ function prop($index)
     if (isset($_GET[$index])) $val = $_GET[$index];
     if (isset($_POST[$index])) $val = $_POST[$index];
     
-    if (get_magic_quotes_gpc()) $val = stripslashes($val);
+    $val = stripslashes($val);
     return $val;
 }
 
@@ -131,7 +130,7 @@ function delete($index) {
     $val = null;
     if (isset($_DELETE[$index])) $val = $_DELETE[$index];
     
-    if (get_magic_quotes_gpc()) $val = stripslashes($val);
+    $val = stripslashes($val);
     return $val;
 }
 function put($index) {
@@ -139,7 +138,7 @@ function put($index) {
     $val = null;
     if (isset($_PUT[$index])) $val = $_PUT[$index];
     
-    if (get_magic_quotes_gpc()) $val = stripslashes($val);
+    $val = stripslashes($val);
     return $val;
 }
 

--- a/param.php
+++ b/param.php
@@ -38,11 +38,11 @@ class Param
         $this->params = array();
         
         foreach ($_GET as $key=>$val) {
-            // if (get_magic_quotes_gpc()) $val = stripslashes($val);
+            $val = stripslashes($val);
             $this->params[$key] = $val;
         }
         foreach ($_POST as $key=>$val) {
-            // if (get_magic_quotes_gpc()) $val = stripslashes($val);
+            $val = stripslashes($val);
             $this->params[$key] = $val;
         }
         

--- a/param.php
+++ b/param.php
@@ -38,11 +38,11 @@ class Param
         $this->params = array();
         
         foreach ($_GET as $key=>$val) {
-            if (get_magic_quotes_gpc()) $val = stripslashes($val);
+            // if (get_magic_quotes_gpc()) $val = stripslashes($val);
             $this->params[$key] = $val;
         }
         foreach ($_POST as $key=>$val) {
-            if (get_magic_quotes_gpc()) $val = stripslashes($val);
+            // if (get_magic_quotes_gpc()) $val = stripslashes($val);
             $this->params[$key] = $val;
         }
         


### PR DESCRIPTION
`get_magic_quotes_gpc()` function call does not work as the `php.ini` setting `magic_quotes_gpc` has been removed in php 5.3

> `get_magic_quotes_gpc() ` : Returns the current configuration setting of magic_quotes_gpc
> This function has been DEPRECATED as of PHP 7.4.0. Relying on this function is highly discouraged. 
> --- [php.net - function.get-magic-quotes-gpc][1] 

> Runtime Configuration `magic_quotes_gpc` REMOVED as of PHP 5.4.0
> --- [php.net - info.configuration][2]

[1]:https://www.php.net/manual/en/function.get-magic-quotes-gpc.php
[2]:https://www.php.net/manual/en/info.configuration.php#ini.magic-quotes-gpc

still need to run further tests to see if removing this has adverse security effects