### PR TITLE
Split the Temp Values to display what they are

### DIFF
--- a/Modules/admin/admin_main_view.php
+++ b/Modules/admin/admin_main_view.php
@@ -397,7 +397,8 @@ listItem;
             <?php echo row(sprintf('<span class="align-self-center">%s</span>',_('Model')), $rpi_info['model'].'<div>'.RebootBtn().ShutdownBtn().'</div>','d-flex','d-flex align-items-center justify-content-between') ?>
             <!-- <?php echo row(_('SoC'), $rpi_info['hw']) ?> -->
             <?php echo row(_('Serial num.'), strtoupper(ltrim($rpi_info['sn'], '0'))) ?>
-            <?php echo row(_('Temperature'), sprintf('%s - %s', $rpi_info['cputemp'], $rpi_info['gputemp'])) ?>
+            <?php echo row(_('CPU Temperature'), $rpi_info['cputemp']) ?>
+            <?php echo row(_('GPU Temperature'), $rpi_info['gputemp']) ?>
             <?php echo row(_('emonpiRelease'), $rpi_info['emonpiRelease']) ?>
             <?php echo row(_('File-system'), $rpi_info['currentfs']) ?>
         </dl>


### PR DESCRIPTION
Currently the temp values are given as `Temperature: 48.31°C - 44.31°C` but doesnt give any indication to what the temps are for.
This PR splits them up and labels them to show what the end user is looking at.
`CPU Temperature 47.77°C`
`GPU Temperature 46.41°C`