### PR TITLE
Update .htaccess so that export can take more than 30secs

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -5,6 +5,10 @@
 # Set the default handler.
 DirectoryIndex index.php
 
+<IfModule php_module>
+  php_value max_execution_time 300
+</IfModule>
+
 # Various rewrite rules.
 <IfModule mod_rewrite.c>
   RewriteEngine on


### PR DESCRIPTION
When exporting large feed, the request timeout after default value of 30secs.  This update extend the maximum execution time to 300secs