### PR TITLE
FIX: sidebar divider made unclickable and with href=#

### DIFF
--- a/Lib/misc/sidebar.css
+++ b/Lib/misc/sidebar.css
@@ -20,6 +20,16 @@ Side nav
 .narrow .sidebar-inner .close {
   display: inline-block;
 }
+
+.sidebar-inner .divider {
+	min-height: 1rem;
+	height: 1rem;
+	background: #212121 !important;
+}
+
+.sidebar-inner .divider a {
+	display: none !important;
+}
 /* -------------------------------------------------------------------
 Top nav
 --------------------------------------------------------------------*/

--- a/Modules/admin/admin_menu.php
+++ b/Modules/admin/admin_menu.php
@@ -3,7 +3,7 @@
 
     $menu['sidebar']['emoncms'][] = array(
         'text' => '',
-        'path' => ' ',
+        'href' => '#', // items with no path or href are not shown,
         'li_class' => 'divider',
         'icon' => '',
         'order' => 'b'


### PR DESCRIPTION
Side bar divider is shown as a clickable empty menu item navigating to `+` causing page reload. Such behaviour may confuse the user. This pull request makes the divider visually distinct and non-clickable. Also its href is changed to `#` so that even it is clickable it would not reload the page.