### PR TITLE
separated from #1484

### DIFF
--- a/Lib/dbschemasetup.php
+++ b/Lib/dbschemasetup.php
@@ -48,7 +48,10 @@ function db_schema_diff_datatype($spec, $current)
     if ($spec_default != $current['Default']) {
         $changed = true;
     }
-
+    // check if field Type changed
+    if($spec['type'] !== $current['Type']) {
+        $changed = true;
+    }
     // Null handling is a little involved
     if (isset($spec['Null']) && ($spec['Null'] === false || $spec['Null'] === "NO"))
         $spec_null = "NO";
@@ -172,7 +175,7 @@ function db_schema_add_column($mysqli, $table, $field, $spec, &$operations)
 //
 function db_schema_update_column($mysqli, $table, $field, $spec, &$operations)
 {
-    $result = $mysqli->query("DESCRIBE $table `$field`");
+    $result = $mysqli->query("DESCRIBE `$table` `$field`");
     $current = $result->fetch_array();
 
     // Check if we 1. need to change type 2. need to add a primary key


### PR DESCRIPTION
too much confusion in pull #1484. separated to 2 pull requests. this is the second..

related #1484 

checked field type when comparing
wrapped table name in quotes

was having errors when updating a schema. these checks are useful if databases are named with a reserved word

also the schema wasn't updated when the field types were changed.