### PR TITLE
MOD: timezone as a linked field

### DIFF
--- a/Modules/user/user_model.php
+++ b/Modules/user/user_model.php
@@ -743,6 +743,15 @@ class User
         $stmt->bind_param("si", $timezone, $userid);
         $stmt->execute();
         $stmt->close();
+        $this->invalidate_feeds_cache($userid);
+    }
+
+    public function invalidate_feeds_cache($userid)
+    {
+        if (! $this->redis) return;
+        $feeds = $this->redis->smembers("user:feeds:$userid");
+        foreach($feeds as $feedid)
+            $this->redis->del("feed:$feedid");
     }
 
     //---------------------------------------------------------------------------------------
@@ -786,6 +795,7 @@ class User
             return array('success'=>false, 'message'=>_("Error updating user info"));
         }
         $stmt->close();
+        $this->invalidate_feeds_cache($userid);
     }
 
     // Generates a new random read apikey


### PR DESCRIPTION
Currently the timezone is retrieved in two steps - (1) get user id, (2) get timezone
This pull request suggest linking timezone from the user's table and accessing it with `get_field($feedid,'timezone')`.
Since get_field function uses REDIS cache when available, this approach should improve performance.
To handle timezone changes, the feeds cache is invalidated on updating the timezone field.