### PR TITLE
Fix using using SSL with MQTT without client certificate

### DIFF
--- a/scripts/services/emoncms_mqtt/emoncms_mqtt.php
+++ b/scripts/services/emoncms_mqtt/emoncms_mqtt.php
@@ -151,10 +151,23 @@
                 $mqtt_client->setCredentials($settings['mqtt']['user'],$settings['mqtt']['password']);
                 if(isset($settings['mqtt']['capath']) && $settings['mqtt']['capath'] !== null) {
                     $log->warn("mqtt: using ssl");
-                    $mqtt_client->setTlsCertificates($settings['mqtt']['capath'],
-                                                     $settings['mqtt']['certpath'],
-                                                     $settings['mqtt']['keypath'],
-                                                     $settings['mqtt']['keypw']);
+                    if(isset($settings['mqtt']['certpath']) && $settings['mqtt']['certpath'] !== null && isset($settings['mqtt']['keypath']) && $settings['mqtt']['keypath'] !== null) {
+                        if(isset($settings['mqtt']['keypw']) && $settings['mqtt']['keypw'] !== null) {
+                            // To run setTlsCertificates with capath, certpath, keypath and keypw if they are provided
+                            $mqtt_client->setTlsCertificates($settings['mqtt']['capath'],
+                                                             $settings['mqtt']['certpath'],
+                                                             $settings['mqtt']['keypath'],
+                                                             $settings['mqtt']['keypw']);
+                        } else {
+                            // To run setTlsCertificates with capath, certpath and keypath if they are provided and not keypw
+                            $mqtt_client->setTlsCertificates($settings['mqtt']['capath'],
+                                                             $settings['mqtt']['certpath'],
+                                                             $settings['mqtt']['keypath']);
+                        }
+                    } else {
+                        // To run setTlsCertificates with capath only, if nothing else is provided
+                        $mqtt_client->setTlsCertificates($settings['mqtt']['capath']);
+                    }
                 }
                 $mqtt_client->connect($settings['mqtt']['host'], $settings['mqtt']['port'], 5);
                 // moved subscribe to onConnect callback


### PR DESCRIPTION
Add some changes to check the existence of certpath, keypath and keypw before usng them in setTlsCertificates

Fix #1835 