### PR TITLE
FIX: column H with the process list accomodate all remaining space

### DIFF
--- a/Modules/input/Views/input_view.js
+++ b/Modules/input/Views/input_view.js
@@ -974,7 +974,7 @@ function draw_devices() {
     app.col.G = ((max_description_length * 8) + 70); // additional padding to accomodate description length
     app.col.D = ((max_value_length * 8) + 17);
     app.col.E = ((max_time_length * 8) + 20) + 20; // additional padding to accomodate the 'weeks/days/hours/minutes/s' suffix
-    app.col.H = 200
+    app.col.H = 'calc(100% - ' + (app.col.A + app.col.G + app.col.F + app.col.C + app.col.D + app.col.E) + 'px)';
     
     resize_view();
 

--- a/Modules/input/Views/input_view.php
+++ b/Modules/input/Views/input_view.php
@@ -158,6 +158,10 @@ a.text-muted i[class*="icon-"] {
     opacity: 1;
     height: 3.15rem;
 }
+.node-inputs .pull-right {
+  position: absolute;
+  right: 0;
+}
 .select-mode .node-inputs .node-input {
     cursor: pointer;
 }
@@ -262,7 +266,7 @@ input.checkbox-lg,
                 </div>
                 <div class="name text-nowrap" data-col="A" :style="{width:col.A+'px'}">{{ input.name }}</div>
                 <div class="description" data-col="G" :style="{width:col.G+'px'}">{{ input.description }}</div>
-                <div class="processlist" data-col="H" :style="{width:col.H+'px'}">
+                <div class="processlist" data-col="H" :style="{width:col.H}">
                     <div class="label-container line-height-normal" v-html=input.processlistHtml></div>
                 </div>
                 <div class="buttons pull-right">


### PR DESCRIPTION
Column H containing list of processes is of a fixed width. When an input has many processes, the content is wrapped and hidden. It looks confusing. This pull request removes width constraint on that column making it stretching on all remaining space