### PR TITLE
Mysqltimeseries update

### DIFF
--- a/Modules/feed/Views/feedlist_view.php
+++ b/Modules/feed/Views/feedlist_view.php
@@ -425,6 +425,8 @@ function update_feed_list() {
                 
                 if(feed.engine == 5) {
                     title_lines.push(_('Feed Interval')+": "+(feed.interval||'')+'s')
+                } else {
+                    title_lines.push(_('Feed Interval (approx)')+": "+(feed.interval||'')+'s')
                 }
                 var processListHTML = '';
                 if(feed.processList!=undefined && feed.processList.length > 0){
@@ -435,6 +437,11 @@ function update_feed_list() {
                 if(feed.start_time > 0) {
                     title_lines.push(_('Feed Start Time')+": "+feed.start_time);
                     title_lines.push(format_time(feed.start_time,'LL LTS')+" UTC");
+                }
+
+                if(feed.end_time > 0) {
+                    title_lines.push(_('Feed End Time')+": "+feed.end_time);
+                    title_lines.push(format_time(feed.end_time,'LL LTS')+" UTC");
                 }
 
                 row_title = title_lines.join("\n");

--- a/Modules/feed/engine/MysqlTimeSeries.php
+++ b/Modules/feed/engine/MysqlTimeSeries.php
@@ -195,12 +195,12 @@ class MysqlTimeSeries implements engine_methods
     public function get_data_combined($feedid,$start,$end,$interval,$average=0,$timezone="UTC",$timeformat="unix",$csv=false,$skipmissing=0,$limitinterval=1)
     {
         if (in_array($interval,array("daily","weekly","monthly","annual"))) {
-            return $this->get_data_DMY($feedid, $start, $end, $interval, $average, $timezone, $timeformat, $csv);
+            return $this->get_data_DMY($feedid, $start, $end, $interval, $average, $timezone, $timeformat, $csv, $skipmissing);
         } else {
             if (!$average) {
                 return $this->get_data($feedid, $start, $end, $interval, $timezone, $timeformat, $csv, $skipmissing, $limitinterval);
             } else {
-                return $this->get_average($feedid, $start, $end, $interval, $timezone, $timeformat, $csv);
+                return $this->get_average($feedid, $start, $end, $interval, $timezone, $timeformat, $csv, $skipmissing);
             }
         }
     }
@@ -282,7 +282,7 @@ class MysqlTimeSeries implements engine_methods
      * @param integer $end The unix timestamp in ms of the end of the data range
      * @param integer $interval The number os seconds for each data point to return (used by some engines)
     */
-    public function get_average($feedid, $start, $end, $interval, $timezone, $timeformat, $csv)
+    public function get_average($feedid, $start, $end, $interval, $timezone, $timeformat, $csv, $skipmissing)
     {
         $feedid = (int) $feedid;
         $start = (int) $start;
@@ -327,10 +327,12 @@ class MysqlTimeSeries implements engine_methods
             }
             
             // Write as csv or array
-            if ($csv) { 
-                $helperclass->csv_write($time,$value);
-            } else {
-                $data[] = array($time,$value);
+            if ($value!==null || $skipmissing===0) {
+                if ($csv) { 
+                    $helperclass->csv_write($time,$value);
+                } else {
+                    $data[] = array($time,$value);
+                }
             }
             $time += $interval;
         }
@@ -352,7 +354,7 @@ class MysqlTimeSeries implements engine_methods
      * @param string $interval The name of the interval. Possible values are: daily, weekly, monthly, annual
      * @param string $timezone The time zone to which the intervals refer
     */
-    public function get_data_DMY($feedid, $start, $end, $interval, $average, $timezone, $timeformat, $csv)
+    public function get_data_DMY($feedid, $start, $end, $interval, $average, $timezone, $timeformat, $csv, $skipmissing)
     {
         if (!in_array($interval,array("daily","weekly","monthly","annual"))) return false;
         
@@ -432,10 +434,12 @@ class MysqlTimeSeries implements engine_methods
             }
             
             // Write as csv or array
-            if ($csv) { 
-                $helperclass->csv_write($div_start,$value);
-            } else {
-                $data[] = array($div_start,$value);
+            if ($value!==null || $skipmissing===0) {
+                if ($csv) { 
+                    $helperclass->csv_write($div_start,$value);
+                } else {
+                    $data[] = array($div_start,$value);
+                }
             }
                       
             // Advance position 

--- a/Modules/feed/engine/MysqlTimeSeries.php
+++ b/Modules/feed/engine/MysqlTimeSeries.php
@@ -304,7 +304,7 @@ class MysqlTimeSeries implements engine_methods
         $start = (int) $start;
         $end = (int) $end;
         $interval= (int) $interval;
-
+        $skipmissing = (int) $skipmissing;
         // Minimum interval
         if ($interval < 1) $interval = 1;
         
@@ -378,7 +378,7 @@ class MysqlTimeSeries implements engine_methods
         $start = (int) $start;
         $end = (int) $end;
         $average = (int) $average;
-        
+        $skipmissing = (int) $skipmissing;       
         $table = $this->get_table_name($feedid);
         
         $meta = $this->get_meta($feedid);

--- a/Modules/feed/feed_model.php
+++ b/Modules/feed/feed_model.php
@@ -385,6 +385,7 @@ class Feed
             $row['value'] = $lastvalue['value'];
             $meta = $this->get_meta($id);
             if (isset($meta->start_time)) $row['start_time'] = $meta->start_time;
+            if (isset($meta->end_time)) $row['end_time'] = $meta->end_time;
             if (isset($meta->interval)) $row['interval'] = $meta->interval;
             $feeds[] = $row;
         }


### PR DESCRIPTION
This pull request is easier to understand changes by looking at each commit in turn. 

- The main goal was to update the engine to match the data request response formats of the other engines.
- I've done this by reusing and not changing the sql previously used.
- The only method that is a little slower is the standard get_data without averaging method as this uses the 'data_sampling' option as standard (it could change to a faster return all datapoints approach as the interval approaches the interval of the data stored in the feed, but needs to return timestamps in relation to request)
- The return original interval option needs to be reintroduced as well (same as for phptimeseries)
- csv export method has been integrated in the other get_data methods 

PHPFina vs Mysql data response tests:

Daily data:

![image](https://user-images.githubusercontent.com/503186/147095463-327a1bff-e5a0-4756-8838-0844b36366bf.png)

CSV view:

![image](https://user-images.githubusercontent.com/503186/147095797-7a25d930-47f1-43a1-a4ca-f081c44295fa.png)

