### PR TITLE
Fix deprecation warnings from PHP8+

### DIFF
--- a/Modules/admin/admin_model.php
+++ b/Modules/admin/admin_model.php
@@ -545,7 +545,7 @@ class Admin {
             $prefix = $this->redis->getOption(Redis::OPT_PREFIX);
             $this->redis->del(array_map(
                 function ($key) use ($prefix) {
-                    return preg_replace( "/^${prefix}/", '', $key );
+                    return preg_replace( "/^{$prefix}/", '', $key );
                 }, $this->redis->keys('diskstats*'))
             );
             return array('success'=>true);

--- a/process_settings.php
+++ b/process_settings.php
@@ -110,7 +110,7 @@ function resolve_env_vars($value)
         $env_name = $match;
         $env_value = getenv($env_name);
         if ($env_value === false) {
-            echo "<p>Error: environment var '${env_name}' not defined</p>";
+            echo "<p>Error: environment var '{$env_name}' not defined</p>";
             return $value;
         }
 

--- a/scripts/emoncms-cli
+++ b/scripts/emoncms-cli
@@ -27,7 +27,7 @@ switch ($commandName) {
         runMigrations();
         break;
     default:
-        echo "${commandName} is an invalid command\n\n";
+        echo "{$commandName} is an invalid command\n\n";
         printAvailableCommands();
         exit(1);
 }


### PR DESCRIPTION
Found that these deprecated string interpolations tend to cause some rather scary looking errors re:headers output when running on PHP 8.2, and didn't think it would harm anyone still running on PHP7.