### PR TITLE
Update core.php

### DIFF
--- a/core.php
+++ b/core.php
@@ -27,6 +27,8 @@ function get_application_path()
     } elseif (server('HTTP_X_FORWARDED_PROTO') == "https") {
         // Web server is running behind a proxy which is running HTTPS
         $proto = "https";
+    } elseif (request_header('HTTP_X_FORWARDED_PROTO') == "https") {
+        $proto = "https";
     }
 
     if (isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
@@ -146,6 +148,16 @@ function prop($index)
         $val = stripslashes($val);
     }
     return $val;
+}
+
+function request_header($index)
+{
+   $val = null;
+   $headers = apache_request_headers();
+   if (isset($headers[$index])) {
+        $val = $headers[$index];
+  }
+  return $val;
 }
 
 


### PR DESCRIPTION
When using docker and apache as reverse proxy
 RequestHeader set HTTP_X_FORWARDED_PROTO https
is not passed on to $_SERVER['HTTP_X_FORWARDED_PROTO'] hence emoncms remains in state HTTP with $proto as default set to https.

This fix resolves this issue by adding a check for reading request_headers and not $_SERVER variables.