### PR TITLE
Native email class

### DIFF
--- a/Lib/email.php
+++ b/Lib/email.php
@@ -1,127 +1,443 @@
 <?php
 
-/* A simple helper class for email functions
-
-   Compatible with SwiftMailer v5.4.8
-   Installation:
-
-   git -C /opt/emoncms/modules clone -b 'v5.4.8' --single-branch https://github.com/swiftmailer/swiftmailer.git
-
-   Copy SMTP settings section from default-settings.ini to settings.ini and ammend as necessary
-
+/* A simple email helper class using SMTP via fsockopen
+   
+   This provides more reliable email delivery than mail() function
+   and supports SMTP authentication.
 */
 
 class Email
 {
     private $log;
-    private $have_swift;
-    private $message;
+    private $smtp_settings;
+    private $from_email;
+    private $from_name;
+    private $to;
+    private $cc;
+    private $bcc;
+    private $subject;
+    private $body;
+    private $content_type;
+    private $attachments;
+    private $boundary; // Added missing property
 
-    function __construct()
+    function __construct($smtp_settings = null)
     {
-        global $settings, $linked_modules_dir;
+        global $settings;
         $this->log = new EmonLogger(__FILE__);
+        
+        // Allow dependency injection for better testability
+        $this->smtp_settings = $smtp_settings ?? ($settings['smtp'] ?? []);
+        $this->from_email = $this->smtp_settings['from_email'] ?? '';
+        $this->from_name = $this->smtp_settings['from_name'] ?? '';
+        $this->to = '';
+        $this->cc = '';
+        $this->bcc = '';
+        $this->subject = '';
+        $this->body = '';
+        $this->content_type = 'text/html';
+        $this->attachments = [];
+    }
 
-        $this->message = null;
-        // include SwiftMailer. path from a PEAR install,
-        $this->have_swift = @include_once("swift_required.php");
-        // path from module lib
-        if (!$this->have_swift) {
-            $this->have_swift = @include_once("$linked_modules_dir/swiftmailer/lib/swift_required.php");
-        }
-        if ($this->have_swift) {
-            $this->message = Swift_Message::newInstance();
-            
-            $from = array();
-            $from[$settings['smtp']['from_email']] = $settings['smtp']['from_name'];
-            $this->message->setFrom($from);
-        }
+    // Add email validation
+    private function validateEmail($email)
+    {
+        return filter_var($email, FILTER_VALIDATE_EMAIL) !== false;
+    }
+
+    // Add header sanitization to prevent injection attacks
+    private function sanitizeHeader($header)
+    {
+        return str_replace(["\r", "\n", "\0"], '', $header);
     }
 
     function check()
     {
-        if (!$this->have_swift) {
-            $this->log->error("check() Could not find SwiftMailer, email functions are ignored.");
+        if (!function_exists('fsockopen')) {
+            $this->log->error("check() fsockopen() function is not available.");
             return false;
         }
+        
+        if (empty($this->smtp_settings['host'])) {
+            $this->log->error("check() SMTP host not configured.");
+            return false;
+        }
+        
         return true;
     }
 
     function from($from)
     {
-        if ($this->check()) {
-            $this->message->setFrom($from);
+        if (is_array($from)) {
+            $email = key($from);
+            $name = current($from);
+        } else {
+            $email = $from;
+            $name = '';
         }
+        
+        // Validate email address
+        if (!$this->validateEmail($email)) {
+            throw new InvalidArgumentException("Invalid from email address: $email");
+        }
+        
+        $this->from_email = $email;
+        $this->from_name = $this->sanitizeHeader($name);
     }
 
     function to($to)
     {
-        if ($this->check()) {
-            $this->message->setTo($to);
+        // Validate all email addresses
+        $emails = is_array($to) ? $to : [$to];
+        foreach ($emails as $email) {
+            $cleanEmail = $this->extractEmail($email);
+            if (!$this->validateEmail($cleanEmail)) {
+                throw new InvalidArgumentException("Invalid email address: $email");
+            }
         }
+        $this->to = is_array($to) ? implode(', ', $to) : $to;
     }
     
     function cc($cc)
     {
-        if ($this->check()) {
-            $this->message->setCc($cc);
+        // Validate CC email addresses
+        if (!empty($cc)) {
+            $emails = is_array($cc) ? $cc : [$cc];
+            foreach ($emails as $email) {
+                $cleanEmail = $this->extractEmail($email);
+                if (!$this->validateEmail($cleanEmail)) {
+                    throw new InvalidArgumentException("Invalid CC email address: $email");
+                }
+            }
         }
+        $this->cc = is_array($cc) ? implode(', ', $cc) : $cc;
     }
+    
     function bcc($bcc)
     {
-        if ($this->check()) {
-            $this->message->setBcc($bcc);
+        // Validate BCC email addresses
+        if (!empty($bcc)) {
+            $emails = is_array($bcc) ? $bcc : [$bcc];
+            foreach ($emails as $email) {
+                $cleanEmail = $this->extractEmail($email);
+                if (!$this->validateEmail($cleanEmail)) {
+                    throw new InvalidArgumentException("Invalid BCC email address: $email");
+                }
+            }
         }
+        $this->bcc = is_array($bcc) ? implode(', ', $bcc) : $bcc;
     }
 
     function subject($subject)
     {
-        if ($this->check()) {
-            $this->message->setSubject($subject);
-        }
+        $this->subject = $this->sanitizeHeader($subject);
     }
 
     function body($body, $type = 'text/html')
     {
-        if ($this->check()) {
-            $this->message->setBody($body, $type);
-        }
+        $this->body = $body;
+        $this->content_type = $type;
     }
 
     function attach($filepath, $contentType = null)
     {
-        if ($this->check()) {
-            $this->message->attach(Swift_Attachment::fromPath($filepath, $contentType));
+        if (file_exists($filepath)) {
+            $this->attachments[] = [
+                'path' => $filepath,
+                'type' => $contentType ?: mime_content_type($filepath),
+                'name' => basename($filepath)
+            ];
         }
     }
 
     function send()
     {
-        global $settings;
-        if ($this->check()) {
-            try {
-                if  ($settings['smtp']['sendmail']) {
-                    $transport = Swift_SendmailTransport::newInstance('/usr/sbin/sendmail -bs');
-                } else {
-                    $transport = Swift_SmtpTransport::newInstance($settings['smtp']['host'], $settings['smtp']['port']);
-                    if (isset($settings['smtp']['encryption']) && $settings['smtp']['encryption']) {
-                        $transport->setEncryption($settings['smtp']['encryption']);
-                    }
-                    if (isset($settings['smtp']['username'])) {
-                        $transport->setUsername($settings['smtp']['username']);
-                    }
-                    if (isset($settings['smtp']['password'])) {
-                        $transport->setPassword($settings['smtp']['password']);
-                    }
-                }
-                $mailer = Swift_Mailer::newInstance($transport);
-                $mailer->send($this->message);
-            } catch (Exception $e) {
-                return array('success'=>false, 'message'=>$e->getMessage());
+        if (!$this->check()) {
+            return array('success'=>false, 'message'=>"SMTP configuration invalid.");
+        }
+
+        try {
+            // Use sendmail if configured
+            if (!empty($this->smtp_settings['sendmail'])) {
+                return $this->sendViaSendmail();
+            } else {
+                return $this->sendViaSMTP();
             }
+        } catch (Exception $e) {
+            $this->log->error("Email send failed: " . $e->getMessage());
+            return array('success'=>false, 'message'=>"Failed to send email");
+        }
+    }
+    
+    private function sendViaSendmail()
+    {
+        $headers = $this->buildHeaders();
+        $body = $this->buildBody();
+        
+        $sendmail_path = '/usr/sbin/sendmail -bs';
+        $mail_content = $headers . "\r\n" . $body;
+        
+        $process = popen($sendmail_path, 'w');
+        if (!$process) {
+            return array('success'=>false, 'message'=>"Could not open sendmail process.");
+        }
+        
+        fwrite($process, $mail_content);
+        $result = pclose($process);
+        
+        if ($result === 0) {
             return array('success'=>true, 'message'=>"");
         } else {
-            return array('success'=>false, 'message'=>"Could not find SwiftMailer, email not sent.");
+            return array('success'=>false, 'message'=>"Sendmail returned error code: $result");
         }
+    }
+
+    // Improved SMTP response reading for multi-line responses
+    private function readSMTPResponse($smtp)
+    {
+        $response = '';
+        do {
+            $line = fgets($smtp, 515);
+            if ($line === false) {
+                throw new Exception("Failed to read SMTP response");
+            }
+            $response .= $line;
+            // Continue reading if line starts with "xxx-" (multi-line response)
+        } while (strlen($line) >= 4 && $line[3] === '-');
+        
+        return trim($response);
+    }
+
+    // Improved socket cleanup
+    private function closeSMTP($smtp, $message = "")
+    {
+        if (is_resource($smtp)) {
+            @fwrite($smtp, "QUIT\r\n");
+            @fclose($smtp);
+        }
+        if ($message) {
+            throw new Exception($message);
+        }
+    }
+    
+    private function sendViaSMTP()
+    {
+        $host = $this->smtp_settings['host'];
+        $port = $this->smtp_settings['port'] ?? 25;
+        $username = $this->smtp_settings['username'] ?? '';
+        $password = $this->smtp_settings['password'] ?? '';
+        $encryption = $this->smtp_settings['encryption'] ?? '';
+        $timeout = $this->smtp_settings['timeout'] ?? 30;
+        
+        $smtp = null;
+        
+        try {
+            // Create socket with proper SSL handling
+            $context = stream_context_create();
+            if ($encryption === 'ssl') {
+                $host = 'ssl://' . $host;
+                $port = $port ?: 465;
+            }
+            
+            $smtp = fsockopen($host, $port, $errno, $errstr, $timeout);
+            if (!$smtp) {
+                throw new Exception("Could not connect to SMTP server: $errstr ($errno)");
+            }
+
+            // Set timeout for socket operations
+            stream_set_timeout($smtp, $timeout);
+            
+            // Read server greeting
+            $response = $this->readSMTPResponse($smtp);
+            if (substr($response, 0, 3) !== '220') {
+                $this->closeSMTP($smtp, "SMTP server error: " . substr($response, 0, 50));
+            }
+            
+            // Send EHLO
+            fwrite($smtp, "EHLO " . ($_SERVER['SERVER_NAME'] ?? 'localhost') . "\r\n");
+            $response = $this->readSMTPResponse($smtp);
+            
+            // Start TLS if required
+            if ($encryption === 'tls') {
+                fwrite($smtp, "STARTTLS\r\n");
+                $response = $this->readSMTPResponse($smtp);
+                if (substr($response, 0, 3) !== '220') {
+                    $this->closeSMTP($smtp, "STARTTLS failed");
+                }
+                
+                stream_socket_enable_crypto($smtp, true, STREAM_CRYPTO_METHOD_TLS_CLIENT);
+                
+                // Send EHLO again after TLS
+                fwrite($smtp, "EHLO " . ($_SERVER['SERVER_NAME'] ?? 'localhost') . "\r\n");
+                $response = $this->readSMTPResponse($smtp);
+            }
+            
+            // Authenticate if credentials provided
+            if ($username && $password) {
+                fwrite($smtp, "AUTH LOGIN\r\n");
+                $response = $this->readSMTPResponse($smtp);
+                if (substr($response, 0, 3) !== '334') {
+                    $this->closeSMTP($smtp, "AUTH LOGIN failed");
+                }
+                
+                fwrite($smtp, base64_encode($username) . "\r\n");
+                $response = $this->readSMTPResponse($smtp);
+                if (substr($response, 0, 3) !== '334') {
+                    $this->closeSMTP($smtp, "Username authentication failed");
+                }
+                
+                fwrite($smtp, base64_encode($password) . "\r\n");
+                $response = $this->readSMTPResponse($smtp);
+                if (substr($response, 0, 3) !== '235') {
+                    $this->closeSMTP($smtp, "Password authentication failed");
+                }
+            }
+            
+            // Send MAIL FROM
+            fwrite($smtp, "MAIL FROM: <{$this->from_email}>\r\n");
+            $response = $this->readSMTPResponse($smtp);
+            if (substr($response, 0, 3) !== '250') {
+                $this->closeSMTP($smtp, "MAIL FROM failed");
+            }
+            
+            // Send RCPT TO
+            $recipients = array_merge(
+                $this->parseEmails($this->to),
+                $this->parseEmails($this->cc),
+                $this->parseEmails($this->bcc)
+            );
+            
+            foreach ($recipients as $recipient) {
+                fwrite($smtp, "RCPT TO: <{$recipient}>\r\n");
+                $response = $this->readSMTPResponse($smtp);
+                if (substr($response, 0, 3) !== '250') {
+                    $this->closeSMTP($smtp, "RCPT TO failed for recipient");
+                }
+            }
+            
+            // Send DATA
+            fwrite($smtp, "DATA\r\n");
+            $response = $this->readSMTPResponse($smtp);
+            if (substr($response, 0, 3) !== '354') {
+                $this->closeSMTP($smtp, "DATA command failed");
+            }
+            
+            // Send headers and body
+            $headers = $this->buildHeaders();
+            $body = $this->buildBody();
+            
+            fwrite($smtp, $headers . "\r\n" . $body . "\r\n.\r\n");
+            $response = $this->readSMTPResponse($smtp);
+            if (substr($response, 0, 3) !== '250') {
+                $this->closeSMTP($smtp, "Message sending failed");
+            }
+            
+            // Send QUIT and close
+            $this->closeSMTP($smtp);
+            
+            return array('success'=>true, 'message'=>"Email sent successfully");
+            
+        } catch (Exception $e) {
+            if ($smtp) {
+                $this->closeSMTP($smtp);
+            }
+            throw $e; // Re-throw to be caught by send() method
+        }
+    }
+    
+    private function buildHeaders()
+    {
+        $headers = [];
+        
+        // From header
+        if ($this->from_name) {
+            $headers[] = "From: {$this->from_name} <{$this->from_email}>";
+        } else {
+            $headers[] = "From: {$this->from_email}";
+        }
+        
+        // To, CC, BCC
+        if ($this->to) $headers[] = "To: {$this->to}";
+        if ($this->cc) $headers[] = "Cc: {$this->cc}";
+        // Note: BCC is not included in headers
+        
+        // Subject
+        $headers[] = "Subject: {$this->subject}";
+        
+        // Date
+        $headers[] = "Date: " . date('r');
+        
+        // Message ID
+        $headers[] = "Message-ID: <" . md5(uniqid(time())) . "@" . ($_SERVER['SERVER_NAME'] ?? 'localhost') . ">";
+        
+        // MIME headers
+        $headers[] = "MIME-Version: 1.0";
+        
+        if (empty($this->attachments)) {
+            $headers[] = "Content-Type: {$this->content_type}; charset=UTF-8";
+            $headers[] = "Content-Transfer-Encoding: 8bit";
+        } else {
+            $boundary = md5(time());
+            $headers[] = "Content-Type: multipart/mixed; boundary=\"{$boundary}\"";
+            $this->boundary = $boundary;
+        }
+        
+        return implode("\r\n", $headers);
+    }
+    
+    private function buildBody()
+    {
+        if (empty($this->attachments)) {
+            return $this->body;
+        }
+        
+        $boundary = $this->boundary;
+        $body = "--{$boundary}\r\n";
+        $body .= "Content-Type: {$this->content_type}; charset=UTF-8\r\n";
+        $body .= "Content-Transfer-Encoding: 8bit\r\n\r\n";
+        $body .= $this->body . "\r\n";
+        
+        foreach ($this->attachments as $attachment) {
+            $content = base64_encode(file_get_contents($attachment['path']));
+            
+            $body .= "--{$boundary}\r\n";
+            $body .= "Content-Type: {$attachment['type']}; name=\"{$attachment['name']}\"\r\n";
+            $body .= "Content-Transfer-Encoding: base64\r\n";
+            $body .= "Content-Disposition: attachment; filename=\"{$attachment['name']}\"\r\n\r\n";
+            $body .= chunk_split($content) . "\r\n";
+        }
+        
+        $body .= "--{$boundary}--\r\n";
+        
+        return $body;
+    }
+
+    // Helper method to extract email from "Name <email>" format
+    private function extractEmail($emailString)
+    {
+        if (preg_match('/<([^>]+)>/', $emailString, $matches)) {
+            return trim($matches[1]);
+        }
+        return trim($emailString);
+    }
+    
+    private function parseEmails($emailString)
+    {
+        if (empty($emailString)) return [];
+        
+        $emails = explode(',', $emailString);
+        $result = [];
+        
+        foreach ($emails as $email) {
+            $email = trim($email);
+            // Extract email from "Name <email@domain.com>" format
+            if (preg_match('/<([^>]+)>/', $email, $matches)) {
+                $result[] = $matches[1];
+            } else {
+                $result[] = $email;
+            }
+        }
+        
+        return $result;
     }
 }

--- a/default-settings.ini
+++ b/default-settings.ini
@@ -191,8 +191,6 @@ action = "view"
 
 
 ; (OPTIONAL) Email SMTP, used for password reset or other email functions
-; Requires SwiftMailer v5.4.8, To install:
-; git -C /opt/emoncms/modules clone -b 'v5.4.8' --single-branch https://github.com/swiftmailer/swiftmailer.git
 [smtp]
 ; Email address to email proccessed input values
 default_emailto = ''

--- a/docs/design/developing-a-new-module.md
+++ b/docs/design/developing-a-new-module.md
@@ -133,7 +133,7 @@ The **MySQL** database can be accessed with the global variable `$mysqli`. It is
 In order to use this database, REDIS must be installed inn the server. For Linux users go to your terminal:
 ```
 sudo apt-get install redis-server
-sudo pecl install channel://pecl.php.net/dio-0.0.6 redis swift/swift
+sudo pecl install channel://pecl.php.net/dio-0.0.6 redis
 sudo sh -c 'echo "extension=redis.so" > /etc/php5/apache2/conf.d/20-redis.ini'
 sudo sh -c 'echo "extension=redis.so" > /etc/php5/cli/conf.d/20-redis.ini'
 ```

--- a/example.settings.ini
+++ b/example.settings.ini
@@ -53,8 +53,6 @@ feedviewpath = "graph/"
 [public_profile]
 
 ; Emailer
-; Requires SwiftMailer v5.4.8, To install:
-; git -C /opt/emoncms/modules clone -b 'v5.4.8' --single-branch https://github.com/swiftmailer/swiftmailer.git
 [smtp]
 ; Email address to email proccessed input values
 ;default_emailto = 'root@localhost'

--- a/scripts/examples/send_email_test.php
+++ b/scripts/examples/send_email_test.php
@@ -1,0 +1,62 @@
+<?php
+/*
+    All Emoncms code is released under the GNU Affero General Public License.
+    See COPYRIGHT.txt and LICENSE.txt.
+
+    ---------------------------------------------------------------------
+    Emoncms - open source energy visualisation
+    Part of the OpenEnergyMonitor project:
+    http://openenergymonitor.org
+
+    This script is a test for sending emails from the Emoncms CLI.
+    It uses the SMTP settings defined in the settings.ini file.
+    To run this script, use the command:
+
+    php scripts/examples/send_email_test.php
+
+    Make sure to configure the SMTP settings in settings.ini before running.
+
+    Add the following to your settings.ini file:
+
+    [smtp]
+    default_emailto = 'Your email to test'
+    host = "smpt.emailprovider.com"
+    port = 465
+    from_email = 'hello@myemail.com'
+    from_name = 'Emoncms'
+    encryption = "ssl"
+    username = "hello@myemail.com"
+    password = "PASSWORD"
+
+*/
+
+// CLI only
+if (php_sapi_name() !== 'cli') {
+    echo "This script is for CLI use only.\n";
+    die;
+}
+
+// Required 
+define('EMONCMS_EXEC', 1);
+
+// Change to the emoncms root directory
+chdir(dirname(__FILE__)."/../../");
+
+// Load email settings
+require "process_settings.php";
+require "Lib/EmonLogger.php";
+$log = new EmonLogger(__FILE__);
+
+$email = $settings['smtp']['default_emailto'];
+
+require "Lib/email.php";
+$emailer = new Email();
+$emailer->to(array($email));
+$emailer->subject("Email test example from Emoncms CLI script");
+$emailer->body("<p>This is a test email sent from the Emoncms CLI script.</p><p>If you received this email, it means that the email configuration is working correctly.</p>");
+$result = $emailer->send();
+if (!$result['success']) {
+    print "Email send returned error. emailto=" . $email . " message='" . $result['message'] . "'\n";
+} else {
+    print "Email sent successfully to $email\n";
+}


### PR DESCRIPTION
Native email class thanks to Claude and Copilot to fix:

- https://github.com/emoncms/emoncms/issues/1859
- https://github.com/emoncms/emoncms/issues/1843

Why native, it's not that much code, it reduces dependencies, use of email in emoncms is minimal, advanced email features are not required. 

I'd also like to add the option to use a transactional email service in place of smtp here but that can wait to a separate development. (e.g open source postal or cuttlefish, and perhaps plunk for hosted but still open source https://www.useplunk.com/) 