### PR TITLE
Define GLOB_BRACE if non-existent

### DIFF
--- a/locale.php
+++ b/locale.php
@@ -12,6 +12,11 @@
 // no direct access
 defined('EMONCMS_EXEC') or die('Restricted access');
 
+
+// Work around for Alpine Linux
+!defined('GLOB_BRACE') or define('GLOB_BRACE', 0);
+
+
 // Return all locale directory from all modules.
 // If one module has a language it will be detected
 function directoryLocaleScan($dir)


### PR DESCRIPTION
Resolves #1680 

Tested against the emoncms hassio image.

https://github.com/inverse/hassio-addon-emoncms/issues/16#issuecomment-819750768

That warning is no-longer present. The others I'll still need to figure out though.