### PR TITLE
Fix logging millisecond timestamps so they correctly show positive numbers

### DIFF
--- a/Lib/EmonLogger.php
+++ b/Lib/EmonLogger.php
@@ -94,7 +94,7 @@ class EmonLogger
         }
 
         $now = microtime(true);
-        $micro = sprintf("%03d", ($now - round($now,0,PHP_ROUND_HALF_DOWN)) * 1000);
+        $micro = sprintf("%03d", ($now - intval($now)) * 1000 );
         $now = DateTime::createFromFormat('U', (int)$now); // Only use UTC for logs
         $now = $now->format("Y-m-d H:i:s").".$micro";
         // Clear log file if more than 256MB (temporary solution)


### PR DESCRIPTION
Fix logging millisecond timestamps so they correctly show positive numbers:

2026-01-01 03:51:10.952|WARN|emonc
2026-01-01 03:57:11.207|WARN|emonc

rather than negative numbers eg:
2025-12-31 13:11:11.474|WARN|emonc
2025-12-31 13:11:11.-480|WARN|emon