### PR TITLE
Add missing MQTT settings for old config

### DIFF
--- a/Lib/process_old_settings.php
+++ b/Lib/process_old_settings.php
@@ -53,7 +53,9 @@ $settings = array(
     'capath'    => isset($mqtt_server["capath"])?$mqtt_server["capath"]:null,
     'certpath'  => isset($mqtt_server["certpath"])?$mqtt_server["certpath"]:null,
     'keypath'   => isset($mqtt_server["keypath"])?$mqtt_server["keypath"]:null,
-    'keypw'     => isset($mqtt_server["keypw"])?$mqtt_server["keypw"]:null
+    'keypw'     => isset($mqtt_server["keypw"])?$mqtt_server["keypw"]:null,
+    'userid'    => isset($mqtt_server["userid"])?mqtt_server["userid"]:1,
+    'multiuser' => isset($mqtt_server["multiuser"])?mqtt_server["multiuser"]:false
 ),
 
 // Input


### PR DESCRIPTION
I found that these two settings are critical for MQTT support in EmonCMS, but if running on a legacy config format, they don't exist.

* userid
* multiuser

I don't believe these are used in a local installation, so have defaulted them to 1, and false respectively.