### PR TITLE
is_Pi() function MAC address range

### DIFF
--- a/Modules/admin/admin_model.php
+++ b/Modules/admin/admin_model.php
@@ -230,7 +230,7 @@ class Admin {
      * @return boolean
      */
     public static function is_Pi() {
-        return @exec('ifconfig | grep b8:27:eb:');
+        return !empty(@exec('ip addr | grep -i "b8:27:eb:\|dc:a6:32:"'));
     }
 
     /**


### PR DESCRIPTION
fix #1528

the reboot/restart buttons are currently set to show if ran on a raspberry pi. the [is_Pi()](https://github.com/emoncms/emoncms/blob/master/Modules/admin/admin_model.php#L232) function checks the device's mac address starts with the range associated to the raspberry pi foundation.

**NOT TESTED ON RASPBERRY PI 4**

added new mac address range for rpi4.

does the raspberry pi 4 has a different mac address range?? please comment if you know.

If you run this on your raspberry pi4 you should get your mac address for the ethernet and wifi network controllers...
```
ip address | egrep "^\s+link" | awk '{$1=$1};1' | cut -d' ' -f2 | tail -n+2
```
> this command will list the mac addresses on your raspberry pi
> _(steps: find all lines starting with 'link', trim white space chars, display column 2, remove first line)_
example output on rpi3:
![image](https://user-images.githubusercontent.com/1466013/76853654-a0524600-6845-11ea-86eb-1fa2895dc438.png)
** please dont comment with your full MAC address. It's unique to your device - the first three octets are fine to identify the company **

Found reference to `dc:a6:32:` as the OUI for **raspberry pi trading** (owned by raspberry pi foundation)

- [List of Registered OUIs (Organizationally Unique Identifiers)](http://standards-oui.ieee.org/oui.txt)
- [Wikipedia article mentions Raspberry Pi Trading](https://en.wikipedia.org/wiki/Raspberry_Pi_Foundation)

please comment if you have a raspberry pi 4 and your mac address doesn't start with `dc:a6:32:` so that I can amend this pull request with the correct values.