### PR TITLE
Clear warning when hosted on php7.4

### DIFF
--- a/locale.php
+++ b/locale.php
@@ -105,7 +105,7 @@ function set_lang($language)
 function set_lang_by_user($lang)
 {
     $locale = $lang.'.UTF8';
-    define(LC_MESSAGES, $locale);
+    define('LC_MESSAGES', $locale);
     putenv("LC_ALL=$locale");
     setlocale(LC_ALL, $locale);
 }


### PR DESCRIPTION
The following warning is generated when php = 7.4
<b>Warning:</b>
Use of undefined constant LC_MESSAGES - assumed 'LC_MESSAGES' (this will throw an Error in a future version of PHP) in C:\xampp\htdocs\emoncms\locale.php on line <b>108</b>