### PR TITLE
Remove Time from input array

### DIFF
--- a/Modules/input/input_methods.php
+++ b/Modules/input/input_methods.php
@@ -56,6 +56,8 @@ class InputMethods
         //if ($param->exists('time')) $time = (int) $param->val('time'); else $time = time();
         if ($param->exists('time')) {
             $inputtime = $param->val('time');
+            // Remove from array so no used as an input
+            unset($jsondataLC['time']);
 
             // validate time
             if (is_numeric($inputtime)){


### PR DESCRIPTION
*Breaking change for anyone logging time*

re #1624 

Remove the time element from the array so no Input is created.

If the time is a string, then a N/A appears in the Inputs

If a user wants to log time it can be added as an additional JSON field but not called `time`.