### PR TITLE
Fix inputs screen for PHP8 re:utf8_encode

### DIFF
--- a/Modules/input/input_model.php
+++ b/Modules/input/input_model.php
@@ -370,7 +370,7 @@ class Input
         for ($i=0; $i<count($result); $i+=2) {
             $row = $result[$i];
             $lastvalue = $result[$i+1];
-            $row["description"] = utf8_encode($row["description"]);
+            $row["description"] = mb_convert_encoding($row["description"], 'UTF-8', mb_list_encodings());
             if (!isset($lastvalue['time']) || !is_numeric($lastvalue['time']) || is_nan($lastvalue['time'])) {
                 $row['time'] = null;
             } else {


### PR DESCRIPTION
Inputs screen spins forever because of a deprecation warning about `utf8_encode`. On my local running instance of emoncms on PHP8.2, this fixed the issue, but it's based off of the Docker devbox. Still, I assume `mbstring` should be available for most if not all installs.