### PR TITLE
Add .devcontainer to simplify development

### DIFF
--- a/.devcontainer/dev-compose.yaml
+++ b/.devcontainer/dev-compose.yaml
@@ -1,0 +1,32 @@
+services:
+  devcontainer:
+    image: alexjunk/emoncms
+    environment:
+      - TZ=Europe/Paris
+      - EMONCMS_DATADIR=/data/emoncms
+      - REDIS_BUFFER=1
+      - EMONCMS_LOG_LEVEL=2
+      - MYSQL_DATABASE=emoncms
+      - MYSQL_USER=emoncms
+      - MYSQL_PASSWORD=emonpiemoncmsmysql2016
+      - MQTT_USER=emonpi
+      - MQTT_PASSWORD=emonpimqtt2016
+      - MQTT_HOST=localhost
+      - MQTT_BASETOPIC=emon
+      - MQTT_CLIENT_ID=emoncms
+      - MQTT_LOG_LEVEL=error
+      - HTTP_CONF=/etc/apache2/httpd.conf
+      - CRT_FILE=/etc/ssl/apache2/server.pem
+      - KEY_FILE=/etc/ssl/apache2/server.key
+      - CUSTOM_APACHE_CONF=0
+      - USE_HOSTNAME_FOR_MQTT_TOPIC_CLIENTID=0
+      - CNAME=localhost
+    volumes:
+      - data:/data
+      - ../:/var/www/emoncms
+    ports:
+      - 8088:80
+      - 8883:1883
+    restart: always
+volumes:
+  data:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "emoncms_core_dev",
+  "dockerComposeFile": "dev-compose.yaml",
+  "workspaceFolder": "/var/www/emoncms",
+  "shutdownAction": "stopCompose",
+  "service": "devcontainer",
+  "postCreateCommand": ["/bin/sh", "-c", "/bin/sh .devcontainer/setup.sh"],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "devsense.phptools-vscode"
+      ]
+    }
+  }
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env sh
+dev_branch=json_i18n
+cd "$WWW/emoncms"
+git pull
+git checkout $dev_branch
+cd "$OEM_DIR"
+make module name=graph
+make module name=dashboard
+make module name=app 
+make module name=device
+make symodule name=sync
+make symodule name=postprocess
+make symodule name=backup
+cd "$WWW/emoncms/Modules/graph"
+git remote set-url origin https://github.com/emoncms/graph
+git pull
+git checkout $dev_branch
+cd "$WWW/emoncms/Modules/dashboard"
+git remote set-url origin https://github.com/emoncms/dashboard
+git pull
+git checkout $dev_branch
+cd "$WWW/emoncms/Modules/device"
+git remote set-url origin https://github.com/emoncms/device
+git pull
+git checkout $dev_branch
+cd "$EMONCMS_DIR/modules/sync"
+git remote set-url origin https://github.com/emoncms/sync
+git pull
+git checkout $dev_branch
+cd "$EMONCMS_DIR/modules/postprocess"
+git remote set-url origin https://github.com/emoncms/postprocess
+git pull
+git checkout $dev_branch
+cd "$EMONCMS_DIR/modules/backup"
+git remote set-url origin https://github.com/emoncms/backup
+git pull
+git checkout $dev_branch


### PR DESCRIPTION
this is to introduce a development process using vscode and devcontainer

- git clone your emoncms fork on you development machine
- launch vscode
- open your emoncms fork in vscode and reopen in container > emoncms should be accessible locally on port 8088

module per module, you can adapt the url repo once you have a fork of the considered module. Adaptation has to be done in the .devcontainer/setup.sh file. Once adapted, press ctrl+shift+P and rebuild