### PR TITLE
added missing generic-family to font name

### DIFF
--- a/process_settings.php
+++ b/process_settings.php
@@ -46,7 +46,7 @@ if ($settings_error) {
         echo "$settings_error_title\n";
         echo "$settings_error_message\n";
     } else {
-        echo "<div style='width:600px; background-color:#eee; padding:20px; font-family:arial;'>";
+        echo "<div style='width:600px; background-color:#eee; padding:20px; font-family:arial,serif;'>";
         echo "<h3>$settings_error_title</h3>";
         echo "<p>$settings_error_message</p>";
         echo "</div>";


### PR DESCRIPTION
Added serif to font-family:arial; as its missing a generic-family - options from one of the following: "serif", "sans-serif", "cursive", "fantasy", "monospace".