### PR TITLE
admin model is applying formatting for file state

### DIFF
--- a/Modules/admin/admin_model.php
+++ b/Modules/admin/admin_model.php
@@ -424,12 +424,12 @@ class Admin {
      * @return void
      */
     public static function get_fs_state(){
-        $currentfs = "<b>read-only</b>";
+        $currentfs = "read-only";
         exec('mount', $resexec);
         $matches = null;
         preg_match('/^\/dev\/mmcblk0p2 on \/ .*(\(rw).*/mi', implode("\n",$resexec), $matches);
         if (!empty($matches)) {
-            $currentfs = "<b>read-write</b>";
+            $currentfs = "read-write";
         }
         if (!Admin::is_Pi()) $currentfs = '?';
         return $currentfs;


### PR DESCRIPTION
When viewing the Pi information in Admin the display of information is bold for the titles and normal for the information except for the read-write state. This sets the read-write/read-only value the same as all the other information.