### PR TITLE
Fix last update time for inputs and feeds

### DIFF
--- a/Lib/responsive-linked-tables.js
+++ b/Lib/responsive-linked-tables.js
@@ -40,7 +40,7 @@ $(function() {
     //data-toggle="collapse"
 
     $(document).on("shown hidden", '#table .tbody.collapse', function(e){
-    	$header = $('[data-target="#'+e.target.id+'"]')
+        $header = $('[data-target="#'+e.target.id+'"]')
         if (e.type == 'hidden'){
             $header.addClass('collapsed')
             $header.find('.icon-indicator').removeClass('icon-chevron-down').addClass('icon-chevron-right')
@@ -123,33 +123,45 @@ function list_format_updated(time) {
 }
 
 function list_format_updated_obj(time) {
-    time = time * 1000;
-    var servertime = new Date().getTime(); // - table.timeServerLocalOffset;
-    var update = new Date(time).getTime();
-    
+    var servertime = (new Date()).getTime() - app.timeServerLocalOffset;
+    time = new Date(time * 1000);
+    var update = time.getTime();
+
     var delta = servertime - update;
     var secs = Math.abs(delta) / 1000;
     var mins = secs / 60;
     var hour = secs / 3600;
     var day = hour / 24;
-    
+
     var updated = secs.toFixed(0) + "s";
     if ((update == 0) || (!$.isNumeric(secs))) updated = "n/a";
     else if (secs.toFixed(0) == 0) updated = "now";
-    else if (day > 7 && delta > 0) updated = "inactive";
+    else if (day > 365 && delta > 0) updated = time.toLocaleDateString("en-GB",{year:"numeric", month:"short"});
+    else if (day > 31 && delta > 0) updated = time.toLocaleDateString("en-GB",{month:"short", day:"numeric"});
     else if (day > 2) updated = day.toFixed(1) + " days";
     else if (hour > 2) updated = hour.toFixed(0) + " hrs";
     else if (secs > 180) updated = mins.toFixed(0) + " mins";
     
     secs = Math.abs(secs);
-    var color = "rgb(255,0,0)";
+    var color = "rgb(150,150,150)";
     if (delta < 0) color = "rgb(60,135,170)"
     else if (secs < 25) color = "rgb(50,200,50)"
     else if (secs < 60) color = "rgb(240,180,20)"; 
     else if (secs < (3600*2)) color = "rgb(255,125,20)"
-    
+    else if (secs < (3600*24*31)) color = "rgb(255,0,0)"
+
     return {color:color,value:updated};
 }
+
+// Number of ms from last update
+function list_format_last_update(time) {
+    time = time * 1000;
+    var servertime = new Date().getTime() - app.timeServerLocalOffset;
+    var update = new Date(time).getTime();
+    var delta = servertime - update;
+    return delta
+}
+
 
 // Format value dynamically
 function list_format_value(value) {

--- a/Lib/tablejs/custom-table-fields.js
+++ b/Lib/tablejs/custom-table-fields.js
@@ -174,8 +174,8 @@ var customtablefields = {
 
 // Calculate and color updated time
 function list_format_updated(time) {
-  time = time * 1000;
   var servertime = (new Date()).getTime() - table.timeServerLocalOffset;
+  time = new Date(time * 1000);
   var update = (new Date(time)).getTime();
 
   var delta = servertime - update;
@@ -187,17 +187,19 @@ function list_format_updated(time) {
   var updated = secs.toFixed(0) + "s";
   if ((update == 0) || (!$.isNumeric(secs))) updated = "n/a";
   else if (secs.toFixed(0) == 0) updated = "now";
-  else if (day > 7 && delta > 0) updated = "inactive";
+  else if (day > 365 && delta > 0) updated = time.toLocaleDateString("en-GB",{year:"numeric", month:"short"});
+  else if (day > 31 && delta > 0) updated = time.toLocaleDateString("en-GB",{month:"short", day:"numeric"});
   else if (day > 2) updated = day.toFixed(1) + " days";
   else if (hour > 2) updated = hour.toFixed(0) + " hrs";
   else if (secs > 180) updated = mins.toFixed(0) + " mins";
 
   secs = Math.abs(secs);
-  var color = "rgb(255,0,0)";
+  var color = "rgb(150,150,150)";
   if (delta < 0) color = "rgb(60,135,170)"
   else if (secs < 25) color = "rgb(50,200,50)"
   else if (secs < 60) color = "rgb(240,180,20)"; 
   else if (secs < (3600*2)) color = "rgb(255,125,20)"
+  else if (secs < (3600*24*31)) color = "rgb(255,0,0)"
 
   return "<span style='color:"+color+";'>"+updated+"</span>";
 }

--- a/Modules/feed/Views/feedlist_view.php
+++ b/Modules/feed/Views/feedlist_view.php
@@ -88,7 +88,7 @@ function translate(property) {
 body{padding:0!important}
 
 #table {
-    margin-top:3rem
+    margin-top:4rem
 }
 #footer {
     margin-left: 0px;
@@ -133,30 +133,9 @@ body{padding:0!important}
     right: 0;
 }
 
-.node-feeds .node-feed.status-warning:after,
-.node.status-warning .accordion-toggle:after {
-    background: #FFC107;
-}
-.node-feeds .node-feed.status-success:after,
-.node.status-success .accordion-toggle:after {
-    background: #28A745;
-}
-.node-feeds .node-feed.status-danger:after,
-.node.status-danger .accordion-toggle:after {
-    background: #DC3545;
-}
-
-.node.status-warning .accordion-toggle .last-update,
-.node-feeds .node-feed.status-warning .last-update{
-    color: #C70!important;
-}
-.node.status-success .accordion-toggle .last-update,
-.node-feeds .node-feed.status-success .last-update{
-    color: #28A745!important; 
-}
-.node.status-danger .accordion-toggle .last-update,
-.node-feeds .node-feed.status-danger .last-update{
-    color: #DC3545!important;
+.node-feeds .node-feed:after,
+.accordion-toggle:after {
+    background: var(--status-color)!important;
 }
 
 </style>
@@ -355,9 +334,9 @@ if (!session_write) {
    $("#feed-footer").hide();
 }
 
-
 var feedviewpath = "<?php echo $settings['interface']['feedviewpath']; ?>";
 
+var app = {};
 var feeds = {};
 var nodes = {};
 var selected_feeds = {};
@@ -378,9 +357,10 @@ var firstLoad = true;
 function update_feed_list() {
     var public_username_str = "";
     if (public_userid) public_username_str = public_username+"/";
+    var requestTime = (new Date()).getTime();
 
-    $.ajax({ url: path+public_username_str+"feed/list.json?meta=1", dataType: 'json', async: true, success: function(data) {
-    
+    $.ajax({ url: path+public_username_str+"feed/list.json?meta=1", dataType: 'json', async: true, success: function(data, textStatus, xhr) {
+        if( typeof app !== 'undefined') app.timeServerLocalOffset = requestTime-(new Date(xhr.getResponseHeader('Date'))).getTime(); // Offset in ms from local to server time
         if (data.message!=undefined && data.message=="Username or password empty") {
             window.location.href = "/";
             return false;
@@ -426,37 +406,48 @@ function update_feed_list() {
         firstLoad = false;
         var out = "";
         
-        // get node overview
-        var node_size = {},
-            node_time = {};
 
-        for (let n in nodes) {
-            let node = nodes[n];
-            node_size[n] = 0;
-            node_time[n] = 0;
-            for (let f in node) {
-                let feed = node[f];
-                node_size[n] += Number(feed.size);
-                node_time[n] = parseInt(feed.engine) !== 7 && feed.time > node_time[n] ? feed.time : node_time[n];
-            }
-        }
 
         // display nodes and feeds
         var counter = 0;
         for (var node in nodes) {
             counter ++;
             isCollapsed = !nodes_display[node];
-            out += '<div class="node accordion ' + nodeIntervalClass(nodes[node]) + '">';
+
+            var node_size = 0;
+            var node_time = null;
+            var oldest_time = 0;
+            for (var feed in nodes[node]) {
+                var feed = nodes[node][feed];
+                node_size += Number(feed.size);
+
+                var last_update = list_format_last_update(feed.time);
+                if (feed.time != null && parseInt(feed.engine) !== 7 && last_update > oldest_time) {
+                    oldest_time = last_update;
+                    node_time = feed;
+                }
+            }
+
+            if (node_time == null) {
+                var fv = list_format_updated_obj(0);
+                fv.value_color = list_format_updated(0);
+            } else {
+                var fv = list_format_updated_obj(node_time.time);
+                fv.value_color = list_format_updated(node_time.time);
+            }
+
+
+            out += '<div class="node accordion" style="--status-color: '+ fv.color + '">';
             out += '    <div class="node-info accordion-toggle thead'+(isCollapsed ? ' collapsed' : '')+'" data-toggle="collapse" data-target="#collapse'+counter+'">'
             out += '      <div class="select text-center has-indicator" data-col="B"><span class="icon-chevron-'+(isCollapsed ? 'right' : 'down')+' icon-indicator"></span></div>';
             out += '      <h5 class="name" data-col="A">'+node+':</h5>';
             out += '      <div class="public" class="text-center" data-col="E"></div>';
             out += '      <div class="engine" data-col="G"></div>';
-            out += '      <div class="size text-center" data-col="H">'+list_format_size(node_size[node])+'</div>';
+            out += '      <div class="size text-center" data-col="H">'+list_format_size(node_size)+'</div>';
             out += '      <div class="processlist" data-col="F"></div>';
             out += '      <div class="node-feed-right pull-right">';
-            out += '        <div class="value" data-col="C"></div>';
-            out += '        <div class="time" data-col="D">'+list_format_updated(node_time[node])+'</div>';
+            out += '        <div class="value text-center" data-col="C"></div>';
+            out += '        <div class="time text-center" data-col="D">'+fv.value_color+'</div>';
             out += '      </div>';
             out += '    </div>';
             
@@ -495,7 +486,9 @@ function update_feed_list() {
 
                 row_title = title_lines.join("\n");
 
-                out += "<div class='" + feedListItemIntervalClass(feed) + " node-feed feed-graph-link' feedid="+feedid+" title='"+row_title+"' data-toggle='tooltip'>";
+                var fv = list_format_updated_obj(feed.time);
+
+                out += "<div class='node-feed feed-graph-link' style=\"--status-color: "+ fv.color + "\" feedid="+feedid+" title='"+row_title+"' data-toggle='tooltip'>";
                 var checked = ""; if (selected_feeds[feedid]) checked = "checked";
                 out += "<div class='select text-center' data-col='B'><input class='feed-select' type='checkbox' feedid='"+feedid+"' "+checked+"></div>";
                 out += "<div class='name' data-col='A'>"+feed.name+"</div>";
@@ -519,8 +512,8 @@ function update_feed_list() {
                 out += '  <div class="processlist" data-col="F">'+processListHTML+'</div>';
                 out += '  <div class="node-feed-right pull-right">';
                 if (feed.unit==undefined) feed.unit = "";
-                out += '    <div class="value" data-col="C">'+list_format_value(feed.value)+' '+feed.unit+'</div>';
-                out += '    <div class="time" data-col="D">'+list_format_updated(feed.time)+'</div>';
+                out += '    <div class="value text-center" data-col="C">'+list_format_value(feed.value)+' '+feed.unit+'</div>';
+                out += '    <div class="time text-center" data-col="D">'+list_format_updated(feed.time)+'</div>';
                 out += '  </div>';
                 out += '</div>';
             }
@@ -586,39 +579,6 @@ function buildFeedNodeList() {
         node_names.push(feed[0].tag)
     }
     autocomplete(document.getElementById("feed-node"), node_names);
-}
-
-
-function missedIntervals(feed) {
-    if (!feed) return void 0;
-    var lastUpdated = new Date(feed.time * 1000);
-    var now = new Date().getTime();
-    var elapsed = (now - lastUpdated) / 1000;
-    let missedIntervals = parseInt(elapsed / feed.interval);
-    return missedIntervals;
-}
-function feedListItemIntervalClass (feed) {
-    if (!feed) return void 0;
-    let missed = missedIntervals(feed);
-    let result = [];
-    if (missed < 3) result.push('status-success');
-    if (missed > 2 && missed < 9) result.push('status-warning');
-    if (missed > 8) result.push('status-danger');
-    return result.join(' ');
-}
-function nodeIntervalClass (feeds) {
-    let nodeMissed = 0;
-    for (f in feeds) {
-        let missed = missedIntervals(feeds[f]);
-        if (missed > nodeMissed) {
-            nodeMissed = missed;
-        }
-    }
-    let result = [];
-    if (nodeMissed < 3) result.push('status-success');
-    if (nodeMissed > 2 && nodeMissed < 9) result.push('status-warning');
-    if (nodeMissed > 8) result.push('status-danger');
-    return result.join(' ');
 }
 
 

--- a/Modules/input/Views/input_view.php
+++ b/Modules/input/Views/input_view.php
@@ -91,31 +91,12 @@ input[type="checkbox"] { margin:0px; }
 .buttons{
     padding-right: .4em;
 }
-.status-success.node-info::after,
-.status-success.node-input::after{
-    background: #28A745!important;
-}
-.status-danger.node-info::after,
-.status-danger.node-input::after{
-    background: #DC3545!important;
-}
-.status-warning.node-info::after,
-.status-warning.node-input::after{
-    background: #FFC107!important;
+
+.node-info::after,
+.node-input::after {
+    background: var(--status-color)!important;
 }
 
-.status-success.node-info .last-update,
-.status-success.node-input .last-update{
-    color: #28A745!important;
-}
-.status-danger.node-info .last-update,
-.status-danger.node-input .last-update{
-    color: #DC3545!important;
-}
-.status-warning.node-info .last-update,
-.status-warning.node-input .last-update{
-    color: #C70!important;
-}
 
 [data-col] { overflow:hidden; }
 
@@ -228,7 +209,7 @@ input.checkbox-lg,
       <template v-if="loaded">
         <template v-if="total_devices > 0">
         <div class="node accordion line-height-expanded" v-for="(device,nodeid) in devices" :class="{'select-mode': selectMode}">
-            <div @click="toggleCollapse($event, nodeid)" class="node-info accordion-toggle thead" :class="[deviceStatus(device)]" :data-node="nodeid" :data-target="'#collapse_' + nodeid">
+            <div @click="toggleCollapse($event, nodeid)" class="node-info accordion-toggle thead" :style="{ '--status-color': device.time_color }" :data-node="nodeid" :data-target="'#collapse_' + nodeid">
 
             <div class="select text-center has-indicator" data-col="B">
                 <span v-if="!selectMode || getDeviceInputIds(device) == 0" class="icon-indicator" :class="{'icon-chevron-down': isCollapsed(nodeid),'icon-chevron-up': !isCollapsed(nodeid)}"></span>
@@ -244,7 +225,7 @@ input.checkbox-lg,
             <div class="processlist" data-col="H" :style="{width:col.H+'px'}"></div>
             <div class="buttons pull-right">
                 <div class="device-schedule text-center hidden" data-col="F" :style="{width:col.F+'px'}"><i class="icon-time"></i></div>
-                <div class="device-last-updated text-center" data-col="E" :style="{width:col.E+'px'}"></div>
+                <div class="device-last-updated text-center" data-col="E" :style="{width:col.E+'px', color:device.time_color}">{{ device.time_value }}</div>
                 <a @click.prevent.stop="show_device_key(device)" href="#" class="device-key text-center" data-col="D" :style="{width:col.D+'px'}" :class="{'text-muted': !device_module}" data-col-width="50"  title="<?php echo _('Show device key'); ?>">
                     <i class="icon-lock"></i>
                 </a>
@@ -254,7 +235,7 @@ input.checkbox-lg,
             </div>
             </div>
             <div :id="'collapse_' + nodeid" class="node-inputs collapse tbody" :class="{in: collapsed.indexOf(nodeid) === -1}" :data-node="nodeid">
-            <div @click="toggleSelected($event, input.id)" class="node-input" :id="input.id" v-for="(input,index) in device.inputs" :class="[inputStatus(input), {'selected': selected.indexOf(input.id) > -1}]">
+            <div @click="toggleSelected($event, input.id)" class="node-input" :id="input.id" v-for="(input,index) in device.inputs" :style="{ '--status-color': input.time_color }" :class="[{'selected': selected.indexOf(input.id) > -1}]">
                 <div class="select text-center" data-col="B">
                     <input class="input-select" type="checkbox" :value="input.id" v-model="selected">
                 </div>

--- a/Modules/process/Views/process_ui.js
+++ b/Modules/process/Views/process_ui.js
@@ -289,7 +289,7 @@ var processlist_ui =
       } else {
         // default else
         badges.push({
-          text: 'wait&hellip;',
+          text: ' 🕒… ',
           title: '',
           cssClass: 'muted',
           href: false

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
     "name"         : "Emoncms Core",
-    "version"      : "11.5.0",
+    "version"      : "11.5.1",
     "location"     : "/var/www",
     "branches_available": ["stable","master"]
 }


### PR DESCRIPTION
- Fix report of last updated input and feed.
- Refactor to use same logic for both in resposive-linked-tables.js shared lib.
- Added new feature to report month/day of last update time when update was more than 1 month ago in gray color. Useful for easy understanding time for disabled inputs or feeds.
- Fix consider server time out of sync with timeServerLocalOffset var.
- Fix input table first line offset.

Screenshot:
![image](https://github.com/emoncms/emoncms/assets/4527135/5a5f7edd-1646-4c9a-8791-4d92cbcd460b)
