### PR TITLE
Add Pi mac addresses and version info for Pi 4 v1.5 detection

### DIFF
--- a/Modules/admin/admin_model.php
+++ b/Modules/admin/admin_model.php
@@ -576,7 +576,7 @@ class Admin {
      * @return bool
      */
     public function is_Pi() {
-        return !empty($this->exec('ip addr | grep -i "b8:27:eb:\|dc:a6:32:"'));
+        return !empty($this->exec('ip addr | grep -i "b8:27:eb:\|dc:a6:32:\|28:cd:c1:\|e4:5f:01:"'));
     }
 
     /**

--- a/Modules/admin/pi-model.json
+++ b/Modules/admin/pi-model.json
@@ -306,6 +306,13 @@
     "Manufacturer": "Sony UK"
   },
   {
+    "Code": "b03115",
+    "Model": "4B",
+    "Revision": "1.5",
+    "RAM": "2GB",
+    "Manufacturer": "Sony UK"
+  },
+  {
     "Code": "c03111",
     "Model": "4B",
     "Revision": "1.1",


### PR DESCRIPTION
Added the two missing mac address ranges for raspberry pi detection
Listed here https://udger.com/resources/mac-address-vendor-detail?name=raspberry_pi_foundation

Added the missing revision info for Pi4B v1.5 2GB
Listed here https://github.com/raspberrypi/documentation/blob/develop/documentation/asciidoc/computers/raspberry-pi/revision-codes.adoc