### PR TITLE
Fix failure in MQTT import when Redis is not enabled

### DIFF
--- a/scripts/phpmqtt_input.php
+++ b/scripts/phpmqtt_input.php
@@ -1,5 +1,12 @@
 <?php
 
+    /*
+
+       This script is deprecated.  You should probably be using
+       scripts/services/emoncms_mqtt/emoncms_mqtt.php instead.
+
+     */
+
     // TBD: support user target in message schema
     $mqttsettings = array(
         'userid' => 1
@@ -164,7 +171,7 @@
 
         // PUBLISH
         // loop through all queued items in redis
-        if ($connected && $pub_count>10) {
+        if ($redis !== false && $connected && $pub_count>10) {
             $pub_count = 0;
             $publish_to_mqtt = $redis->hgetall("publish_to_mqtt");
             foreach ($publish_to_mqtt as $topic=>$value) {

--- a/scripts/services/emoncms_mqtt/emoncms_mqtt.php
+++ b/scripts/services/emoncms_mqtt/emoncms_mqtt.php
@@ -167,7 +167,7 @@
 
         // PUBLISH
         // loop through all queued items in redis
-        if ($connected && $pub_count>10) {
+        if ($redis !== false && $connected && $pub_count>10) {
             $pub_count = 0;
             $publish_to_mqtt = $redis->hgetall("publish_to_mqtt");
             foreach ($publish_to_mqtt as $topic=>$value) {


### PR DESCRIPTION
Prevent use of Redis for obtaining data to publish to MQTT when Redis is not enabled

Also, add comments to phpmqtt_input.php to indicate that it is deprecated in favour of emoncms_mqtt.php