### PR TITLE
fixed "Unknown or bad timezone" issue

### DIFF
--- a/Modules/user/user_model.php
+++ b/Modules/user/user_model.php
@@ -37,6 +37,10 @@ class User
 
         $this->redis = $redis;
         $this->log = new EmonLogger(__FILE__);
+
+        $timezone_offset_minutes = 0; // could be added as param to request???
+        $timezone_name = timezone_name_from_abbr("", $timezone_offset_minutes*60, false);
+        $this->default_timezone = !empty($settings["interface"]["default_timezone"])? $settings["interface"]["default_timezone"]: $timezone_name;
     }
 
     //---------------------------------------------------------------------------------------
@@ -650,13 +654,13 @@ class User
     public function get_timezone($userid)
     {
         $userid = (int) $userid;
-        if (!$userid) return false;
+        if (!$userid) return $this->default_timezone;
         if ($result = $this->mysqli->query("SELECT timezone FROM users WHERE id = '$userid';")) {
             if ($row = $result->fetch_object()) {
                 return $row->timezone;
             }
         }
-        return false;
+        return $this->default_timezone;
     }
 
     // List supported PHP timezones

--- a/Modules/user/user_model.php
+++ b/Modules/user/user_model.php
@@ -38,8 +38,8 @@ class User
         $this->redis = $redis;
         $this->log = new EmonLogger(__FILE__);
 
-        $timezone_offset_minutes = 0; // could be added as param to request???
-        $timezone_name = timezone_name_from_abbr("", $timezone_offset_minutes*60, false);
+        $tz_mins_offset = 0; // could be added as param to request???
+        $timezone_name = timezone_name_from_abbr("", $tz_mins_offset*60, false);
         $this->default_timezone = !empty($settings["interface"]["default_timezone"])? $settings["interface"]["default_timezone"]: $timezone_name;
     }
 


### PR DESCRIPTION
see: 
https://community.openenergymonitor.org/t/dashboard-loggedin-vs-public/11626/31

added User\default_timezone
stopped User\get_timezone() from returning false
User\get_timezone() now defaults to default_timezone

the requests for dashboards don't currently include a guest user's timezone. Only logged in users can specify a timezone (set in their account page)

using this pull request you can add a default timezone to your settings file. eg. 
```
default_timezone = 'Europe/Paris'
```
**not currently set in the default-settings file** needs testing with different setups first

must be a value supported by PHP: https://www.php.net/manual/en/timezones.europe.php

and the time calculations will use this offset instead of UTC
https://github.com/emrysr/emoncms/blob/c68e9ff887376c85dce1f2984079cc4f166b4196/Modules/process/process_model.php#L30-L49
