### PR TITLE
Remove Unset of time parameter

### DIFF
--- a/Modules/input/input_methods.php
+++ b/Modules/input/input_methods.php
@@ -57,7 +57,8 @@ class InputMethods
         if ($param->exists('time')) {
             $inputtime = $param->val('time');
             // Remove from array so no used as an input
-            unset($jsondataLC['time']);
+            // Removed as causing unexpected results.
+            // unset($jsondataLC['time']);
 
             // validate time
             if (is_numeric($inputtime)){


### PR DESCRIPTION
Remove `unset($jsondataLC['time']);` as it was causing unexpect results

https://community.openenergymonitor.org/t/anyone-importing-data-from-weewx-weather-station-into-emoncms-its-stopped-working/16916/2