### PR TITLE
mac address broadcast through API admin/getmac route

### DIFF
--- a/Modules/admin/admin_controller.php
+++ b/Modules/admin/admin_controller.php
@@ -134,6 +134,12 @@ function admin_controller()
     // ----------------------------------------------------------------------------------------
     // System info page actions
     // ----------------------------------------------------------------------------------------
+    if ($route->action == 'getmac') {
+        // return server mac address
+        $route->format = 'text';
+        $cmd = "ifconfig -a | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}'";
+        return str_replace("\n", "", shell_exec($cmd));
+    }
 
     if ($route->action == 'service') {
         $route->format = 'json';

--- a/Modules/admin/admin_controller.php
+++ b/Modules/admin/admin_controller.php
@@ -138,7 +138,9 @@ function admin_controller()
         // return server mac address
         $route->format = 'text';
         $cmd = "ifconfig -a | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}'";
-        return str_replace("\n", "", shell_exec($cmd));
+        $result=shell_exec($cmd);
+        if (!isset($result)) return "UNKNOWN_DEVICE";
+        return str_replace("\n", "", $result);
     }
 
     if ($route->action == 'service') {


### PR DESCRIPTION
It is vendor responsibility to provide a unique identifier

It is asked for example by home-assistant when using the emoncms module synchronizing an existing emoncms installation to home-assistant core

broadcasting the mac address through the API is an accepted solution : cf https://developers.home-assistant.io/docs/entity_registry_index/