### PR TITLE
Multi user management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,5 @@ Modules/*/
 !Modules/time/
 !Modules/user/
 !Modules/vis/
-
+!Modules/account/
 /vendor/

--- a/Modules/account/account_controller.php
+++ b/Modules/account/account_controller.php
@@ -1,0 +1,57 @@
+<?php
+
+function account_controller() {
+    global $route, $session, $mysqli, $user;
+
+    require_once("Modules/account/account_model.php");
+    $account_class = new Accounts($mysqli, $user);
+    
+    // List linked accounts
+    // GET /account/list
+    // GET /account/list.json 
+    if ($route->action == "list" && $session["write"]) {
+        if ($route->format == 'html') {
+            return view("Modules/account/account_view.php",array());
+        } else {
+            $route->format = 'json';
+            return $account_class->list($session["userid"]);
+        }
+    }
+
+    // Add account
+    // POST /account/add.json (post body: username, password)
+    if ($route->action == "add" && $session["write"]) {
+        
+        $username = post("username",true);
+        $password = post("password",true);
+        $email = post("email",true);
+        $timezone = post("timezone",true);
+
+        $result = $account_class->add($session["userid"],$username,$password,$email,$timezone);
+        $route->format = 'json';
+        return $result;
+    }
+
+    // Unlink account
+    // GET /account/unlink.json (get body: userid)
+    if ($route->action == "unlink" && $session["write"]) {
+        $userid = post("userid",true);
+        return $account_class->unlink($session["userid"],$userid);
+    }
+
+    // Switch user
+    // GET /account/switch.json?userid=123
+    if ($route->action == "switch" && $session["write"]) {
+        $userid = get("userid",false);
+        $account_class->switch($session["userid"],$userid);
+    }
+
+    // Set access
+    // POST /account/access.json (post body: userid, access)
+    if ($route->action == "setaccess" && $session["write"]) {
+        $userid = post("userid",true);
+        $access = post("access",true);
+        return $account_class->set_access($session["userid"],$userid,$access);
+    }
+
+}

--- a/Modules/account/account_controller.php
+++ b/Modules/account/account_controller.php
@@ -35,6 +35,7 @@ function account_controller() {
     // Unlink account
     // GET /account/unlink.json (get body: userid)
     if ($route->action == "unlink" && $session["write"]) {
+        $route->format = 'json';
         $userid = post("userid",true);
         return $account_class->unlink($session["userid"],$userid);
     }
@@ -42,13 +43,15 @@ function account_controller() {
     // Switch user
     // GET /account/switch.json?userid=123
     if ($route->action == "switch" && $session["write"]) {
+        $route->format = 'json';
         $userid = get("userid",false);
-        $account_class->switch($session["userid"],$userid);
+        return $account_class->switch($session["userid"],$userid);
     }
 
     // Set access
     // POST /account/access.json (post body: userid, access)
     if ($route->action == "setaccess" && $session["write"]) {
+        $route->format = 'json';
         $userid = post("userid",true);
         $access = post("access",true);
         return $account_class->set_access($session["userid"],$userid,$access);

--- a/Modules/account/account_menu.php
+++ b/Modules/account/account_menu.php
@@ -1,0 +1,15 @@
+<?php
+global $session, $mysqli;
+if ($session["write"]) {
+    // Only show account menu if user is not a linked user
+    $userid = $session["userid"];
+    try {
+        $result = $mysqli->query("SELECT * FROM accounts WHERE linkeduser='$userid'");
+        if (!$result->fetch_object()) {
+            $menu["setup"]["l2"]['account'] = array("name"=>_('Accounts'),"href"=>"account/list", "order"=>13, "icon"=>"user");
+        }
+    } catch (Exception $e) {
+        // Do nothing
+    }
+
+}

--- a/Modules/account/account_model.php
+++ b/Modules/account/account_model.php
@@ -1,0 +1,179 @@
+<?php
+
+class Accounts
+{
+    private $mysqli;
+    private $user;
+    private $table = "accounts";
+
+    public function __construct($mysqli, $user)
+    {
+        $this->mysqli = $mysqli;
+        $this->user = $user;
+    }
+
+    public function list($adminuser)
+    {
+        $adminuser = (int) $adminuser;
+
+        $accounts = array();
+        $result = $this->mysqli->query("SELECT linkeduser FROM ".$this->table." WHERE adminuser = '$adminuser'");
+        while ($row = $result->fetch_object()) {
+
+            // Get user details
+            $u = $this->user->get($row->linkeduser);
+
+            // Count feeds
+            $result2 = $this->mysqli->query("SELECT COUNT(*) AS feeds FROM feeds WHERE userid = '$row->linkeduser'");
+            $f = $result2->fetch_object();
+
+            $account = new stdClass();
+            $account->id = $row->linkeduser;
+            $account->username = $u->username;
+            $account->email = $u->email;
+            $account->feeds = $f->feeds;
+            $account->access = $this->user->get_access($row->linkeduser);
+
+            $accounts[] = $account;
+        }
+        return $accounts;
+    }
+
+    public function add($adminuser,$username,$password,$email,$timezone) 
+    {
+        // Check if adminuser is a linkeduser 
+        $result = $this->mysqli->query("SELECT * FROM ".$this->table." WHERE linkeduser='$adminuser'");
+        if ($result->fetch_object()) {
+            return array("success"=>false,"message"=>"Cannot add user as admin user is a linked user");
+        }
+
+        $userid = $this->user->get_id($username);
+        // If user does not exist then register
+        if (!$userid) {
+            // Get adminuser details, if email is the same turn off email verification
+            $adminuser_details = $this->user->get($adminuser);
+            if ($adminuser_details->email == $email) {
+                global $settings;
+                $settings["interface"]["email_verification"] = false;
+            }
+            // User does not exist
+            // Register user
+            $result = $this->user->register($username, $password, $email, $timezone);
+            if (!$result['success']) return $result;
+            // if success then get userid
+            $linkeduser = $result['userid'];
+
+            // Disable login access by default
+            $this->user->set_access($linkeduser,0);
+            
+        } else {
+            // else check password and fetch userid
+            $result = $this->user->get_apikeys_from_login($username,$password);
+            if (!$result['success']) {
+                return array("success"=>false,"message"=>"invalid username or password");
+            }
+            $linkeduser = $result['userid'];
+        }
+
+        // Check linked user is not admin user
+        if ($adminuser==$linkeduser) {
+            return array("success"=>false,"message"=>"cannot link to self");
+        }
+        
+        // Check if user is already linked
+        $result = $this->mysqli->query("SELECT * FROM ".$this->table." WHERE linkeduser='$linkeduser'");
+        if ($row = $result->fetch_object()) {
+            return array("success"=>false,"message"=>"user already linked");
+        }
+        
+        // Add user to linked table
+        $this->mysqli->query("INSERT INTO ".$this->table." (adminuser,linkeduser) VALUES ('$adminuser','$linkeduser')");
+        
+        return array("success"=>true,"message"=>"user linked");
+    }
+    
+    public function unlink($adminuser,$linkeduser)
+    {
+        $adminuser = (int) $adminuser;
+        $linkeduser = (int) $linkeduser;
+
+        // Check if linkeduser belongs to adminuser
+        if (!$this->is_linked($adminuser,$linkeduser)) {
+            return array("success"=>false,"message"=>"access denied");
+        }
+
+        // Unlink user
+        $this->mysqli->query("DELETE FROM ".$this->table." WHERE adminuser='$adminuser' AND linkeduser='$linkeduser'");
+        return array("success"=>true,"message"=>"user unlinked");
+    }
+
+    public function switch($adminuser, $linkeduser) {
+        $adminuser = (int) $adminuser;
+        $linkeduser = (int) $linkeduser;
+
+        // switch to adminuser
+        if (!$linkeduser && isset($_SESSION["adminuser"])) {
+            $userid = $_SESSION["adminuser"];
+            unset($_SESSION["adminuser"]);
+            $this->load_user_session($userid);
+
+            header("Location: ../account/list");
+            // stop any other code from running once http header sent
+            exit();
+        }
+
+        // check that linkeduser is linked to adminuser
+        if (!$this->is_linked($adminuser,$linkeduser)) {
+            return array("success"=>false,"message"=>"access denied");
+        }
+
+        // switch user
+        $_SESSION["adminuser"] = $adminuser;
+        $this->load_user_session($linkeduser);
+        
+        header("Location: ../".$_SESSION["startingpage"]);
+        // stop any other code from running once http header sent
+        exit();
+    }
+
+    public function load_user_session($userid) {
+        $userid = (int) $userid;
+        $result = $this->mysqli->query("SELECT `username`,`admin`,`timezone`,`startingpage`,`gravatar` FROM users WHERE `id`='$userid'");
+        if ($row = $result->fetch_object()) {
+            $_SESSION["userid"] = $userid;
+            $_SESSION['admin'] = $row->admin;
+            $_SESSION["username"] = $row->username;
+            $_SESSION["timezone"] = $row->timezone;
+            $_SESSION["startingpage"] = $row->startingpage;
+            $_SESSION["gravatar"] = $row->gravatar;
+        }
+    }
+
+    // Set access
+    public function set_access($adminuser,$linkeduser,$access) {
+        $adminuser = (int) $adminuser;
+        $linkeduser = (int) $linkeduser;
+        $access = (int) $access;
+
+        // Check if linkeduser belongs to adminuser
+        if (!$this->is_linked($adminuser,$linkeduser)) {
+            return array("success"=>false,"message"=>"access denied");
+        }
+
+        // Set access
+        $this->user->set_access($linkeduser,$access);
+
+        return array("success"=>true,"message"=>"access updated");
+    }
+
+    // Check if linkeduser belongs to adminuser
+    public function is_linked($adminuser,$linkeduser) {
+        $adminuser = (int) $adminuser;
+        $linkeduser = (int) $linkeduser;
+        $result = $this->mysqli->query("SELECT * FROM ".$this->table." WHERE adminuser='$adminuser' AND linkeduser='$linkeduser'");
+        if ($result->fetch_object()) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/Modules/account/account_schema.php
+++ b/Modules/account/account_schema.php
@@ -1,0 +1,6 @@
+<?php
+
+$schema['accounts'] = array(
+    'adminuser' => array('type' => 'int(11)'),
+    'linkeduser' => array('type' => 'int(11)')
+);

--- a/Modules/account/account_view.php
+++ b/Modules/account/account_view.php
@@ -1,0 +1,195 @@
+<?php
+defined('EMONCMS_EXEC') or die('Restricted access');
+global $path;
+?>
+<style>
+    .content-container {
+        max-width: 980px;
+    }
+</style>
+<script src="<?php echo $path; ?>Lib/vue.min.js"></script>
+
+<div id="app">
+    <h2><?php echo _("My Accounts"); ?></h2>
+
+    <div class="input-prepend input-append" style="float:right">
+        <button class="btn" id="open-add-user-modal"><i class="icon icon-plus"></i> <?php echo _("Add new user"); ?></button>
+    </div>
+
+    <p><?php echo _("Number of users:"); ?> {{accounts.length}}</p>
+    <br>
+
+    <div v-if="accounts.length==0" class="alert alert-warning"><?php echo _("Multi user management. Click on add new user to create a new user or to add an existing user."); ?></div>
+    <table class="table table-striped" v-else>
+        <tr>
+            <th><?php echo _("Edit"); ?></th>
+            <th><?php echo _("Id"); ?></th>
+            <th><?php echo _("Username"); ?></th>
+            <th><?php echo _("Email"); ?></th>
+            <th><?php echo _("User Login"); ?></th>
+            <th><?php echo _("Feeds"); ?></th>
+            <th></th>
+        </tr>
+        <tr v-for="(user,index) in accounts">
+            <td><a class="btn btn-info btn-sm" :href="path+'account/switch?userid='+user.id">view</a></td>
+            <td>{{ user.id }}</td>
+            <td>{{ user.username }}</td>
+            <td>{{ user.email }}</td>
+            <td @click="change_access(index)" style="cursor:pointer" title="Click to change access level">
+                <span class="label label-inverse" v-if="user.access==0">Disabled</span>
+                <span class="label label-warning" v-if="user.access==1">Read only</span>
+                <span class="label label-success" v-if="user.access==2">Write access</span>
+            </td>
+            <td>{{ user.feeds }}</td>
+            <td @click="unlink(index)" style="cursor:pointer"><i class="icon-trash"></i></td>
+        </tr>
+    </table>
+
+    <div id="addNewUserModal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="addNewUserModalLabel" aria-hidden="true" data-backdrop="static" style="width:300px">
+        <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+            <h3 id="addNewUserModalLabel">Add new user</h3>
+        </div>
+        <div class="modal-body">
+
+            <p>
+                <lable>Username:</label><br>
+                <input v-model="add_username" type="text" style="width:250px" />
+            </p>
+            <p>
+                <lable>Password:</label><br>
+                <input v-model="add_password" type="text" style="width:250px" />
+            </p>
+            <p>
+                <lable>Email:</label><br>
+                <input v-model="add_email" type="text" style="width:250px" />
+            </p>
+            <p>
+                <lable>Timezone:</label><br>
+                <input v-model="add_timezone" type="text" style="width:250px" />
+            </p>
+
+            <div class="alert alert-error" v-if="add_error" style="margin-bottom:0px">{{ add_error }}</div>
+
+        </div>
+        <div class="modal-footer">
+            <button class="btn" data-dismiss="modal" aria-hidden="true"><?php echo _('Close'); ?></button>
+            <button class="btn btn-info"  @click="add_account"><?php echo _('Add user'); ?></button>
+        </div>
+    </div>
+</div>
+
+<script>
+    // Vue app
+    var app = new Vue({
+        el: '#app',
+        data: {
+            accounts: [],
+            user: {},
+            add_username: "",
+            add_password: "",
+            add_email: "",
+            add_timezone: "",
+            add_error: false
+        },
+        mounted: function() {
+            this.getAccounts();
+            this.getUser();
+        },
+        methods: {
+            getAccounts: function() {
+                // using jquery ajax
+                $.ajax({
+                    url: path + "account/list.json",
+                    dataType: 'json',
+                    success: function(result) {
+                        app.accounts = result;
+                    }
+                });
+            },
+            getUser: function() {
+                // using jquery ajax
+                $.ajax({
+                    url: path + "user/get.json",
+                    dataType: 'json',
+                    success: function(result) {
+                        app.user = result;
+                        app.add_email = app.user.email;
+                        app.add_timezone = app.user.timezone;
+                    }
+                });
+            },
+            add_account: function() {
+                $.ajax({
+                    type: "POST",
+                    url: path + "account/add.json",
+                    dataType: 'json',
+                    data: {
+                        username: encodeURIComponent(app.add_username),
+                        password: encodeURIComponent(app.add_password),
+                        email: encodeURIComponent(app.add_email),
+                        timezone: encodeURIComponent(app.add_timezone)
+                    },
+                    success: function(result) {
+                        if (result.success) {
+                            app.getAccounts();
+                            $('#addNewUserModal').modal('hide');
+                        } else {
+                            app.add_error = result.message;
+                        }
+                    }
+                });
+            },
+            change_access: function(index) {
+                var userid = app.accounts[index].id;
+                var access = app.accounts[index].access;
+                access ++;
+                if (access > 2) access = 0;
+                $.ajax({
+                    type: "POST",
+                    url: path + "account/setaccess.json",
+                    dataType: 'json',
+                    data: {
+                        userid: userid,
+                        access: access
+                    },
+                    success: function(result) {
+                        app.accounts[index].access = access;
+                    }
+                });
+            },
+            unlink: function(index) {
+                var userid = app.accounts[index].id;
+
+                // ask for confirmation
+                if (!confirm("Are you sure you want to unlink this user? Original user will not be deleted")) return;
+
+                $.ajax({
+                    type: "POST",
+                    url: path + "account/unlink.json",
+                    dataType: 'json',
+                    data: {
+                        userid: userid
+                    },
+                    success: function(result) {
+                        app.getAccounts();
+                    }
+                });
+            }
+        },
+        filters: {
+            access: function(value) {
+                if (value == 0) return "Disabled";
+                if (value == 1) return "Read only";
+                if (value == 2) return "Write access";
+                return "Unknown";
+            }
+        
+        }
+    });
+
+    $("#open-add-user-modal").click(function() {
+        app.add_error = false;
+        $('#addNewUserModal').modal('show');
+    });
+</script>

--- a/Modules/user/deleteuser.php
+++ b/Modules/user/deleteuser.php
@@ -4,6 +4,11 @@ defined('EMONCMS_EXEC') or die('Restricted access');
 
 function delete_user($userid,$mode) {
 
+    $dryrun = true;
+    if ($mode=="permanentdelete") {
+        $dryrun = false;
+    }
+
     global $mysqli,$redis,$user,$settings;
 
     $result1 = $mysqli->query("SELECT id,apikey_read,apikey_write FROM users WHERE id=$userid");
@@ -51,6 +56,16 @@ function delete_user($userid,$mode) {
         foreach ($schema as $tablename=>$columns) {
             if (isset($columns['userid'])) {
                 $result .= delete_entry_in_table($tablename,$userid,$mode);
+            }
+        }
+        
+        // It would be better to implement some kind of standard interface for this
+        if (file_exists("Modules/account/account_model.php")) {
+            require_once("Modules/account/account_model.php");
+            $account_class = new Accounts($mysqli, $user);
+            $account_result = $account_class->delete_user($userid, $dryrun);
+            if ($account_result['success']) {
+                $result .= "- ".$account_result['message']."\n";
             }
         }
         

--- a/Modules/user/user_model.php
+++ b/Modules/user/user_model.php
@@ -410,12 +410,25 @@ class User
         }
         else
         {
+            // Default write access
+            if (!isset($userData->access)) $userData->access = 2;
+            
+            // If no access via login
+            if ($userData->access==0) {
+                return array('success'=>false, 'message'=>_("Login disabled for this account"));
+            }
+            
             session_regenerate_id();
             $_SESSION['userid'] = $userData->id;
             $_SESSION['username'] = $username;
-            $_SESSION['read'] = 1;
-            $_SESSION['write'] = 1;
-            $_SESSION['admin'] = $userData->admin;
+            
+            if ($userData->access>0) { 
+                $_SESSION['read'] = 1;
+            }
+            if ($userData->access>1) {
+                $_SESSION['write'] = 1;
+                $_SESSION['admin'] = $userData->admin;
+            }
             $_SESSION['lang'] = $userData->language;
             $_SESSION['timezone'] = $userData->timezone;
             $_SESSION['startingpage'] = $userData->startingpage;
@@ -771,6 +784,22 @@ class User
         $stmt->bind_param("si", $timezone, $userid);
         $stmt->execute();
         $stmt->close();
+    }
+    
+    //---------------------------------------------------------------------------------------
+    // Access
+    //---------------------------------------------------------------------------------------
+    public function set_access($userid, $access) {
+        $userid = (int) $userid;
+        $access = (int) $access;
+        $this->mysqli->query("UPDATE users SET `access`='$access' WHERE `id`='$userid'");
+    }
+    
+    public function get_access($userid) {
+        $userid = (int) $userid;
+        $result = $this->mysqli->query("SELECT `access` FROM users WHERE `id`='$userid'");
+        $data = $result->fetch_object();
+        return $data->access;
     }
 
     //---------------------------------------------------------------------------------------

--- a/Modules/user/user_schema.php
+++ b/Modules/user/user_schema.php
@@ -9,6 +9,8 @@ $schema['users'] = array(
     'apikey_write' => array('type' => 'varchar(64)'),
     'apikey_read' => array('type' => 'varchar(64)'),
     'lastlogin' => array('type' => 'datetime'),
+    // Via username & password login (0: no access, 1: read access, 2: write access)
+    'access' => array('type' => 'int(11)', 'default'=>2),
     'admin' => array('type' => 'int(11)', 'Null'=>false),
 
     // User profile fields

--- a/Theme/theme.php
+++ b/Theme/theme.php
@@ -56,7 +56,7 @@ if (!in_array($settings["interface"]["themecolor"], ["blue","sun","yellow2","sta
         <div class="menu-top bg-menu-top">
             <div class="menu-l1"><ul></ul></div>
             <div class="menu-tr"><ul>
-
+            
             <?php if ($session["read"]) { ?>
             <li class="<?php echo $session["gravatar"]?'':'no-'; ?>gravitar dropdown"><a id="user-dropdown" href="#" title="<?php echo $session["username"]." ".($session['admin']?'(Admin)':'')?>" class="grav-container img-circle d-flex dropdown-toggle" data-toggle="dropdown">
             <?php if (!$session["gravatar"]) { ?>
@@ -69,6 +69,10 @@ if (!in_array($settings["interface"]["themecolor"], ["blue","sun","yellow2","sta
                 <ul class="dropdown-menu pull-right" style="font-size:1rem">
                     <?php if ($session["write"]) { ?>
                     <li><a href="<?php echo $path; ?>user/view" title="<?php echo _("My Account"); ?>" style="line-height:30px"><svg class="icon"><use xlink:href="#icon-user"></use></svg> <?php echo _("My Account"); ?></a></li>
+                    <li class="divider"><a href="#"></a></li>
+                    <?php } ?>
+                    <?php if (isset($_SESSION['adminuser'])) { ?>
+                    <li><a href="<?php echo $path; ?>account/switch" title="<?php echo _("Admin"); ?>" style="line-height:30px"><svg class="icon"><use xlink:href="#icon-logout"></use></svg> <?php echo _("Admin"); ?></a></li>
                     <li class="divider"><a href="#"></a></li>
                     <?php } ?>
                     <li><a href="<?php echo $path; ?>user/logout" title="<?php echo _("Logout"); ?>" style="line-height:30px"><svg class="icon"><use xlink:href="#icon-logout"></use></svg> <?php echo _("Logout"); ?></a></li>


### PR DESCRIPTION
A simple multi user management module for emoncms that allows a single user (any user) to become an admin user for a number of other linked user accounts. 

1. Provides convenient access to the linked accounts
2. New user level access control option that can be used to disable login access for a user or restrict login access as read-only.

Core goal, to keep the implementation as simple as possible, I've been round in circles enough times with group based multi user management approaches. This accounts table also mirrors the same multi user billing implementation used on emoncms.org with the intention of integrating this as an extension of that functionality so that it's possible to manage in addition to just handling the billing for linked users...

**Heatpump Monitoring**
This tool could be used by an installer to create an account for each site/installation. Providing a convenient login and list of sites/installations under management. Read only access with username and password login can be provided to users. Linked users cannot access data from other users (more secure than placing multiple sites under a single emoncms account) 

![image](https://github.com/emoncms/emoncms/assets/503186/ccda6e83-0de0-4f6e-a086-20dea81369f0)
