### PR TITLE
using filter_var() to sanitize user input for feed units

### DIFF
--- a/Modules/feed/feed_model.php
+++ b/Modules/feed/feed_model.php
@@ -841,7 +841,9 @@ class Feed
         }
 
         if (isset($fields->unit)) {
-            if (preg_replace('/[^\p{N}\p{L}_°\/%\s\-:]/u','',$fields->unit)!=$fields->unit) return array('success'=>false, 'message'=>'invalid characters in feed unit');
+	    if ($fields->unit !== filter_var($fields->unit, FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_BACKTICK | FILTER_FLAG_NO_ENCODE_QUOTES | FILTER_FLAG_STRIP_LOW)) {
+		    return array('success'=>false, 'message'=>'invalid characters in feed unit');
+	    }
             if (strlen($fields->unit) > 10) return array('success'=>false, 'message'=>'feed unit too long');
             if ($stmt = $this->mysqli->prepare("UPDATE feeds SET unit = ? WHERE id = ?")) {
                 $stmt->bind_param("si",$fields->unit,$id);


### PR DESCRIPTION
fix #1529 
using php filter_var() function to remove unwanted characters. will still allow most desired characters.

![image](https://user-images.githubusercontent.com/1466013/76843821-41380580-6834-11ea-80f1-fe9fc387c229.png)
