### PR TITLE
spelling error

### DIFF
--- a/Modules/feed/Views/feedlist_view.php
+++ b/Modules/feed/Views/feedlist_view.php
@@ -95,7 +95,7 @@ body{padding:0!important}
 #feeds-to-delete { font-style:italic; }
 
 #deleteFeedModalSelectedItems{
-    postion:absolute;
+    position:absolute;
     overflow:hidden;
     text-align:left;
     background: #f5f5f5;


### PR DESCRIPTION
error in the css postion isn't valid.
To see ignored attribute goto feeds create a new virtual feed then select delete. In the modal that pops up head to modal-footer > feeds-to-delete