### PR TITLE
Fix inputlist resize behaviour

### DIFF
--- a/Lib/emoncms.js
+++ b/Lib/emoncms.js
@@ -70,7 +70,7 @@ $(function(){
         clearTimeout(resizeTimeout)
         resizeTimeout = setTimeout(function() {
             $.event.trigger("window.resized");
-        }, 200);
+        }, 100);
     })
 });
 

--- a/Modules/input/Views/input_view.js
+++ b/Modules/input/Views/input_view.js
@@ -83,6 +83,9 @@ var app = new Vue({
             D: 100, // value     
             C: 50,  // config       
         },
+        col_h: {
+            H: 'auto'
+        },
         selected: [],
         collapsed: [],
         paused: false,
@@ -975,6 +978,7 @@ function draw_devices() {
     app.col.D = ((max_value_length * 8) + 17);
     app.col.E = ((max_time_length * 8) + 20) + 20; // additional padding to accomodate the 'weeks/days/hours/minutes/s' suffix
     app.col.H = 200
+    app.col_h.H = 'auto'
     
     resize_view();
 
@@ -984,6 +988,7 @@ function draw_devices() {
 }
 
 function resize_view() {
+    
     // Hide columns
     var col_max = JSON.parse(JSON.stringify(app.col));
     var rowWidth = $("#app").width();
@@ -1014,7 +1019,13 @@ function resize_view() {
     }
     
     for (var key in hidden) {
-        if (hidden[key]) app.col[key] = 0; else app.col[key] = col_max[key]
+        if (hidden[key]) {
+            app.col[key] = 0;
+            app.col_h[key] = 0;
+        } else {
+            app.col[key] = col_max[key]
+            app.col_h[key] = 'auto';
+        }
     }
 }
 
@@ -1303,10 +1314,8 @@ $("#save-processlist").click(function (){
 // watchResize(onResize,50) // only call onResize() after delay (similar to debounce)
 
 // debouncing causes odd rendering during resize - run this at all resize points...
-var resize_timeout = 0;
-$(window).on("resize",function() {
-    clearTimeout(resize_timeout)
-    resize_timeout = setTimeout(resize_view,40);
+$(window).on("window.resized",function() {
+    draw_devices();
 });
 
 

--- a/Modules/input/Views/input_view.php
+++ b/Modules/input/Views/input_view.php
@@ -262,7 +262,7 @@ input.checkbox-lg,
                 </div>
                 <div class="name text-nowrap" data-col="A" :style="{width:col.A+'px'}">{{ input.name }}</div>
                 <div class="description" data-col="G" :style="{width:col.G+'px'}">{{ input.description }}</div>
-                <div class="processlist" data-col="H" :style="{width:col.H+'px'}">
+                <div class="processlist" data-col="H" :style="{width:col.H+'px', height:col_h.H}">
                     <div class="label-container line-height-normal" v-html=input.processlistHtml></div>
                 </div>
                 <div class="buttons pull-right">


### PR DESCRIPTION
Fixes bug when resizing input lists. 

**What the bug looked like:**
![image](https://user-images.githubusercontent.com/503186/109631282-b718a800-7b3d-11eb-8ad0-e561671a9e47.png)

**Description:**
When resizing to small screen the processlist element retained it's original height even though the element is meant to be hidden by width = 0px. Adding another property to set the element height (col_h) and switching between auto and 0 height depending on whether it should be hidden or not fixes most of the issue.

There was an associated second issue to do with conflicting window resize events registered in Lib/emoncms.js and the input_list.js. This pull request switches to using the trigger created by the emoncms.js event rather than having a duplicate handler.

**Result**

![image](https://user-images.githubusercontent.com/503186/109631907-5b9aea00-7b3e-11eb-854c-76fe381e297b.png)
