### PR TITLE
adding a UUID to each feed object

### DIFF
--- a/Modules/feed/feed_model.php
+++ b/Modules/feed/feed_model.php
@@ -396,6 +396,16 @@ class Feed
         } else {
             $feeds = $this->mysql_get_user_feeds($userid,$getmeta);
         }
+        $result = $this->mysqli->query("SELECT uuid FROM users WHERE `id` = '$userid'");
+        if ($row = $result->fetch_object()) {
+            $uuid = $row->uuid;
+            if ($uuid) {
+                foreach ($feeds as $k=>$f) {
+                    $f['uuid'] = $uuid."-".$f['userid']."-".$f['id'];
+                    $feeds[$k] = $f;
+                }
+            }
+        }
         return $feeds;
     }
 

--- a/Modules/feed/feed_model.php
+++ b/Modules/feed/feed_model.php
@@ -407,7 +407,7 @@ class Feed
             $uuid = $row->uuid;
             if ($uuid) {
                 foreach ($feeds as $k=>$f) {
-                    $f['uuid'] = $uuid."-".$f['userid']."-".$f['id'];
+                    $f['uuid'] = $uuid."-".$f['id'];
                     $feeds[$k] = $f;
                 }
             } else {

--- a/Modules/user/user_model.php
+++ b/Modules/user/user_model.php
@@ -276,8 +276,8 @@ class User
         $apikey_read = generate_secure_key(16);
         $uuid = guidv4();
 
-        $stmt = $this->mysqli->prepare("INSERT INTO users ( username, password, email, salt ,apikey_read, apikey_write, timezone, admin, uuid) VALUES (?,?,?,?,?,?,?,?,?)");
-        $stmt->bind_param("sssssss", $username, $password, $email, $salt, $apikey_read, $apikey_write, $timezone, 0, $uuid);
+        $stmt = $this->mysqli->prepare("INSERT INTO users ( username, password, email, salt ,apikey_read, apikey_write, timezone, uuid, admin) VALUES (?,?,?,?,?,?,?,?,0)");
+        $stmt->bind_param("ssssssss", $username, $password, $email, $salt, $apikey_read, $apikey_write, $timezone, $uuid);
         if (!$stmt->execute()) {
             $error = $this->mysqli->error;
             $stmt->close();

--- a/Modules/user/user_model.php
+++ b/Modules/user/user_model.php
@@ -274,9 +274,10 @@ class User
 
         $apikey_write = generate_secure_key(16);
         $apikey_read = generate_secure_key(16);
+        $uuid = guidv4();
 
-        $stmt = $this->mysqli->prepare("INSERT INTO users ( username, password, email, salt ,apikey_read, apikey_write, timezone, admin) VALUES (?,?,?,?,?,?,?,0)");
-        $stmt->bind_param("sssssss", $username, $password, $email, $salt, $apikey_read, $apikey_write, $timezone);
+        $stmt = $this->mysqli->prepare("INSERT INTO users ( username, password, email, salt ,apikey_read, apikey_write, timezone, admin, uuid) VALUES (?,?,?,?,?,?,?,?,?)");
+        $stmt->bind_param("sssssss", $username, $password, $email, $salt, $apikey_read, $apikey_write, $timezone, 0, $uuid);
         if (!$stmt->execute()) {
             $error = $this->mysqli->error;
             $stmt->close();

--- a/Modules/user/user_schema.php
+++ b/Modules/user/user_schema.php
@@ -22,7 +22,8 @@ $schema['users'] = array(
     'tags' => array('type' => 'text'),
     'startingpage' => array('type'=>'varchar(64)', 'default'=>'feed/list'),
     'email_verified' => array('type' => 'int(11)', 'default'=>0),
-    'verification_key' => array('type' => 'varchar(64)', 'default'=>'')
+    'verification_key' => array('type' => 'varchar(64)', 'default'=>''),
+    'uuid' => array('type' => 'varchar(32)', 'default'=>'')
 );
 
 $schema['rememberme'] = array(

--- a/Modules/user/user_schema.php
+++ b/Modules/user/user_schema.php
@@ -23,7 +23,7 @@ $schema['users'] = array(
     'startingpage' => array('type'=>'varchar(64)', 'default'=>'feed/list'),
     'email_verified' => array('type' => 'int(11)', 'default'=>0),
     'verification_key' => array('type' => 'varchar(64)', 'default'=>''),
-    'uuid' => array('type' => 'varchar(32)', 'default'=>'')
+    'uuid' => array('type' => 'varchar(36)', 'default'=>'')
 );
 
 $schema['rememberme'] = array(

--- a/core.php
+++ b/core.php
@@ -362,3 +362,22 @@ function generate_secure_key($length) {
         return bin2hex(openssl_random_pseudo_bytes($length));
     }
 }
+
+// ---------------------------------------------------------------------------------------------------------
+// Generate a 16 bytes (128 bits) UUID - RFC 4122 compliant Version 4
+// ---------------------------------------------------------------------------------------------------------
+function guidv4() {
+    if (function_exists('random_bytes')) {
+        $data = random_bytes(16);
+    } else {
+        $data = openssl_random_pseudo_bytes(16);
+    }
+    // Set version to 0100
+    $data[6] = chr(ord($data[6]) & 0x0f | 0x40);
+    // Set bits 6-7 to 10
+    $data[8] = chr(ord($data[8]) & 0x3f | 0x80);
+
+    // Output the 36 character UUID.
+    return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
+}
+


### PR DESCRIPTION
continuation of work started here : https://github.com/emoncms/emoncms/pull/1885

integration of a guidv4 function in the core and modification of user and feed models

to test things with a [standalone container](https://hub.docker.com/repository/docker/alexjunk/emoncms/general) :

```
git clone -b uuid_in_user_table http://github.com/alexandrecuer/emoncms
cd emoncms
sudo docker run --rm -p 8081:80 -p 7883:1883 -v $(pwd)/core.php:/var/www/emoncms/core.php -v $(pwd)/Modules/user:/var/www/emoncms/Modules/user -v $(pwd)/Modules/feed:/var/www/emoncms/Modules/feed -it alexjunk/emoncms
```
- create first user
- download a dataset without user, eg : `wget https://github.com/alexandrecuer/smartgrid/raw/master/datasets/no_user_table/bloch-2021.tar.gz`
- restore it

![image](https://github.com/emoncms/emoncms/assets/24553739/62092dd0-b6d6-4294-af84-c5b63892e3ae)

Existing installations will need to run the migration, errors will be thrown in the log to advise for that

The first time the `feed/list.json` route is called, an uuid is generated for those freshly migrated user

Using a migrated installation with a previous emoncms version should cause no problem