### PR TITLE
formatted url param as html characters

### DIFF
--- a/Modules/user/user_controller.php
+++ b/Modules/user/user_controller.php
@@ -36,8 +36,7 @@ function user_controller()
             $msg = empty($route_query['msg']) ? get('msg') : $route_query['msg'];
             $ref = empty($route_query['ref']) ? get('ref') : $route_query['ref'];
             $message = filter_var(urldecode($msg), FILTER_SANITIZE_STRING);
-            $referrer = filter_var(urldecode(base64_decode($ref)), FILTER_SANITIZE_URL);
-            
+            $referrer = htmlentities(filter_var(urldecode(base64_decode($ref)), FILTER_SANITIZE_URL));
             // load login template with the above parameters
             $result = view("Modules/user/login_block.php", array(
                 'allowusersregister'=>$allowusersregister,


### PR DESCRIPTION
encoded url parameter as html special characters before using it as a value in the referrer input field
used php's [htmlentities()](https://www.php.net/manual/en/function.htmlentities.php) function to clean the value. eg: `<html>` to `&lt;html&gt;`

The input value is used to redirect the user on successful login.

The value was displayed as "raw" html and was able to be altered as such in the url:
```html
    <input name="referrer" type="hidden" value="<?php echo $referrer ?>">
```
https://github.com/emoncms/emoncms/blob/master/Modules/user/login_block.php#L105

the `$referrer` var is passed to the login page as a url encoded base64 string and is only decoded and displayed on the login page.