### PR TITLE
Keep update log visible

### DIFF
--- a/Modules/admin/Views/update_view.php
+++ b/Modules/admin/Views/update_view.php
@@ -285,9 +285,6 @@ function getUpdateLog() {
                 refresh_updateLog(result);
                 if (result.indexOf("System update done")!=-1) {
                     clearInterval(updates_log_interval);
-                    setTimeout(function() {
-                        $("#update-logfile-view").slideUp();
-                    },3000);
                 }
             }
         }


### PR DESCRIPTION
Issue https://github.com/emoncms/emoncms/issues/1815 and https://github.com/emoncms/emoncms/issues/1806 highlight that the update window disappears within 3 seconds of the update completing.

Curiously, this window remains permanently visible if the update log doesn't exist.

I've removed the 3 second timer which triggers hiding the window