### PR TITLE
Adapt admin model for a correct behaviour in container

### DIFF
--- a/Modules/admin/Views/admin_main_view.php
+++ b/Modules/admin/Views/admin_main_view.php
@@ -89,19 +89,21 @@ listItem;
                       <strong><?php echo $value['state']; ?></strong> <?php echo $value['text']; ?>
                       <div class="btn-group" role="group" style="float:right">
 
-                      <?php if ($value['unitfilestate']!="disabled" && $value['state']!="Active") { ?>
-                      <button class="btn btn-small btn-success service-action" service_action="start" service_key="<?php echo $key; ?>">Start</button>
-                      <?php } ?>
+                      <?php if ($value["unitfilestate"]!="container") { ?>
+                          <?php if ($value['unitfilestate']!="disabled" && $value['state']!="Active") { ?>
+                          <button class="btn btn-small btn-success service-action" service_action="start" service_key="<?php echo $key; ?>">Start</button>
+                          <?php } ?>
 
-                      <?php if ($value['state']=="Active") { ?>
-                        <button class="btn btn-small btn-danger service-action" service_action="stop" service_key="<?php echo $key; ?>">Stop</button>
-                        <button class="btn btn-small btn-warning service-action" service_action="restart" service_key="<?php echo $key; ?>">Restart</button>
-                      <?php } ?>
+                          <?php if ($value['state']=="Active") { ?>
+                          <button class="btn btn-small btn-danger service-action" service_action="stop" service_key="<?php echo $key; ?>">Stop</button>
+                          <button class="btn btn-small btn-warning service-action" service_action="restart" service_key="<?php echo $key; ?>">Restart</button>
+                          <?php } ?>
 
-                      <?php if ($value['unitfilestate']=="disabled") { ?>
-                      <button class="btn btn-small btn-primary service-action" service_action="enable" service_key="<?php echo $key; ?>">Enable</button>
-                      <?php } elseif ($value['state']!="Active") { ?>
-                      <button class="btn btn-small btn-inverse service-action" service_action="disable" service_key="<?php echo $key; ?>">Disable</button>
+                          <?php if ($value['unitfilestate']=="disabled") { ?>
+                          <button class="btn btn-small btn-primary service-action" service_action="enable" service_key="<?php echo $key; ?>">Enable</button>
+                          <?php } elseif ($value['state']!="Active") { ?>
+                          <button class="btn btn-small btn-inverse service-action" service_action="disable" service_key="<?php echo $key; ?>">Disable</button>
+                          <?php } ?>
                       <?php } ?>
 
                       </div>

--- a/Modules/admin/admin_model.php
+++ b/Modules/admin/admin_model.php
@@ -185,7 +185,7 @@ class Admin {
                 "mosquitto",
                 "emoncms_sync"
             ];
-            if (in_array(needle: $service_name, haystack: $container_services)) {
+            if (in_array($service_name, $container_services)) {
                 return [
                     "LoadState"=>"loaded",
                     "ActiveState"=>"active",
@@ -480,7 +480,7 @@ class Admin {
         // I would have used disk_free_space() and disk_total_space() here but
         // there appears to be no way to get a list of partitions in PHP?
         $output = array();
-        if (file_exists(filename: "/.dockerenv")) {
+        if (file_exists("/.dockerenv")) {
             //return $partitions;
             $output = $this->exec_array('df -B 1 /data');
         } else {
@@ -526,7 +526,7 @@ class Admin {
                 $readload = 0;
                 $writeload = 0;
                 $loadtime = 0;
-                if (!file_exists(filename: "/.dockerenv")) {
+                if (!file_exists("/.dockerenv")) {
                     ob_start();
                     @passthru("iostat -o JSON -k $filesystem");
                     $output = trim(ob_get_clean());
@@ -553,7 +553,7 @@ class Admin {
                     } elseif ($partition=="/home/pi/data") {
                         $partition_name = "mmcblk0p3";
                     }
-                    if (file_exists(filename: "/.dockerenv")) {
+                    if (file_exists("/.dockerenv")) {
                         $elements = explode(separator: "/", string: $filesystem);
                         $partition_name = end(array: $elements);
                     }
@@ -741,7 +741,7 @@ class Admin {
             $v = "n/a";
         } else {
             if (@file_exists('/usr/sbin/mosquitto')) {
-                if (file_exists(filename: "/.dockerenv")) {
+                if (file_exists("/.dockerenv")) {
                     $v = $this->exec('/usr/sbin/mosquitto -h | grep version');
                 } else {
                     $v = $this->exec('/usr/sbin/mosquitto -h | grep -oP \'(?<=mosquitto\sversion\s)[0-9.]+(?=\s*)\'');

--- a/Modules/admin/admin_model.php
+++ b/Modules/admin/admin_model.php
@@ -554,8 +554,8 @@ class Admin {
                         $partition_name = "mmcblk0p3";
                     }
                     if (file_exists("/.dockerenv")) {
-                        $elements = explode(separator: "/", string: $filesystem);
-                        $partition_name = end(array: $elements);
+                        $elements = explode("/", $filesystem);
+                        $partition_name = end($elements);
                     }
                     if ($partition_name) {
                         $sectors_read = $this->exec("awk '/$partition_name/ {print $6}' /proc/diskstats");

--- a/Modules/admin/admin_model.php
+++ b/Modules/admin/admin_model.php
@@ -176,7 +176,7 @@ class Admin {
         // Validate service name
         // remove .service from name
         $service_name = str_replace('.service','',$name);
-        if (file_exists("/.dockerenv")) {
+        if (file_exists("/.dockerenv") && file_exists("/opt/openenergymonitor/emoncms_pre.sh")) {
             $container_services = [
                 "emoncms_mqtt",
                 "feedwriter",

--- a/Modules/admin/admin_model.php
+++ b/Modules/admin/admin_model.php
@@ -176,6 +176,24 @@ class Admin {
         // Validate service name
         // remove .service from name
         $service_name = str_replace('.service','',$name);
+        if (file_exists(filename: "/.dockerenv")) {
+            $container_services = [
+                "emoncms_mqtt",
+                "feedwriter",
+                "service-runner",
+                "redis-server",
+                "mosquitto",
+                "emoncms_sync"
+            ];
+            if (in_array(needle: $service_name, haystack: $container_services)) {
+                return [
+                    "LoadState"=>"loaded",
+                    "ActiveState"=>"active",
+                    "SubState"=>"running",
+                    "UnitFileState"=>"container",
+                ];
+            } else return [];
+        }
         if (!in_array($service_name, $this->get_services_list())) {
             return array();
         }
@@ -462,8 +480,13 @@ class Admin {
         // I would have used disk_free_space() and disk_total_space() here but
         // there appears to be no way to get a list of partitions in PHP?
         $output = array();
-        if (!$output = $this->exec_array('df -B 1 -x squashfs')) {
-            return $partitions;
+        if (file_exists(filename: "/.dockerenv")) {
+            //return $partitions;
+            $output = $this->exec_array('df -B 1 /data');
+        } else {
+            if (!$output = $this->exec_array('df -B 1 -x squashfs')) {
+                return $partitions;
+            }
         }
         foreach($output as $line)
         {
@@ -503,11 +526,12 @@ class Admin {
                 $readload = 0;
                 $writeload = 0;
                 $loadtime = 0;
-
-                ob_start();
-                @passthru("iostat -o JSON -k $filesystem");
-                $output = trim(ob_get_clean());
-                $stats = json_decode($output, true);
+                if (!file_exists(filename: "/.dockerenv")) {
+                    ob_start();
+                    @passthru("iostat -o JSON -k $filesystem");
+                    $output = trim(ob_get_clean());
+                    $stats = json_decode($output, true);
+                }
                 if (isset($stats['sysstat']['hosts'][0]['statistics'][0]['disk'][0])) {
                     $disk = $stats['sysstat']['hosts'][0]['statistics'][0]['disk'][0];
                     $partition_name = $disk["disk_device"];
@@ -528,6 +552,10 @@ class Admin {
                         $partition_name = "mmcblk0p3";
                     } elseif ($partition=="/home/pi/data") {
                         $partition_name = "mmcblk0p3";
+                    }
+                    if (file_exists(filename: "/.dockerenv")) {
+                        $elements = explode(separator: "/", string: $filesystem);
+                        $partition_name = end(array: $elements);
                     }
                     if ($partition_name) {
                         $sectors_read = $this->exec("awk '/$partition_name/ {print $6}' /proc/diskstats");
@@ -713,7 +741,11 @@ class Admin {
             $v = "n/a";
         } else {
             if (@file_exists('/usr/sbin/mosquitto')) {
-                $v = $this->exec('/usr/sbin/mosquitto -h | grep -oP \'(?<=mosquitto\sversion\s)[0-9.]+(?=\s*)\'');
+                if (file_exists(filename: "/.dockerenv")) {
+                    $v = $this->exec('/usr/sbin/mosquitto -h | grep version');
+                } else {
+                    $v = $this->exec('/usr/sbin/mosquitto -h | grep -oP \'(?<=mosquitto\sversion\s)[0-9.]+(?=\s*)\'');
+                }
             }
         }
         return $v;

--- a/Modules/admin/admin_model.php
+++ b/Modules/admin/admin_model.php
@@ -176,7 +176,7 @@ class Admin {
         // Validate service name
         // remove .service from name
         $service_name = str_replace('.service','',$name);
-        if (file_exists(filename: "/.dockerenv")) {
+        if (file_exists("/.dockerenv")) {
             $container_services = [
                 "emoncms_mqtt",
                 "feedwriter",


### PR DESCRIPTION
This commits permits the admin module to work friendly in container without having to deal with systemctl commands or df, iostat or grep options (-x squashfs, -o JSON, -oP) that it cannot achieve

![image](https://github.com/user-attachments/assets/b7cff580-ed3f-4259-8d8d-44bb85b40a16)
![image](https://github.com/user-attachments/assets/bd0005ed-af92-470c-a05f-4fbeb2d8bc2a)

Still in containers, this also permits the sync module not to complain not to find emoncms_sync
![image](https://github.com/user-attachments/assets/5a771d83-65d4-4305-a1dd-9bc04ff870ec)
