### PR TITLE
Fix false to array deprecation in feed/fetch.json

### DIFF
--- a/Modules/feed/feed_controller.php
+++ b/Modules/feed/feed_controller.php
@@ -85,6 +85,7 @@ function feed_controller()
         // To "fetch" multiple feed values in a single request
         // http://emoncms.org/feed/fetch.json?ids=123,567,890
         } elseif ($route->action == "fetch") {
+            $result = [];
             $feedids = (array) (explode(",",(get('ids'))));
             for ($i=0; $i<count($feedids); $i++) {
                 $feedid = (int) $feedids[$i];


### PR DESCRIPTION
* This occurs using PHP 8.1 when the returned JSON begins with: *
* <br />
* <b>Deprecated</b>:  Automatic conversion of false to array is deprecated in
* <b>/var/www/emoncms/Modules/feed/feed_controller.php</b> on line <b>94</b>
* <br /> *