### PR TITLE
FIX: handling of missing feeds

### DIFF
--- a/Modules/feed/feed_controller.php
+++ b/Modules/feed/feed_controller.php
@@ -147,12 +147,15 @@ function feed_controller()
                             }
                         }
                     } else {
-                        $missing = $feedid;
+                        $missing[] = intval($feedid); //add feed id to array of missing ids
                     }
                 }
                 if (!empty($missing)) {
                     // return error if any feed ids not found
-                    return array('success'=>false, 'message'=> count($missing) .' feeds do not exist');
+                    if (count($missing) === 1) // if just one feed not found, return its id
+                        return array('success'=>false, 'message'=> "feed $missing[0] does not exist", 'feeds' => $missing);
+                    else
+                        return array('success'=>false, 'message'=> count($missing) .' feeds do not exist', 'feeds' => $missing);
                 } else {
                     
                     if ($singular && count($results)==1) {


### PR DESCRIPTION
When user deletes a feed and then open a previously saved graph, the `graph` module shows improper message and stalls with a broken graph with no ability to fix it. This PR fixes PHP error (improper collection of feed ids) and and suggest a solution for broken graphs by returning an array of missing feed ids. This will let the client (`graph` module) to remove bad feeds from the graph and keep good ones.