### PR TITLE
Possible solution to Cumulative totals resetting

### DIFF
--- a/Modules/feed/feed_model.php
+++ b/Modules/feed/feed_model.php
@@ -542,6 +542,10 @@ class Feed
                     $lastvalue['value'] = (float) $lastvalue['value'];
                 }
                 // CHAVEIRO comment: Can return NULL as a valid number or else processlist logic will be broken
+                // Test for avoid to reset PowerToKWh process feed
+                if (is_null($lastvalue['time']) || is_null($lastvalue['value'])) {
+                    $lastvalue = $this->EngineClass($engine)->lastvalue($id);
+                }
             } else {
                 // if it does not, load it in to redis from the actual feed data because we have no updated data from sql feeds table with redis enabled.
                 $lastvalue = $this->EngineClass($engine)->lastvalue($id);


### PR DESCRIPTION
I have seen this happen to me; i.e. the cumulative process resetting to zero.

Community discussion

https://community.openenergymonitor.org/t/correcting-cumulative-kwh-reset-with-post-process-module/4631/12

nicsergio suggested a fix to the get_timevalue() function. I have pulled that in here for discussion.

As it relates to one of your comments @chaveiro perhaps you could look at the logic.  I am **not** suggesting this is correct just the user reports that the issue stopped for him when using this code.

Another user has noted this happening as well. https://community.openenergymonitor.org/t/how-is-post-processing-supposed-to-work/15478

