### PR TITLE
Enable PI info, reboot, and shutdown for late model RPis

### DIFF
--- a/Modules/admin/admin_model.php
+++ b/Modules/admin/admin_model.php
@@ -611,7 +611,7 @@ class Admin {
      * @return bool
      */
     public function is_Pi() {
-        return !empty($this->exec('ip addr | grep -i "b8:27:eb:\|dc:a6:32:\|28:cd:c1:\|d8:3a:dd:\|e4:5f:01:"'));
+        return !empty($this->exec('ip addr | grep -i "2c:cf:67:\|b8:27:eb:\|dc:a6:32:\|28:cd:c1:\|d8:3a:dd:\|e4:5f:01:"'));
     }
 
     /**


### PR DESCRIPTION
Late model RaspberryPIs are using a new mac OUI (see https://maclookup.app/macaddress/2ccf67). 
These devices (Raspberry Pi 4B sourced from AdaFruit in my case) do not have the 
PI section enabled in admin and therefore can't reboot/shutdown.

This PR enabled this OUI. Reboot/shutdown works, though video temps do not (yet) 
work.
