### PR TITLE
Fix for "Deprecated: Creation of dynamic property

### DIFF
--- a/Modules/input/input_methods.php
+++ b/Modules/input/input_methods.php
@@ -12,6 +12,7 @@
 // no direct access
 defined('EMONCMS_EXEC') or die('Restricted access');
 
+#[\AllowDynamicProperties] 
 class InputMethods
 {
     private $mysqli;

--- a/Modules/input/input_methods.php
+++ b/Modules/input/input_methods.php
@@ -16,6 +16,10 @@ defined('EMONCMS_EXEC') or die('Restricted access');
 class InputMethods
 {
     private $mysqli;
+    private $user;
+    private $input;
+    private $process;
+    private $device;
     private $feed;
     private $redis;
 

--- a/Modules/input/input_methods.php
+++ b/Modules/input/input_methods.php
@@ -12,7 +12,6 @@
 // no direct access
 defined('EMONCMS_EXEC') or die('Restricted access');
 
-#[\AllowDynamicProperties] 
 class InputMethods
 {
     private $mysqli;


### PR DESCRIPTION
### Using PHP8.2 generate this warnings on input pages. as dynamic properties are deprecated as of PHP 8.2.0
#### Mentiond in this issue https://github.com/emoncms/emoncms/issues/1837

`Deprecated: Creation of dynamic property InputMethods::$user is deprecated in /mnt/storage/services/www/emoncms/Modules/input/input_methods.php on line 26
Deprecated: Creation of dynamic property InputMethods::$input is deprecated in /mnt/storage/services/www/emoncms/Modules/input/input_methods.php on line 27
Deprecated: Creation of dynamic property InputMethods::$process is deprecated in /mnt/storage/services/www/emoncms/Modules/input/input_methods.php on line 29
Deprecated: Creation of dynamic property InputMethods::$device is deprecated in /mnt/storage/services/www/emoncms/Modules/input/input_methods.php on line 30`

Using_ Dynamic Properties with marking the class with this #[\AllowDynamicProperties] attribute solves the issues.