### PR TITLE
Change how timestamp is removed from Inputs

### DIFF
--- a/Modules/input/input_methods.php
+++ b/Modules/input/input_methods.php
@@ -56,8 +56,6 @@ class InputMethods
         //if ($param->exists('time')) $time = (int) $param->val('time'); else $time = time();
         if ($param->exists('time')) {
             $inputtime = $param->val('time');
-            // Remove from array so no used as an input
-            unset($jsondataLC['time']);
 
             // validate time
             if (is_numeric($inputtime)){
@@ -131,6 +129,10 @@ class InputMethods
                 } else {
                     $log->info("No time element found in JSON - System time used");
                     $time = time();
+                }
+                // Remove from array so no used as an input
+                if (array_key_exists('time',$jsondataLC)){
+                    unset($jsondataLC['time']);
                 }
                 $inputs = $jsondata;
             } else {


### PR DESCRIPTION
As noted https://github.com/emoncms/emoncms/commit/c8c88dd0bb2a7f2df8aab5977e32d89bc4966b25#r46773477

The `unset` was in the wrong place.

Moved as a standalone condition to remove from the `$inputs` if it exists.

NEEDS TESTING