### PR TITLE
use get_data_combined directly in feed_model

### DIFF
--- a/Modules/feed/engine/CassandraEngine.php
+++ b/Modules/feed/engine/CassandraEngine.php
@@ -166,7 +166,7 @@ class CassandraEngine implements engine_methods
      * @param integer $limitinterval not implemented
      *
      */
-    public function get_data($feedid,$start,$end,$interval,$skipmissing,$limitinterval)
+    public function get_data_combined($feedid,$start,$end,$interval,$average=0,$timezone="UTC",$timeformat="unix",$csv=false,$skipmissing=0,$limitinterval=1)
     {
         global $settings; // max_datapoints;
 

--- a/Modules/feed/engine/PHPFina.php
+++ b/Modules/feed/engine/PHPFina.php
@@ -583,23 +583,7 @@ class PHPFina implements engine_methods
             return $data;
         }
     }
-    
-    public function get_data($id,$start,$end,$interval,$skipmissing,$limitinterval) {
-        return $this->get_data_combined($id,$start,$end,$interval,0,"UTC","unix",false,$skipmissing,$limitinterval);
-    }
-    
-    public function get_data_DMY($id,$start,$end,$mode,$timezone) {
-        return $this->get_data_combined($id,$start,$end,$mode,0,$timezone,"unix",false,0,0);
-    }
-    
-    public function get_average($id,$start,$end,$interval) {
-        return $this->get_data_combined($id,$start,$end,$interval,1,"UTC","unix",false,0,0);  
-    }
-    
-    public function get_average_DMY($id,$start,$end,$mode,$timezone) {
-        return $this->get_data_combined($id,$start,$end,$mode,1,$timezone,"unix",false,0,0);
-    }
-    
+        
     public function csv_export($id,$start,$end,$interval,$timezone) {
         if ($timezone==false) {
             $timeformat = "unix";

--- a/Modules/feed/engine/PHPFinaTest.php
+++ b/Modules/feed/engine/PHPFinaTest.php
@@ -63,7 +63,8 @@ class PHPFinaTest extends \PHPUnit\Framework\TestCase {
     public function testGet_data() {
         $skipmissing = 0;
         $limitinterval = 1;
-		$data = $this->engine->get_data($this->feedid,$this->start,$this->end,$this->interval,$skipmissing,$limitinterval);
+		    $data = $this->engine->get_data_combined($this->feedid,$this->start,$this->end,$this->interval,0,"UTC","unix",false,$skipmissing,$limitinterval);
+		
         $this->assertTrue(!empty($data) && empty($data['success']), 'no blank result or success == false');
     }
 
@@ -83,23 +84,8 @@ class PHPFinaTest extends \PHPUnit\Framework\TestCase {
         $this->assertTrue(strpos($response->content(), 'csv') !== false);
 	}
 
-    public function testGet_average_DMY() {
-		$this->engine->get_average_DMY($this->feedid,$this->start,$this->end,$mode,$timezone);
-		$this->assertTrue(false);
-	}
-
-    public function testGet_average() {
-		$this->engine->get_average($this->feedid,$this->start,$this->end,$this->outinterval);
-		$this->assertTrue(false);
-	}
-
     public function testGet_data_DMY_time_of_day() {
 		$this->engine->get_data_DMY_time_of_day($this->feedid,$this->start,$this->end,$mode,$timezone,$split);
-		$this->assertTrue(false);
-	}
-
-    public function testGet_data_DMY() {
-		$this->engine->get_data_DMY($this->feedid,$this->start,$this->end,$mode,$timezone);
 		$this->assertTrue(false);
 	}
 

--- a/Modules/feed/engine/PHPTimeSeries.php
+++ b/Modules/feed/engine/PHPTimeSeries.php
@@ -437,22 +437,6 @@ class PHPTimeSeries implements engine_methods
             return $data;
         }
     }
-
-    public function get_data($id,$start,$end,$interval,$skipmissing,$limitinterval) {
-        return $this->get_data_combined($id,$start,$end,$interval,0,"UTC","unix",false,$skipmissing,$limitinterval);
-    }
-    
-    public function get_data_DMY($id,$start,$end,$mode,$timezone) {
-        return $this->get_data_combined($id,$start,$end,$mode,0,$timezone,"unix",false,0,0);
-    }
-    
-    public function get_average($id,$start,$end,$interval) {
-        return $this->get_data_combined($id,$start,$end,$interval,1,"UTC","unix",false,0,0);  
-    }
-    
-    public function get_average_DMY($id,$start,$end,$mode,$timezone) {
-        return $this->get_data_combined($id,$start,$end,$mode,1,$timezone,"unix",false,0,0);
-    }
     
     public function csv_export($id,$start,$end,$interval,$timezone) {
         if ($timezone==false) {

--- a/Modules/feed/engine/RedisBuffer.php
+++ b/Modules/feed/engine/RedisBuffer.php
@@ -125,7 +125,7 @@ class RedisBuffer implements engine_methods
      * @param integer $skipmissing not implemented
      * @param integer $limitinterval not implemented
     */
-    public function get_data($feedid,$start,$end,$interval,$skipmissing,$limitinterval)
+    public function get_data_combined($feedid,$start,$end,$interval,$average=0,$timezone="UTC",$timeformat="unix",$csv=false,$skipmissing=0,$limitinterval=1)
     {
         $feedid = intval($feedid);
         $start = round($start/1000);
@@ -135,14 +135,12 @@ class RedisBuffer implements engine_methods
         $len = $this->redis->zCount("feed:$feedid:buffer",$start,$end);
         // process if there is data on buffer for the range
         if ($len > 0) {
-            $this->log->info("get_data() feed=$feedid len=$len start=$start end=$end");
+            $this->log->info("get_data_combined() feed=$feedid len=$len start=$start end=$end");
             $range = 50000; // step range number of points to extract on each iteration 50k-100k is ok
             for ($i=0; $i<=$len; $i = $i + $range)
             {
-                //$this->log->info("get_data() Reading block $i");
                 $buf_item = $this->redis->zRangeByScore("feed:$feedid:buffer", $start, $end, array('withscores' => true, 'limit' => array($i, $range)));
                 foreach($buf_item as $rawvalue => $time) {
-                    //$this->log->info("get_data() time=$time rawvalue=$rawvalue");
                     $f = explode("|",$rawvalue);
                     $value = $f[1];
                     $time=$time*1000;

--- a/Modules/feed/engine/TemplateEngine.php
+++ b/Modules/feed/engine/TemplateEngine.php
@@ -133,14 +133,9 @@ class TemplateEngine implements engine_methods
      * please note that unix timestamps should be expressed in ms cause coming from the js
      * 
     */
-    public function get_data($feedid,$start,$end,$interval,$skipmissing,$limitinterval)
+    public function get_data_combined($id,$start,$end,$interval,$average=0,$timezone="UTC",$timeformat="unix",$csv=false,$skipmissing=0,$limitinterval=1)
     {
         return array();
-    }
-
-    public function get_data_DMY($id,$start,$end,$mode,$timezone)
-    {
-    
     }
     
     public function get_data_DMY_time_of_day($id,$start,$end,$mode,$timezone,$split) 
@@ -176,16 +171,6 @@ class TemplateEngine implements engine_methods
         foreach ($this->writebuffer as $feedid=>$data) {
         // $this->someSaveMechanism->array($data[$p][0],$data[$p][1]);
         }
-    }
-
-    public function get_average($id,$start,$end,$interval)
-    {
-    
-    }
-    
-    public function get_average_DMY($id,$start,$end,$mode,$timezone)
-    {
-    
     }
     
     public function upload_fixed_interval($id,$start,$interval,$npoints)

--- a/Modules/feed/engine/VirtualFeed.php
+++ b/Modules/feed/engine/VirtualFeed.php
@@ -93,15 +93,16 @@ class VirtualFeed implements engine_methods
     // 4-  First processor of virtual feed processlist should be the source_feed_data_time() this will get data from a slot.
     // 5 - Agreggates all slots time and processed data.
     // 6 - Returns data to the graph.
-    public function get_data($feedid,$start,$end,$interval,$skipmissing,$limitinterval)
+    public function get_data_combined($feedid,$start,$end,$interval,$average=0,$timezone="UTC",$timeformat="unix",$csv=false,$skipmissing=0,$limitinterval=1)
     {
-        $feedid = intval($feedid);
+        $feedid = (int) $feedid;
         $processList = $this->feed->get_processlist($feedid);
-        if ($processList == '' || $processList == null) { return false; }
-        $start = round($start/1000);
-        $end = round($end/1000);
-        $interval = intval($interval); // time gap in seconds
-                
+        if ($processList == '' || $processList == null) return false;
+        
+        $start = $start * 0.001;
+        $end = $end * 0.001;
+
+        $interval = (int) $interval; // time gap in seconds
         if ($interval<1) $interval = 1;
         $dp = ceil(($end - $start) / $interval); // datapoints for desied range with set interval time gap
         $end = $start + ($dp * $interval);
@@ -184,8 +185,8 @@ class VirtualFeed implements engine_methods
 
         // Write to output stream
         $exportfh = @fopen( 'php://output', 'w' );
-
-        $data = $this->get_data($feedid,$start*1000,$end*1000,$outinterval,0,0);
+        
+        $data = $this->get_data_combined($feedid,$start*1000,$end*1000,$outinterval,0,"UTC","unix",false,0,0);
         $max = sizeof($data);
         for ($i=0; $i<$max; $i++){
             $timenew = $helperclass->getTimeZoneFormated($data[$i][0]/1000,$usertimezone);

--- a/Modules/feed/engine/VirtualFeed.php
+++ b/Modules/feed/engine/VirtualFeed.php
@@ -112,9 +112,8 @@ class VirtualFeed implements engine_methods
         $dataValue = null;
                 
         // Lets instantiate a new class of process so we can run many proceses recursively without interference
-        global $session,$user;
         require_once "Modules/process/process_model.php";
-        $process = new Process($this->mysqli,$this->input,$this->feed,$user->get_timezone($userid));
+        $process = new Process($this->mysqli,$this->input,$this->feed,$timezone);
 
         if ($dp > 0) 
         {

--- a/Modules/feed/engine/shared_helper.php
+++ b/Modules/feed/engine/shared_helper.php
@@ -159,36 +159,19 @@ interface engine_methods{
     /**
      * Return the data for the given timerange
      *
-     * @param integer $feedid The id of the feed to fetch from
+     * @param integer $id The id of the feed to fetch from
      * @param integer $start The unix timestamp in ms of the start of the data range
      * @param integer $end The unix timestamp in ms of the end of the data range
-     * @param integer $interval The number os seconds for each data point to return (used by some engines)
-     * @param integer $skipmissing Skip null values from returned data (used by some engines)
-     * @param integer $limitinterval Limit datapoints returned to this value (used by some engines)
-    */
-    public function get_data($feedid,$start,$end,$interval,$skipmissing,$limitinterval);
-    
-    /**
-     * return data in csv format
-     *
-     * @param integer $feedid The id of the feed to fetch from
-     * @param integer $start The unix timestamp in ms of the start of the data range
-     * @param integer $end The unix timestamp in ms of the end of the data range
-     * @param integer $outinterval The number of seconds for each data point to return 
-     * @param mixed One of the supported timezone names or an offset value (+0200). 
-     * @return void
+     * @param integer $interval output data point interval
+     * @param integer $average enabled/disable averaging
+     * @param string $timezone a name for a php timezone eg. "Europe/London"
+     * @param string $timeformat csv datetime format e.g: unix timestamp, excel, iso8601
+     * @param integer $csv pipe output as csv
+     * @param integer $skipmissing skip null datapoints
+     * @param integer $limitinterval limit interval to feed interval
+     * @return void or array
      */
-
-    /**
-     * @param integer $feedid The id of the feed to fetch from
-     * @param integer $start The unix timestamp in ms of the start of the data range
-     * @param integer $end The unix timestamp in ms of the end of the data range
-     * @param integer $outinterval output data point interval
-     * @param string $usertimezone a name for a php timezone eg. "Europe/London"
-     * @see http://php.net/manual/en/timezones.php
-     * @return void
-     */
-    public function csv_export($feedid,$start,$end,$outinterval,$usertimezone);    
+    public function get_data_combined($feedid,$start,$end,$interval,$average,$timezone,$timeformat,$csv,$skipmissing,$limitinterval);
     
     /**
      * delete all past data for a feed. keeping all the feed settings the same

--- a/Modules/feed/feed_controller.php
+++ b/Modules/feed/feed_controller.php
@@ -27,7 +27,8 @@ function feed_controller()
     $input = new Input($mysqli,$redis,$feed);
     
     require_once "Modules/process/process_model.php";
-    $process = new Process($mysqli,$input,$feed,$user->get_timezone($session['userid']));
+    $user_timezone = $user->get_timezone($session['userid']);
+    $process = new Process($mysqli,$input,$feed,$user_timezone);
 
     if ($route->format == 'html')
     {
@@ -131,20 +132,20 @@ function feed_controller()
                                 if (isset($_GET['limitinterval']) && $_GET['limitinterval']==0) $limitinterval = 0;
                                 
                                 if (isset($_GET['interval'])) {
-                                    $results[$key]['data'] = $feed->get_data($feedid,get('start'),get('end'),get('interval'),$skipmissing,$limitinterval);
+                                    $results[$key]['data'] = $feed->get_data($feedid,get('start'),get('end'),get('interval'),0,"UTC","unix",false,$skipmissing,$limitinterval);
                                 } else if (isset($_GET['mode'])) {
                                     if (isset($_GET['split'])) {
                                         $results[$key]['data'] = $feed->get_data_DMY_time_of_day($feedid,get('start'),get('end'),get('mode'),get('split'));
                                     } else {
-                                        $results[$key]['data'] = $feed->get_data_DMY($feedid,get('start'),get('end'),get('mode'));
+                                        $results[$key]['data'] = $feed->get_data($feedid,get('start'),get('end'),get('mode'),0,$user_timezone,"unix",false,0,0);
                                     }
                                 }
                             // feed/average --------------------------------------------   
                             } else if ($route->action == 'average') {
                                 if (isset($_GET['mode'])) {
-                                    $results[$key]['data'] = $feed->get_average_DMY($feedid,get('start'),get('end'),get('mode'));
+                                    $results[$key]['data'] = $feed->get_data($feedid,get('start'),get('end'),get('mode'),1,$user_timezone,"unix",false,0,0);
                                 } else if (isset($_GET['interval'])) {
-                                    $results[$key]['data'] = $feed->get_average($feedid,get('start'),get('end'),get('interval'));
+                                    $results[$key]['data'] = $feed->get_data($feedid,get('start'),get('end'),get('interval'),1,"UTC","unix",false,0,0);                          
                                 } 
                             }
                         }

--- a/Modules/process/process_processlist.php
+++ b/Modules/process/process_processlist.php
@@ -1504,7 +1504,7 @@ class Process_ProcessList
             }
             $start*=1000; // convert to milliseconds for engine
             $end*=1000;
-            $data = $this->feed->get_data($feedid,$start,$end,$interval,1,1); // get data from feed engine with skipmissing and limit interval options
+            $data = $this->feed->get_data($feedid,$start,$end,$interval,"UTC","unix",false,1,1);
         } else {
             
             $data = $this->feed->get_timevalue($feedid); // get last data from feed engine 

--- a/Modules/process/process_processlist.php
+++ b/Modules/process/process_processlist.php
@@ -1504,7 +1504,7 @@ class Process_ProcessList
             }
             $start*=1000; // convert to milliseconds for engine
             $end*=1000;
-            $data = $this->feed->get_data($feedid,$start,$end,$interval,"UTC","unix",false,1,1);
+            $data = $this->feed->get_data($feedid,$start,$end,$interval,0,"UTC","unix",false,1,1);
         } else {
             
             $data = $this->feed->get_timevalue($feedid); // get last data from feed engine 


### PR DESCRIPTION
Part of work on https://github.com/emoncms/emoncms/issues/1744

use get_data_combined directly in feed_model, remove get_data_DMY, get_average & get_average_DMY methods