### PR TITLE
admin_main_view.php: Remove echo of $rpi_info['hw']

### DIFF
--- a/Modules/admin/Views/admin_main_view.php
+++ b/Modules/admin/Views/admin_main_view.php
@@ -232,7 +232,6 @@ listItem;
         <h4 class="text-info text-uppercase border-top pt-2 mt-0 px-1"><?php echo _('Pi'); ?></h4>
         <dl class="row">
             <?php echo row(sprintf('<span class="align-self-center">%s</span>',_('Model')), $rpi_info['model'].'<div>'.RebootBtn().ShutdownBtn().'</div>','d-flex','d-flex align-items-center justify-content-between') ?>
-            <!-- <?php echo row(_('SoC'), $rpi_info['hw']) ?> -->
             <?php echo row(_('Serial num.'), strtoupper(ltrim($rpi_info['sn'], '0'))) ?>
             <?php echo row(_('CPU Temperature'), $rpi_info['cputemp']) ?>
             <?php echo row(_('GPU Temperature'), $rpi_info['gputemp']) ?>


### PR DESCRIPTION
It's not set anymore since https://github.com/emoncms/emoncms/commit/6b4d93dc230c75da97d9c9c008c57a263f0d1c85

Fixes https://github.com/emoncms/emoncms/issues/1903