### PR TITLE
FIX: JS error on deleting empty feed

### DIFF
--- a/Modules/feed/Views/feedlist_view.php
+++ b/Modules/feed/Views/feedlist_view.php
@@ -814,7 +814,7 @@ function showSelectedFeeds(feed_inputs) {
     for(s in selected) {
         titles[s] = selected[s].tag+":"+selected[s].name;
         // virtual feed processes
-        if ( selected[s].hasOwnProperty('processList') && selected[s].processList.length > 0 ) {
+        if ( selected[s].hasOwnProperty('processList') && selected[s].processList && selected[s].processList.length > 0 ) {
             linked.push(selected[s]);
             let virtualProcesses = processlist_ui.decode(selected[s].processList);
             for(p in virtualProcesses) {


### PR DESCRIPTION
When user is deleting an empty feed, browser shows JS error.
This pull request suggest a fix for that error