### PR TITLE
Fix for multi level topics and JSON Payload *Breaking Change*

### DIFF
--- a/scripts/services/emoncms_mqtt/emoncms_mqtt.php
+++ b/scripts/services/emoncms_mqtt/emoncms_mqtt.php
@@ -318,10 +318,10 @@
                     // added to front of input name.
                         $input_name_parts = array();
                         for ($i=1; $i<$route_len; $i++) $input_name_parts[] = $route[$i];
-                        $input_name = implode("_",$input_name_parts);
+                        $input_name = implode("_",$input_name_parts)."_";
                     }
                     foreach ($jsondata as $key=>$value) {
-                        $inputs[] = array("userid"=>$userid, "time"=>$time, "nodeid"=>$nodeid, "name"=>$input_name."_".$key, "value"=>$value);
+                        $inputs[] = array("userid"=>$userid, "time"=>$time, "nodeid"=>$nodeid, "name"=>$input_name.$key, "value"=>$value);
                     }
                 } else if ($route_len>=2) {
                     // Input name is all the remaining parts connected together

--- a/scripts/services/emoncms_mqtt/emoncms_mqtt.php
+++ b/scripts/services/emoncms_mqtt/emoncms_mqtt.php
@@ -312,8 +312,16 @@
                 $dbinputs = $input->get_inputs($userid);
 
                 if ($jsoninput) {
+                    $input_name = "";
+                    if ($route_len>=2) {
+                    // Input name is all the remaining parts connected together with _ and
+                    // added to front of input name.
+                        $input_name_parts = array();
+                        for ($i=1; $i<$route_len; $i++) $input_name_parts[] = $route[$i];
+                        $input_name = implode("_",$input_name_parts);
+                    }
                     foreach ($jsondata as $key=>$value) {
-                        $inputs[] = array("userid"=>$userid, "time"=>$time, "nodeid"=>$nodeid, "name"=>$key, "value"=>$value);
+                        $inputs[] = array("userid"=>$userid, "time"=>$time, "nodeid"=>$nodeid, "name"=>$input_name."_".$key, "value"=>$value);
                     }
                 } else if ($route_len>=2) {
                     // Input name is all the remaining parts connected together


### PR DESCRIPTION
#1612 

A MQTT message topic & payload such as 

`/emon/emontx001/0/Pulse 10`
and  
`/emon/emontx001/0 {"Pulse":10}` 

will now both appear under the Node `emontx001` as `0_Pulse`.