### PR TITLE
Remove deprecated FILTER_SANITIZE_STRING in feed_model and user_controller

### DIFF
--- a/Modules/feed/feed_model.php
+++ b/Modules/feed/feed_model.php
@@ -848,7 +848,7 @@ class Feed
 
         if (isset($fields->name)) {
             //remove illegal characters
-            $fields->name = trim(filter_var($fields->name, FILTER_SANITIZE_STRING));
+            $fields->name = trim(htmlspecialchars($fields->name));
             //prepare an sql statement that cannot be altered by sql injection
             if ($stmt = $this->mysqli->prepare("UPDATE feeds SET name = ? WHERE id = ?")) {
                 $stmt->bind_param("si",$fields->name, $id);

--- a/Modules/user/user_controller.php
+++ b/Modules/user/user_controller.php
@@ -65,8 +65,11 @@ function user_controller()
         if ($route->action == 'logout') {
             // decode url parameters
             $next = $path;
-            $message = filter_var(urldecode(get('msg')), FILTER_SANITIZE_STRING);
-            $referrer = htmlentities(filter_var(urldecode(base64_decode(get('ref'))), FILTER_SANITIZE_URL));
+            
+            $msg = get('msg');
+            $message = isset($msg) ? htmlspecialchars(urldecode($msg)) : '';
+            $ref = get('ref');
+            $referrer = isset($ref) ? htmlspecialchars(urldecode(base64_decode(get('ref')))) : '';
             
             // encode url parameters to pass through to login page
             $msg = urlencode($message);


### PR DESCRIPTION
Another set of issues from deprecations I stumbled upon while running my own instance of Emoncms on PHP 8.2 -- seems `FILTER_SANITIZE_STRING` was ambiguous and it is thus frowned upon from using it now, `htmlspecialchars()` seems to be the best replacement for most instances.

There was one other instance of `FILTER_SANITIZE_STRING` in the codebase, but it seemed to be far more complicated than these cases - multiple other flags were likely passed to `filter_var` and thus, I wasn't confident `htmlspecialchars()` was a drop-in replacement.

I was able to test the user controller change on my instance (its in the logout action), but I don't have any feed data just yet, so I'm flying a bit blind there.