### PR TITLE
Minor bug fixes for feed module

### DIFF
--- a/Modules/feed/engine/PHPTimeSeries.php
+++ b/Modules/feed/engine/PHPTimeSeries.php
@@ -416,7 +416,7 @@ class PHPTimeSeries implements engine_methods
                 }
 
                 $len = $next_start_dp[0]-$start_dp[0];
-                if ($len) {
+                if ($len>0) {
                     fseek($fh,$start_dp[0]*9);
                     $s = fread($fh,$len*9);
                     $s2 = "";

--- a/Modules/feed/feed_model.php
+++ b/Modules/feed/feed_model.php
@@ -47,7 +47,7 @@ class Feed
             // Load different storage engines
             switch ($e) {
                 case (string)Engine::MYSQL :
-                    require "Modules/feed/engine/MysqlTimeSeries.php";  // Mysql engine
+                    require_once "Modules/feed/engine/MysqlTimeSeries.php";  // Mysql engine
                     $engines[$e] = new MysqlTimeSeries($this->mysqli,$this->redis,$this->settings['mysqltimeseries']);
                     break;
                 case (string)Engine::VIRTUALFEED :


### PR DESCRIPTION
A couple minor fixes found when upgrading to php8.2

1. if a user has a mix of MySQL TimeSeries and Memory feeds, emoncms can sometimes load the Memory engine before the main MySQL engine, resulting in an "this class already loaded" error. Fixed with `require_once`.

2. if a PHPTimeSeries somehow manages to have a _negative_ length, `fread` would error.