### PR TITLE
FIX: PHP error caused by disabled REDIS

### DIFF
--- a/Modules/input/input_model.php
+++ b/Modules/input/input_model.php
@@ -519,7 +519,8 @@ class Input
             $processlist_after = implode(",",$pairsout);
 
             if ($processlist_after!=$processlist) {
-                $this->redis->hset("input:$inputid",'processList',$processlist_after);
+                if ($this->redis)
+                    $this->redis->hset("input:$inputid",'processList',$processlist_after);
                 $this->mysqli->query("UPDATE input SET processList = '$processlist_after' WHERE id='$inputid'");
                 $out .= "processlist for input $inputid changed from $processlist to $processlist_after\n";
             }


### PR DESCRIPTION
In some cases, when REDIS is disabled, cleaning a process list may endup with a PHP error. This pull request suggest a fix for that.