### PR TITLE
Admin display of masked services

### DIFF
--- a/Modules/admin/admin_controller.php
+++ b/Modules/admin/admin_controller.php
@@ -81,7 +81,7 @@ function admin_controller()
                     	if ($value['LoadState']==='masked') {          // Check if service is masked (installed, but configured not to run)
                     		$services[$key]['cssClass'] = 'masked';
                     		$services[$key]['text'] = 'Masked';
-                    	} elseif ($value['SubState']==='running') {    // If not masked, check if file is running
+                    	} elseif ($value['SubState']==='running') {    // If not masked, check if service is running
                     		$services[$key]['cssClass'] = 'success';
                     	} else {                                       // Assume service is in danger
                     		$services[$key]['cssClass'] = 'danger';

--- a/Modules/admin/admin_controller.php
+++ b/Modules/admin/admin_controller.php
@@ -78,14 +78,14 @@ function admin_controller()
                         );
                     	
                     	// Set 'cssClass' based on service's configuration and current status
-                        if ($value['SubState']==='running') {                // Check if service is running
-                            $services[$key]['cssClass'] = 'success';
-                        } elseif ($value['UnitFileState']==='disabled') {    // If service isn't running, check if its disabled
-                            $services[$key]['cssClass'] = 'disabled';
-                            $services[$key]['text'] = 'Disabled';
-                        } else {                                             // Service is not running and not disabled, so is in a failed state
-                            $services[$key]['cssClass'] = 'danger';
-                        }
+                    	if ($value['LoadState']==='masked') {          // Check if service is masked (installed, but configured not to run)
+                    		$services[$key]['cssClass'] = 'masked';
+                    		$services[$key]['text'] = 'Masked';
+                    	} elseif ($value['SubState']==='running') {    // If not masked, check if file is running
+                    		$services[$key]['cssClass'] = 'success';
+                    	} else {                                       // Assume service is in danger
+                    		$services[$key]['cssClass'] = 'danger';
+                    	}
                     }
                 }
                 // add custom messages for feedwriter service

--- a/Modules/admin/admin_controller.php
+++ b/Modules/admin/admin_controller.php
@@ -68,19 +68,22 @@ function admin_controller()
                 $services = array();
                 $system = Admin::system_information();
                 foreach($system['services'] as $key=>$value) {
-                    if (!is_null($system['services'][$key])) {
-                        $services[$key] = array(
+                    if (!is_null($system['services'][$key])) {    // If the service was found on this system
+                        
+                        // Populate service status fields
+                    	$services[$key] = array(
                             'state' => ucfirst($value['ActiveState']),
                             'text' => ucfirst($value['SubState']),
-                            //'cssClass' => $value['SubState']==='running' ? 'success': 'danger',
                             'running' => $value['SubState']==='running'
                         );
-                        if ($value['SubState']==='running') {                // Check if file is running
+                    	
+                    	// Set 'cssClass' based on service's configuration and current status
+                        if ($value['SubState']==='running') {                // Check if service is running
                             $services[$key]['cssClass'] = 'success';
-                        } elseif ($value['UnitFileState']==='disabled') {    // Check if service is disabled
+                        } elseif ($value['UnitFileState']==='disabled') {    // If service isn't running, check if its disabled
                             $services[$key]['cssClass'] = 'disabled';
                             $services[$key]['text'] = 'Disabled';
-                        } else {                                             // Assume service is in danger
+                        } else {                                             // Service is not running and not disabled, so is in a failed state
                             $services[$key]['cssClass'] = 'danger';
                         }
                     }

--- a/Modules/admin/admin_controller.php
+++ b/Modules/admin/admin_controller.php
@@ -236,14 +236,23 @@ function admin_controller()
                     // Get update argument e.g. 'emonpi' or 'rfm69pi'
                     $firmware="";
                     if (isset($_POST['firmware'])) $firmware = $_POST['firmware'];
-                    if (!in_array($firmware,array("none","emonpi","rfm69pi","rfm12pi","custom"))) return "Invalid firmware type";
+                    if (!in_array($firmware,array("none","emonpi","rfm69pi","rfm12pi","custom","emontxv3cm"))) return "Invalid firmware type";
                     // Type: all, emoncms, firmware
                     $type="";
                     if (isset($_POST['type'])) $type = $_POST['type'];
                     if (!in_array($type,array("all","emoncms","firmware","emonhub"))) return "Invalid update type";
+                    // Serial port
+                    $serial_port="ttyAMA0";
+                    if ($_POST['serial_port'] == "null") {
+                        $serial_port = "";
+                    }
+                    else if (isset($_POST['serial_port'])) {
+                        $serial_port = $_POST['serial_port'];
+                        if (!in_array($serial_port,array("ttyAMA0","ttyUSB0","ttyUSB1","ttyUSB2"))) return "Invalid serial port type";  
+                    }
                     
                     if ($redis) {
-                        $redis->rpush("service-runner","$update_script $type $firmware>$update_logfile");
+                        $redis->rpush("service-runner","$update_script $type $firmware $serial_port>$update_logfile");
                         return "service-runner trigger sent";
                     } else {
                         return "redis not running";

--- a/Modules/admin/admin_model.php
+++ b/Modules/admin/admin_model.php
@@ -29,11 +29,15 @@ class Admin {
         }
         if (isset($status['LoadState']) && $status['LoadState'] === 'not-found') {
             $return = null;
-        } else if (isset($status["ActiveState"]) && isset($status["SubState"])) {
+        } else if (
+        		isset($status["ActiveState"]) &&
+        		isset($status["SubState"]) &&
+        		isset($status["LoadState"])
+        		) {
             return array(
                 'ActiveState' => $status["ActiveState"],
                 'SubState' => $status["SubState"],
-                'UnitFileState' => $status["UnitFileState"]
+                'LoadState' => $status["LoadState"]
             );
         } else {
             $return = null;

--- a/Modules/admin/admin_model.php
+++ b/Modules/admin/admin_model.php
@@ -32,7 +32,8 @@ class Admin {
         } else if (isset($status["ActiveState"]) && isset($status["SubState"])) {
             return array(
                 'ActiveState' => $status["ActiveState"],
-                'SubState' => $status["SubState"]
+                'SubState' => $status["SubState"],
+                'UnitFileState' => $status["UnitFileState"]
             );
         } else {
             $return = null;

--- a/Modules/admin/static/admin_styles.css
+++ b/Modules/admin/static/admin_styles.css
@@ -34,6 +34,9 @@ table tr td.subinfo { border-color:transparent;}
 .badge-danger{
     background-color: #DC3545;
 }
+.badge-disabled{
+    background-color: #808080;
+}
 section {
     position: relative;
 }

--- a/Modules/admin/static/admin_styles.css
+++ b/Modules/admin/static/admin_styles.css
@@ -34,7 +34,7 @@ table tr td.subinfo { border-color:transparent;}
 .badge-danger{
     background-color: #DC3545;
 }
-.badge-disabled{
+.badge-masked{
     background-color: #808080;
 }
 section {


### PR DESCRIPTION
The Admin page did not handle a situation where a service was loaded in systemd but purposefully masked so it wouldn't run (for example, when running the MQTT broker on another machine).  Masked services were reported as errors since they weren't running, whether they were supposed to or not.  Such services are now displayed in a new 'Masked' state with a grey status badge (instead of the original red/green badges).

See further discussion of this change at https://community.openenergymonitor.org/t/admin-page-services-status-doesnt-handle-disabled-services/15793/2