### PR TITLE
secure session cookie, use samesite=strict

### DIFF
--- a/Modules/user/rememberme_model.php
+++ b/Modules/user/rememberme_model.php
@@ -40,8 +40,12 @@ class Rememberme {
     // ---------------------------------------------------------------------------------------------------------
     public function __construct($mysqli)
     {
-            $this->mysqli = $mysqli;
-            $this->log = new EmonLogger(__FILE__);
+        $this->mysqli = $mysqli;
+        $this->log = new EmonLogger(__FILE__);
+        
+        if (is_https()) {
+            $this->secure = true;
+        }
     }
 
     // ---------------------------------------------------------------------------------------------------------
@@ -49,7 +53,16 @@ class Rememberme {
     {
         $this->log->info("setCookie: $content $expire");
         
-        setcookie($this->cookieName,$content,$expire,$this->path,$this->domain,$this->secure,$this->httpOnly);
+        // setcookie($this->cookieName,$content,$expire,$this->path,$this->domain,$this->secure,$this->httpOnly);
+        // May be limited to PHP7.3
+        setcookie($this->cookieName,$content, [
+            'expires' => $expire,
+            'path' => $this->path,
+            'domain' => $this->domain,
+            'secure' => $this->secure,
+            'httponly' => $this->httpOnly,
+            'samesite' => 'Strict'
+        ]);
         
         // Double check cookie saved correctly
         if (isset($_COOKIE[$this->cookieName]) && $_COOKIE[$this->cookieName]!=$content) {

--- a/Modules/user/user_model.php
+++ b/Modules/user/user_model.php
@@ -154,15 +154,14 @@ class User
         if (substr($cookie_params['path'], -1) !== '/')
             $cookie_params['path'] .= '/';
         //not pass cookie to javascript 
-        $cookie_params['httponly'] = 1; 
+        $cookie_params['httponly'] = true;
+        $cookie_params['samesite'] = 'Strict';
         
-        session_set_cookie_params(
-            $cookie_params['lifetime'],
-            $cookie_params['path'],
-            $cookie_params['domain'],
-            $cookie_params['secure'],
-            $cookie_params['httponly'] 
-        );
+        if (is_https()) {
+            $cookie_params['secure'] = true;
+        }
+        
+        session_set_cookie_params($cookie_params);
         session_start();
 
         if ($this->enable_rememberme)

--- a/core.php
+++ b/core.php
@@ -15,20 +15,26 @@
 // no direct access
 defined('EMONCMS_EXEC') or die('Restricted access');
 
-function get_application_path()
-{
-    // Default to http protocol
-    $proto = "http";
-
+function is_https() {
     // Detect if we are running HTTPS or proxied HTTPS
     if (server('HTTPS') == 'on') {
         // Web server is running native HTTPS
-        $proto = "https";
+        return true;
     } elseif (server('HTTP_X_FORWARDED_PROTO') == "https") {
         // Web server is running behind a proxy which is running HTTPS
-        $proto = "https";
+        return true;
     } elseif (request_header('HTTP_X_FORWARDED_PROTO') == "https") {
+        return true;
+    }
+    return false;
+}
+
+function get_application_path()
+{
+    if (is_https()) {
         $proto = "https";
+    } else {
+        $proto = "http";
     }
 
     if (isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {


### PR DESCRIPTION
Protect against Cross-Site Request Forgery by restricting use of session cookie to emoncms domain