### PR TITLE
Php 8.1 fix   part1

### DIFF
--- a/Lib/EmonLogger.php
+++ b/Lib/EmonLogger.php
@@ -92,7 +92,7 @@ class EmonLogger
         }
 
         $now = microtime(true);
-        $micro = sprintf("%03d", ($now - ($now >> 0)) * 1000);
+        $micro = sprintf("%03d", ($now - round($now,0,PHP_ROUND_HALF_DOWN)) * 1000);
         $now = DateTime::createFromFormat('U', (int)$now); // Only use UTC for logs
         $now = $now->format("Y-m-d H:i:s").".$micro";
         // Clear log file if more than 256MB (temporary solution)

--- a/Modules/user/user_controller.php
+++ b/Modules/user/user_controller.php
@@ -32,12 +32,19 @@ function user_controller()
         if ($route->action == 'login' && !$session['read']) {
             $route_query = array();
             // pass through the referring path
+			if(!is_null($route->query)){
             parse_str($route->query, $route_query );
+			}
             $msg = empty($route_query['msg']) ? get('msg') : $route_query['msg'];
             $ref = empty($route_query['ref']) ? get('ref') : $route_query['ref'];
-            $message = filter_var(urldecode($msg), FILTER_SANITIZE_STRING);
+			if(!is_null($msg)){
+            $message = htmlspecialchars(urldecode($msg));
+			}
+			else $message="";
+			if(!is_null($ref)){
             $referrer = htmlentities(filter_var(urldecode(base64_decode($ref)), FILTER_SANITIZE_URL));
-            
+            }
+			else $referrer="";
             // load login template with the above parameters
             $result = view("Modules/user/login_block.php", array(
                 'allowusersregister'=>$allowusersregister,

--- a/Modules/vis/vis_controller.php
+++ b/Modules/vis/vis_controller.php
@@ -121,7 +121,7 @@
 
                         # we need to either urlescape the colour, or just scrub out invalid chars. I'm doing the second, since
                         # we can be fairly confident that colours are eiter a hex or a simple word (e.g. "blue" or such)
-                        else if ($type==9) // Color
+                        else if ($type==9 && !is_null(get($key))) // Color
                             $array[$key] = preg_replace('/[^\dA-Za-z]/','',get($key))?get($key):$default;
                     }
                 }

--- a/core.php
+++ b/core.php
@@ -109,8 +109,9 @@ function get($index,$error_if_missing=false,$default=null)
         header('Content-Type: text/plain');
         die("missing $index parameter");
     }
-    
+    if(!is_null($val)){
     $val = stripslashes($val);
+	}
     return $val;
 }
 /**
@@ -140,9 +141,10 @@ function post($index,$error_if_missing=false,$default=null)
     
     if (is_array($val)) {
         $val = array_map("stripslashes", $val);
-    } else {
+    }	
+	if(!is_null($val)){
         $val = stripslashes($val);
-    }
+	}
     return $val;
 }
 /**

--- a/locale.php
+++ b/locale.php
@@ -127,7 +127,7 @@ function set_lang($language)
     // loop through all given $language values
     // if given language is a key or value in the above list use it
     foreach ($language as $lang_code) {
-        $lang_code = filter_var($lang_code, FILTER_SANITIZE_STRING);
+        $lang_code = htmlspecialchars($lang_code);
         if (isset($supported_languages[$lang_code])) { // key check
             $lang = $supported_languages[$lang_code];
             break;

--- a/route.php
+++ b/route.php
@@ -76,7 +76,10 @@ class Route
      */
     public function decode($q, $documentRoot, $requestMethod)
     {
-        // filter out the applications relative root
+        if(is_null($q)){
+			$q="";
+		}
+		// filter out the applications relative root
 
         // If we're running in a subdirectory "emoncms", $q would look like '/emoncms/user/view' instead or just 'user/view'
         // for the example of viewing a users profile. We need to remove the first directory to get the "clean" routing path
@@ -90,7 +93,9 @@ class Route
         // for example this will perform the following:
         // Running at root: str_replace('/var/www', '', '/var/www') => ''
         // Running at subdirectory: str_replace('/var/www', '', '/var/www/emoncms') => '/emoncms'
+		if (!is_null($documentRoot)) {
         $relativeApplicationPath = str_replace($documentRoot, '', $absolutePath);
+		}
 
         // Next up we will need to remove the '/emoncms' from the route path '/emoncms/user/view'
         // str_replace('/emoncms', '', '/emoncms/user/view') => '/user/view'


### PR DESCRIPTION
Changes have been done to : 
route.php
locale.php
core.php
user_controller.php
test if variables are defined to null before calling functions using those variables as parameters (Passing null to parameter #1 ($string) of type string is deprecated in php 8.1)
replace  FILTER_SANITIZE_STRING with htmlspecialchars() (Constant FILTER_SANITIZE_STRING is deprecated )