### PR TITLE
wider timeformat support both for request params and returned data

### DIFF
--- a/Modules/feed/engine/CassandraEngine.php
+++ b/Modules/feed/engine/CassandraEngine.php
@@ -171,8 +171,8 @@ class CassandraEngine implements engine_methods
         global $settings; // max_datapoints;
 
         $feedid = (int) $feedid;
-        $start = round($start/1000);
-        $end = round($end/1000);
+        $start = (int) $start;
+        $end = (int) $end;
         $interval = intval($interval);
         $feedname = $this->feedtable($feedid);
         // Minimum interval
@@ -192,7 +192,7 @@ class CassandraEngine implements engine_methods
                 if($time>=$dp_time){
                     if ($dataValue!=NULL || $skipmissing===0) { // Remove this to show white space gaps in graph
                         if ($dataValue !== null) $dataValue = (float) $dataValue;
-                        $data[] = array($time * 1000, $dataValue);
+                        $data[] = array($time, $dataValue);
                     }
                     $dp_time+=$interval;
                 }
@@ -234,8 +234,8 @@ class CassandraEngine implements engine_methods
     public function deletedatarange($feedid,$start,$end)
     {
         $feedid = (int) $feedid;
-        $start = intval($start/1000.0);
-        $end = intval($end/1000.0);
+        $start = (int) $start;
+        $end = (int) $end;
         $day_range = range($this->unixtoday($start), $this->unixtoday($end));
 
         $feedname = $this->feedtable($feedid);

--- a/Modules/feed/engine/MysqlTimeSeries.php
+++ b/Modules/feed/engine/MysqlTimeSeries.php
@@ -143,16 +143,13 @@ class MysqlTimeSeries implements engine_methods
     public function get_average($feedid, $start, $end, $interval)
     {
         $feedid = (int) $feedid;
-        $start = intval($start/1000);
-        $end = intval($end/1000);
+        $start = (int) $start;
+        $end = (int) $end;
         $interval= (int) $interval;
 
         // Minimum interval
         if ($interval < 1) $interval = 1;
-        // Maximum request size
-        $req_dp = round(($end - $start)/$interval);
-        if ($req_dp > 10000) return array('success'=>false, 'message'=>"Request datapoint limit reached (10000), increase request interval or time range, requested datapoints = $req_dp");
-
+        
         $table = $this->get_table_name($feedid);
         $data = array();
 
@@ -160,7 +157,7 @@ class MysqlTimeSeries implements engine_methods
         $result = $this->mysqli->query($sql);
         if ($result) {
             while($row = $result->fetch_array()) {
-                $data[] = array((int) $row['time']*1000, (float) $row['data_avg']);
+                $data[] = array((int) $row['time'], (float) $row['data_avg']);
             }
         }
         return $data;
@@ -180,8 +177,8 @@ class MysqlTimeSeries implements engine_methods
         $feedid = (int) $feedid;
         if ($mode!="daily" && $mode!="weekly" && $mode!="monthly" && $mode!="annual") return false;
 
-        $start = intval($start/1000);
-        $end = intval($end/1000);
+        $start = (int) $start;
+        $end = (int) $end;
         $table = $this->get_table_name($feedid);
         $data = array();
 
@@ -210,9 +207,9 @@ class MysqlTimeSeries implements engine_methods
                 $dp = $result->fetch_array();
                 if ($dp != null) {
                     if ($dp['dp'] !== null) $dp['dp'] = (float) $dp['dp'];
-                    $data[] = array( $interval_start*1000 , $dp['dp']);
+                    $data[] = array( $interval_start , $dp['dp']);
                 } else {
-                    $data[] = array( $interval_start*1000 , null);
+                    $data[] = array( $interval_start , null);
                 }
             }
             $n++;
@@ -306,8 +303,8 @@ class MysqlTimeSeries implements engine_methods
         global $settings;
 
         $feedid = intval($feedid);
-        $start = round($start/1000);
-        $end = round($end/1000);
+        $start = (int) $start;
+        $end = (int) $end;
         $interval = intval($interval); // time gap in seconds
 
         if ($interval < 1) $interval = 1;
@@ -332,7 +329,7 @@ class MysqlTimeSeries implements engine_methods
                 $stmt->execute();
                 if ($stmt->fetch()) {
                     if ($data_value != null || $skipmissing === 0) { // Remove this to show white space gaps in graph
-                        $time = $data_time * 1000;
+                        $time = $data_time;
                         if ($data_value !== null) $data_value = (float) $data_value ;
                         $data[] = array($time, $data_value);
                     }
@@ -362,7 +359,7 @@ class MysqlTimeSeries implements engine_methods
                 while($row = $result->fetch_array()) {
                     $data_value = $row['data'];
                     if ($data_value != null || $skipmissing === 0) { // Remove this to show white space gaps in graph
-                        $time = $row['time'] * 1000 * $td;
+                        $time = $row['time'] * $td;
                         if ($data_value !== null) $data_value = (float) $data_value ;
                         $data[] = array($time , $data_value);
                     }
@@ -386,8 +383,8 @@ class MysqlTimeSeries implements engine_methods
         if (!in_array($mode,array("daily","weekly","monthly","annual"))) return false;
         
         $feedid = (int) $feedid;
-        $start = intval($start/1000);
-        $end = intval($end/1000);
+        $start = (int) $start;
+        $end = (int) $end;
         $table = $this->get_table_name($feedid);
         $data = array();
 
@@ -426,16 +423,16 @@ class MysqlTimeSeries implements engine_methods
             // Limit DB requests to available datapoints in feed
             if ($range[0]['time'] < $time &&  $time < $range[1]['time']) {
                 // get datapoint using interpolation if necessary
-                $data[] = $this->get_datapoint_interpolated($feedid, $time * 1000);
+                $data[] = $this->get_datapoint_interpolated($feedid, $time);
             }
             elseif($time >= $range[1]['time']) {
                 // return latest feed value
-                $data[] = array($time *1000, (float) $range[1]['data']);
+                $data[] = array($time, (float) $range[1]['data']);
                 break;
             }
             else {
                 // return NULL if requested time is out of feed range
-                $data[] = array($time *1000, null);
+                $data[] = array($time, null);
             }
             $date->modify($increment);
             $n++;
@@ -448,8 +445,8 @@ class MysqlTimeSeries implements engine_methods
         if (!in_array($mode,array("daily","weekly","monthly","annual"))) return false;
 
         $feedid = (int) $feedid;
-        $start = intval($start/1000);
-        $end = intval($end/1000);
+        $start = (int) $start;
+        $end = (int) $end;
         $table = $this->get_table_name($feedid);
         $data = array();
         $split = json_decode($split);
@@ -501,7 +498,7 @@ class MysqlTimeSeries implements engine_methods
                 // Limit DB requests to available datapoints in feed
                 if ($range[0]['time'] < $time &&  $time < $range[1]['time']) {
                     // get datapoint using interpolation if necessary
-                    $result = $this->get_datapoint_interpolated($feedid, $split_time * 1000);
+                    $result = $this->get_datapoint_interpolated($feedid, $split_time);
                     $value = $result[1];
                 }
                 elseif($time >= $range[1]['time']) {
@@ -514,7 +511,7 @@ class MysqlTimeSeries implements engine_methods
                 }
                 $split_values[] = $value;
             }
-            $data[] = array($time*1000, $split_values);
+            $data[] = array($time, $split_values);
             $date->modify($increment);
             $n++;
         }
@@ -551,7 +548,7 @@ class MysqlTimeSeries implements engine_methods
                 }
             }
         } else {
-            return $this->csv_export($feedid, $start*0.001, $end*0.001, $interval, $timezone);
+            return $this->csv_export($feedid, $start, $end, $interval, $timezone);
         }
     }
 
@@ -785,8 +782,8 @@ class MysqlTimeSeries implements engine_methods
     public function delete_data_range($feedid,$start,$end)
     {
         $feedid = intval($feedid);
-        $start = intval($start/1000.0);
-        $end = intval($end/1000.0);
+        $start = (int) $start;
+        $end = (int) $end;
         $table = $this->get_table_name($feedid);
         $this->mysqli->query("DELETE FROM $table where `time` >= '$start' AND `time`<= '$end'");
 
@@ -971,7 +968,7 @@ class MysqlTimeSeries implements engine_methods
     private function get_datapoint_interpolated($feedid, $time)
     {
         $feedid = (int) $feedid;
-        $time = intval($time/1000);
+        $time = (int) $time;
         $table = $this->get_table_name($feedid);
         $data = array();
 
@@ -986,7 +983,7 @@ class MysqlTimeSeries implements engine_methods
             if (count($dp) == 2) {
                 if ($dp[0]['time'] == $time) {
                     // Datapoint to given timestamp found
-                    $data = array($time*1000 , (float) $dp[0]['data']);
+                    $data = array($time , (float) $dp[0]['data']);
                 }
                 else {
                     // No datapoint to given timestamp found. Datapoint will be interpolated
@@ -995,13 +992,13 @@ class MysqlTimeSeries implements engine_methods
                     if ($delta_t != 0){
                         // Linear interpolation
                         $value = $dp[0]['data'] + ($delta_data / $delta_t) * ($time - $dp[0]['time']);
-                        $data = array($time*1000 , (float) $value);
+                        $data = array($time , (float) $value);
                     }
                 }
             }
             else {
                 // only one datapoint found, interpolation not possible.
-                $data = array($time*1000 , null);
+                $data = array($time , null);
             }
         }
         return $data;

--- a/Modules/feed/engine/PHPFina.php
+++ b/Modules/feed/engine/PHPFina.php
@@ -264,6 +264,11 @@ class PHPFina implements engine_methods
      * @param float $scale : numeric value for the scaling 
     */
     public function scalerange($id,$start,$end,$scale){
+        
+        $id = (int) $id;
+        $start = (int) $start;
+        $end = (int) $end;
+        
         //echo("test on $scale not started");
         //case1: NAN
         if(preg_match("/^NAN$/i",$scale)){
@@ -282,15 +287,6 @@ class PHPFina implements engine_methods
             $this->log->warn("scale_range() : conversion to absolute values on the data range");
             $scale="abs(x)"; 
         } else return false;
-        
-        //echo("test finished>");
-        
-        //echo("<br>$scale");
-        //echo("<br>$start and $end");
-        $id = (int) $id;
-        $start = intval($start/1000);
-        $end = intval($end/1000);
-        //echo("<br>$start and $end");
         
         if(!$meta=$this->get_meta($id)){
             $this->log->warn("scale_range() failed to fetch meta id = $id");
@@ -422,12 +418,10 @@ class PHPFina implements engine_methods
     public function get_data_combined($id,$start,$end,$interval,$average=0,$timezone="UTC",$timeformat="unix",$csv=false,$skipmissing=0,$limitinterval=1)
     {
         $id = (int) $id;
+        $start = (int) $start;
+        $end = (int) $end;
         $skipmissing = (int) $skipmissing;
         $limitinterval = (int) $limitinterval;
-        
-        // todo: consider supporting a variety of time formats here
-        $start = intval($start/1000);
-        $end = intval($end/1000);
         
         global $settings;
         if ($timezone===0) $timezone = "UTC";
@@ -568,7 +562,7 @@ class PHPFina implements engine_methods
                 if ($csv) { 
                     $helperclass->csv_write($div_start,$value);
                 } else {
-                    $data[] = array($div_start*1000,$value);
+                    $data[] = array($div_start,$value);
                 }
             }
             
@@ -589,8 +583,8 @@ class PHPFina implements engine_methods
     {
         if ($mode!="daily" && $mode!="weekly" && $mode!="monthly") return false;
 
-        $start = intval($start/1000);
-        $end = intval($end/1000);
+        $start = (int) $start;
+        $end = (int) $end;
         $split = json_decode($split);
         if (gettype($split)!="array") return false;
         if (count($split)>48) return false;
@@ -617,14 +611,10 @@ class PHPFina implements engine_methods
             $modify = "+1 month";
         }
         
-        $n = 0;
-        while($n<10000) // max iterations allows for approx 7 months with 1 day granularity
+        $time = $date->getTimestamp();
+        
+        while($time<=$end)
         {
-            $time = $date->getTimestamp();
-            if ($time>$end) break;
-
-            $value = null;
-
             $split_values = array();
 
             foreach ($split as $splitpoint)
@@ -644,18 +634,16 @@ class PHPFina implements engine_methods
                     // add to the data array if its not a nan value
                     if (!is_nan($val[1])) {
                         $value = $val[1];
-                    } else {
-                        $value = null;
                     }
                 }
 
                 $split_values[] = $value;
             }
-            if ($time>=$start && $time<$end) {
-                $data[] = array($time*1000,$split_values);
-            }
+
+            $data[] = array($time,$split_values);
+            
             $date->modify($modify);
-            $n++;
+            $time = $date->getTimestamp();
         }
         fclose($fh);
         return $data;

--- a/Modules/feed/engine/PHPTimeSeries.php
+++ b/Modules/feed/engine/PHPTimeSeries.php
@@ -255,10 +255,10 @@ class PHPTimeSeries implements engine_methods
     public function get_data_combined($id,$start,$end,$interval,$average=0,$timezone="UTC",$timeformat="unix",$csv=false,$skipmissing=0,$limitinterval=1)
     {
         $id = (int) $id;
+        $start = (int) $start;
+        $end = (int) $end;   
         $skipmissing = (int) $skipmissing;
         $limitinterval = (int) $limitinterval;
-        $start = intval($start/1000);
-        $end = intval($end/1000);
         
         global $settings;
         if ($timezone===0) $timezone = "UTC";
@@ -404,7 +404,7 @@ class PHPTimeSeries implements engine_methods
                     if ($csv) { 
                         $helperclass->csv_write($div_start,$value);
                     } else {
-                        $data[] = array($div_start*1000,$value);
+                        $data[] = array($div_start,$value);
                     }
                 }
                 
@@ -422,7 +422,7 @@ class PHPTimeSeries implements engine_methods
                 if ($csv) { 
                     $helperclass->csv_write($time,$value);
                 } else {
-                    $data[] = array($time*1000,$value);
+                    $data[] = array($time,$value);
                 }
                 $n++;
             }*/

--- a/Modules/feed/engine/RedisBuffer.php
+++ b/Modules/feed/engine/RedisBuffer.php
@@ -128,8 +128,8 @@ class RedisBuffer implements engine_methods
     public function get_data_combined($feedid,$start,$end,$interval,$average=0,$timezone="UTC",$timeformat="unix",$csv=false,$skipmissing=0,$limitinterval=1)
     {
         $feedid = intval($feedid);
-        $start = round($start/1000);
-        $end = round($end/1000);
+        $start = intval($start);
+        $end = intval($end);
         $data = array();
 
         $len = $this->redis->zCount("feed:$feedid:buffer",$start,$end);
@@ -143,7 +143,6 @@ class RedisBuffer implements engine_methods
                 foreach($buf_item as $rawvalue => $time) {
                     $f = explode("|",$rawvalue);
                     $value = $f[1];
-                    $time=$time*1000;
                     $data[$time] = array($time,(float)$value);
                 }
             }

--- a/Modules/feed/engine/TemplateEngine.php
+++ b/Modules/feed/engine/TemplateEngine.php
@@ -148,9 +148,8 @@ class TemplateEngine implements engine_methods
         $skipmissing = (int) $skipmissing;
         $limitinterval = (int) $limitinterval;
         
-        // todo: consider supporting a variety of time formats here
-        $start = intval($start/1000);
-        $end = intval($end/1000);
+        $start = (int) $start;
+        $end = (int) $end;
 
         if ($end<=$start) return array('success'=>false, 'message'=>"request end time before start time");
         
@@ -226,7 +225,7 @@ class TemplateEngine implements engine_methods
             if ($csv) { 
                 $helperclass->csv_write($div_start,$value);
             } else {
-                $data[] = array($div_start*1000,$value);
+                $data[] = array($div_start,$value);
             }
 
             // Advance position 

--- a/Modules/feed/engine/VirtualFeed.php
+++ b/Modules/feed/engine/VirtualFeed.php
@@ -94,9 +94,8 @@ class VirtualFeed implements engine_methods
         $skipmissing = (int) $skipmissing;
         $limitinterval = (int) $limitinterval;
         
-        // todo: consider supporting a variety of time formats here
-        $start = intval($start/1000);
-        $end = intval($end/1000);
+        $start = (int) $start;
+        $end = (int) $end;
         
         $processList = $this->feed->get_processlist($feedid);
         if ($processList == '' || $processList == null) return false;
@@ -164,7 +163,7 @@ class VirtualFeed implements engine_methods
                 if ($csv) { 
                     $helperclass->csv_write($time,$dataValue);
                 } else {
-                    $data[] = array($time*1000, $dataValue);
+                    $data[] = array($time, $dataValue);
                 }
             }
             

--- a/Modules/feed/feed_controller.php
+++ b/Modules/feed/feed_controller.php
@@ -112,10 +112,9 @@ function feed_controller()
 
             $start = get('start',true);
             $end = get('end',true);
-            $default_interval = round((($end-$start)*0.001)/800);
-            $interval = get('interval',false,$default_interval);
+            $interval = get('interval',false,0);
             $timezone = get('timezone',false,$user_timezone);
-            $timeformat = get('timeformat',false,'unix');
+            $timeformat = get('timeformat',false,'unixms');
             $csv = get('csv',false,0);
             $skipmissing = get('skipmissing',false,0);
             $limitinterval = get('limitinterval',false,0);
@@ -157,7 +156,7 @@ function feed_controller()
                                 
                                 $results[$index]['data'] = $feed->get_data($feedid,$start,$end,$interval,$average,$timezone,$timeformat,$csv,$skipmissing,$limitinterval,$delta);
                             } else {
-                                $results[$index]['data'] = $feed->get_data_DMY_time_of_day($feedid,$start,$end,$interval,get('split'));
+                                $results[$index]['data'] = $feed->get_data_DMY_time_of_day($feedid,$start,$end,$interval,$timezone,$timeformat,get('split'));
                             }
                         }
                     } else {

--- a/Modules/vis/visualisations/editrealtime.php
+++ b/Modules/vis/visualisations/editrealtime.php
@@ -215,7 +215,7 @@ $('#multiply-submit').click(function() {
 
     $.ajax({
         url: path + 'feed/scalerange.json',
-        data: "&apikey=" + apikey + "&id=" + feedid + "&start=" + view.start + "&end=" + view.end + "&value=" + multiplyvalue,
+        data: "&apikey=" + apikey + "&id=" + feedid + "&start=" + parseInt(view.start*0.001) + "&end=" + parseInt(view.end*0.001) + "&value=" + multiplyvalue,
         dataType: 'json',
         async: false,
         success: function(result) {
@@ -232,7 +232,7 @@ $('#delete-button').click(function() {
 $("#confirmdelete").click(function() {
     $.ajax({
         url: path + 'feed/deletedatarange.json',
-        data: "&apikey=" + apikey + "&id=" + feedid + "&start=" + view.start + "&end=" + view.end,
+        data: "&apikey=" + apikey + "&id=" + feedid + "&start=" + parseInt(view.start*0.001) + "&end=" + parseInt(view.end*0.001),
         dataType: 'json',
         async: false,
         success: function(result) {


### PR DESCRIPTION
This pull request expands support for different time formats when making get_data requests.

Examples:

    feed/data.json?ids=1&start=-2 week&end=-1 week&interval=daily
    feed/data.json?ids=1&start=-2 week&end=-1 week&interval=daily&timeformat=unix
    feed/data.json?ids=1&start=-2 week&end=-1 week&interval=daily&timeformat=excel
    feed/data.json?ids=1&start=-2 week&end=-1 week&interval=daily&timeformat=iso8601

Example of data returned in iso8601 format:
```

[
  {
    "feedid": "1",
    "data": [
      [
        "2021-11-19T00:00:00+00:00",
        49
      ],
      [
        "2021-11-20T00:00:00+00:00",
        47
      ],
      [
        "2021-11-21T00:00:00+00:00",
        161
      ],
      [
        "2021-11-22T00:00:00+00:00",
        46
      ],
      [
        "2021-11-23T00:00:00+00:00",
        507
      ],
      [
        "2021-11-24T00:00:00+00:00",
        null
      ],
      [
        "2021-11-25T00:00:00+00:00",
        null
      ],
      [
        "2021-11-26T00:00:00+00:00",
        null
      ]
    ]
  }
]
```