### PR TITLE
to support home-assistant ingress mode :-)

### DIFF
--- a/core.php
+++ b/core.php
@@ -45,7 +45,13 @@ function get_application_path($manual_domain=false)
     }
 
     if (isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
-        $path = dirname("$proto://" . server('HTTP_X_FORWARDED_HOST') . server('SCRIPT_NAME')) . "/";
+        $filepath = "$proto://" . server('HTTP_X_FORWARDED_HOST');
+        if (isset($_SERVER['HTTP_X_INGRESS_PATH'])) {
+            // web server is running in ingress mode in home assistant
+            $filepath .= server('HTTP_X_INGRESS_PATH');
+        }
+        $filepath .= server('SCRIPT_NAME');
+        $path = dirname($filepath) . "/";
     } else {
         $path = dirname("$proto://" . server('HTTP_HOST') . server('SCRIPT_NAME')) . "/";
     }


### PR DESCRIPTION
core.php has to be modified when the web server is running in ingress mode, for example inside [homeassistant](https://www.home-assistant.io/blog/2019/04/15/hassio-ingress/)

when running in ingress mode, apache has got some specific headers we have to use in the path

![image](https://github.com/emoncms/emoncms/assets/24553739/2ad60ccc-b0c8-4055-abbf-9cad40c7eade)

when running out of ingress mode, these headers are no more present

![image](https://github.com/emoncms/emoncms/assets/24553739/e74cf9da-54e5-4a8d-a9d6-1cb18d710904)

