### PR TITLE
Update EmonLogger

### DIFF
--- a/Lib/EmonLogger.php
+++ b/Lib/EmonLogger.php
@@ -40,11 +40,13 @@ class EmonLogger
             $this->caller = basename($clientFileName);
             if (!file_exists($this->logfile)) {
                 $fh = @fopen($this->logfile, "a");
-                @fclose($fh);
+                if (!$fh) {
+                   error_log("Log file could not be created");
+                } else {
+                   @fclose($fh);
+                }
             }
-            if (is_writable($this->logfile)) {
-                $this->logenabled = true;
-            }
+            $this->logenabled = is_writable($this->logfile);
         }
     }
     


### PR DESCRIPTION
Ref #1803 

An exception is currently raised when the log file cannot be created.

This handles that.

In addition, if the log file was not writeable, then the `logenabled` was never set to false.

Please test.