### PR TITLE
Update service-runner to python3.

### DIFF
--- a/scripts/services/install-service-runner-update.md
+++ b/scripts/services/install-service-runner-update.md
@@ -14,7 +14,7 @@ The process is as follows:
 **Check the old version has been uninstalled**
 Install the service using the following commands (if redis is already installed skip that command):
 ```bash
-sudo pip install redis
+sudo pip3 install redis
 sudo ln -s /var/www/emoncms/scripts/services/service-runner/service-runner.service /lib/systemd/system
 sudo systemctl enable service-runner.service
 sudo systemctl start service-runner.service
@@ -24,7 +24,7 @@ systemctl status service-runner.service
 View the log with:
 `journalctl -f -u service-runner`
 
-Tested on Raspiban Stretch
+Tested on Raspbian Stretch
 
 ## Non Raspbian setup ##
 If you are not using Raspbian as your base OS you will need to change the **User** the service runs as.
@@ -50,7 +50,7 @@ This version was written by @greeebs using python and systemd instead of bash an
 https://github.com/emoncms/emoncms/pull/1025 for the discussion.
 The python service is far more efficient as a constant connection to redis can be kept open.
 
-To check which service is installed check `crontab -l`.  if there is an entry pointing to the bash script it is running the earlier version.
+To check which service is installed check `crontab -l`.  If there is an entry pointing to the bash script it is running the earlier version.
 
 To remove the old version (prior to installing the new version)
 ```

--- a/scripts/services/service-runner/service-runner.py
+++ b/scripts/services/service-runner/service-runner.py
@@ -7,81 +7,56 @@
 # - Backup module
 # - Others??
 
-import sys
-import redis
 import subprocess
 import time
-import signal
+import shlex
+import redis
 
-def handle_sigterm(sig, frame):
-  print("Got Termination signal, exiting")
-  sys.exit(0)
+KEYS = ["service-runner", "emoncms:service-runner"]
 
-# Setup the signal handler to gracefully exit
-signal.signal(signal.SIGTERM, handle_sigterm)
-signal.signal(signal.SIGINT, handle_sigterm)
 
 def connect_redis():
-  while True:
-    try:
-      server = redis.Redis()
-      if server.ping():
-        print("Connected to redis-server")
-        sys.stdout.flush()
-        return server
-    except redis.exceptions.ConnectionError:
-      print("Unable to connect to redis-server, sleeping for 30s")
-      sys.stdout.flush()
-    time.sleep(30)
-
-print("Starting service-runner")
-sys.stdout.flush()
-
-server = connect_redis()
-
-while True:
-  try:
-    # Check for the existence of a redis 'service-runner' key
-      flag = False
-      if server.exists('service-runner'):
-        flag = server.lpop('service-runner')
-      elif server.exists('emoncms:service-runner'):
-        flag = server.lpop('emoncms:service-runner')
-
-      if flag:
-        print("Got flag: %s\n" % flag)
-        sys.stdout.flush()
-        script, logfile = flag.split('>')
-        cmdstring = "{s} > {l} 2>&1".format(s=script, l=logfile)
-        print("STARTING: " + cmdstring)
-        sys.stdout.flush()
-        # Got a cmdline, now run it.
+    while True:
         try:
-          subprocess.call(cmdstring, shell=True)
-        except SystemExit:
-          # If the sys.exit(0) from the interrupt handler gets caught here,
-          # just break from the while True: and let the script exit normally.
-          break
-        except:
-          # if an error occurs running the subprocess, add the error to
-          #  the specified logfile
-          f = open(logfile, 'a')
-          f.write("Error running [%s]" % cmdstring)
-          f.write("Exception occurred: %s" % sys.exc_info()[0])
-          f.close()
-          raise # Now pass the exception upwards
-        print("COMPLETE: " + cmdstring)
-        sys.stdout.flush()
-  except redis.exceptions.ConnectionError:
-    print("Connection to redis-server lost, attempting to reconnect")
-    sys.stdout.flush()
-    server = connect_redis()
-  except SystemExit:
-    # If the sys.exit(0) from the interrupt handler gets caught here,
-    # just break from the while True: and let the script exit normally.
-    break
-  except:
-    print("Exception occurred", sys.exc_info()[0])
-    sys.exit(1)
-  time.sleep(0.2)
+            server = redis.Redis()
+            if server.ping():
+                print("Connected to redis server", flush=True)
+                return server
+        except redis.exceptions.ConnectionError:
+            print("Unable to connect to redis server, sleeping for 30s", flush=True)
+        time.sleep(30)
 
+
+def main():
+    print("Starting service-runner", flush=True)
+    server = connect_redis()
+    while True:
+        try:
+            # Get the next item from the 'service-runner' list, blocking until one exists
+            packed = server.blpop(KEYS)
+            if not packed:
+                continue
+            flag = packed[1].decode()
+        except redis.exceptions.ConnectionError:
+            print("Connection to redis server lost, attempting to reconnect", flush=True)
+            server = connect_redis()
+            continue
+
+        print("Got flag:", flag, flush=True)
+        script, logfile = flag.split(">")
+        print("STARTING:", script, '&>', logfile, flush=True)
+        # Got a cmdline, now run it.
+        with open(logfile, "a") as f:
+            try:
+                subprocess.call(shlex.split(script), stdout=f, stderr=f)
+            except Exception as exc:
+                # If an error occurs running the subprocess, add the error to
+                # the specified logfile
+                f.write("Error running [%s]" % script)
+                f.write("Exception occurred: %s" % exc)
+                continue
+        print("COMPLETE:", script, flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/services/service-runner/service-runner.service
+++ b/scripts/services/service-runner/service-runner.service
@@ -45,8 +45,8 @@ Documentation=https://github.com/emoncms/emoncms/blob/master/scripts/services/in
 #StandardOutput=file:/var/log/service-runner.log
 
 [Service]
-Type=idle
-ExecStart=/usr/bin/python /var/www/emoncms/scripts/services/service-runner/service-runner.py
+Type=simple
+ExecStart=/usr/bin/python3 /var/www/emoncms/scripts/services/service-runner/service-runner.py
 User=pi
 
 # Restart script if stopped


### PR DESCRIPTION
Port service-runner to python3.

- Change indentation to 4 spaces to conform with the rest of the
project.

- Utilise redis' blpop method to block until there is something to do,
instead of spinning with a short sleep.

- There was a lot of code fighting against itself, like signal handlers
which didn't do any cleanup, other than printing a message, which
complicated the main loop. Since the program is running under a service
supervisor (presumably systemd) this is unnecessary, so remove it.

- Utilise the print(..., flush=True) syntax.

- Avoid subprocess.call(..., shell=True). The command lines are so
simple that we can (and already do) parse them ourselves.

- Avoid wrapping too much code in a try/except. There is only one call
to redis and therefore only one place where the connection can fail, so
only handle those errors there.

- Move everything into a main function, to keep linters happy.

Tested on emonpi 2 with raspbian buster.