### PR TITLE
Hardening: whitelist for service runner

### DIFF
--- a/Modules/admin/components/ComponentsModel.php
+++ b/Modules/admin/components/ComponentsModel.php
@@ -140,8 +140,7 @@ class ComponentsModel
             }
         }
 
-        $script = $this->settings['openenergymonitor_dir'] . "/EmonScripts/update/update_component.sh";
-        return $this->runService($script, escapeshellarg($module_path) . " " . escapeshellarg($branch) . ">" . $this->update_logfile);
+        return $this->pushAction("component-update", [$module_path, $branch], "update");
     }
 
     public function update_all_components($branch)
@@ -159,26 +158,22 @@ class ComponentsModel
             return array('success' => false, 'message' => "Invalid branch");
         }
 
-        $script = $this->settings['openenergymonitor_dir'] . "/EmonScripts/update/update_all_components.sh";
-        return $this->runService($script, escapeshellarg($branch) . ">" . $this->update_logfile);
+        return $this->pushAction("components-update", [$branch], "update");
     }
 
     // -------------------------------------------------------------------------
     // Private helpers
     // -------------------------------------------------------------------------
 
-    private function runService($script, $attributes)
+    private function pushAction(string $action, array $args, ?string $log = null): array
     {
-        if (!file_exists($script)) {
-            $this->log->error("ComponentsModel::runService() Script not found '$script' attributes=$attributes");
-            return array('success' => false, 'message' => "File not found '$script'");
-        }
         if ($this->redis) {
-            $this->redis->rpush("service-runner", "$script $attributes");
-            $this->log->info("ComponentsModel::runService() service-runner trigger sent for '$script $attributes'");
-            return array('success' => true, 'message' => "service-runner trigger sent for '$script $attributes'");
+            $payload = json_encode(['run' => $action, 'args' => $args, 'log' => $log]);
+            $this->redis->rpush("service-runner", $payload);
+            $this->log->info("ComponentsModel::pushAction() service-runner trigger sent for action '$action'");
+            return array('success' => true, 'message' => "service-runner trigger sent for action '$action'");
         } else {
-            $this->log->error("ComponentsModel::runService() Redis not enabled. Cannot execute '$script $attributes' safely.");
+            $this->log->error("ComponentsModel::pushAction() Redis not enabled. Cannot execute action '$action' safely.");
             return array('success' => false, 'message' => "Redis is required to run service commands");
         }
     }

--- a/Modules/admin/info/ServiceModel.php
+++ b/Modules/admin/info/ServiceModel.php
@@ -84,29 +84,22 @@ class ServiceModel
 			return array('success' => false, 'message' => "Invalid service '$service_name'");
 		}
 
-		$script = __DIR__ . '/../../../scripts/service-action.sh';
-		return $this->runService($script, "$name $action");
+		return $this->pushAction("service-action", [$name, $action]);
 	}
 
-	public function runService($script, $attributes)
+	private function pushAction(string $action, array $args, ?string $log = null): array
 	{
-		if (!file_exists($script)) {
-			if ($this->log) {
-				$this->log->error("runService() Script not found '$script' attributes=$attributes");
-			}
-			return array('success' => false, 'message' => "Service action script not found");
-		}
-
 		if ($this->redis) {
-			$this->redis->rpush('service-runner', "$script $attributes");
+			$payload = json_encode(['run' => $action, 'args' => $args, 'log' => $log]);
+			$this->redis->rpush('service-runner', $payload);
 			if ($this->log) {
-				$this->log->info("runService() service-runner trigger sent for '$script $attributes'");
+				$this->log->info("ServiceModel::pushAction() service-runner trigger sent for action '$action'");
 			}
-			return array('success' => true, 'message' => "service-runner trigger sent for '$script $attributes'");
+			return array('success' => true, 'message' => "service-runner trigger sent for action '$action'");
 		}
 
 		if ($this->log) {
-			$this->log->error("runService() Redis not enabled. Cannot execute '$script $attributes' safely.");
+			$this->log->error("ServiceModel::pushAction() Redis not enabled. Cannot execute action '$action' safely.");
 		}
 		return array('success' => false, 'message' => 'Redis is required to run service commands');
 	}

--- a/Modules/admin/serial/SerialModel.php
+++ b/Modules/admin/serial/SerialModel.php
@@ -54,8 +54,7 @@ class SerialModel
         if (!in_array($baudrate, array(9600, 38400, 115200))) {
             return array('success' => false, 'message' => "invalid baud rate");
         }
-        $script = "/var/www/emoncms/scripts/serialmonitor/start.sh";
-        return $this->runService($script, escapeshellarg($baudrate) . " /dev/" . escapeshellarg($serialport));
+        return $this->pushAction("serialmonitor-start", [(string)$baudrate, "/dev/" . $serialport]);
     }
 
     public function stop()
@@ -83,18 +82,15 @@ class SerialModel
         return array('success' => true, 'message' => "serialmonitor cmd sent");
     }
 
-    private function runService($script, $attributes)
+    private function pushAction(string $action, array $args, ?string $log = null): array
     {
-        if (!file_exists($script)) {
-            $this->log->error("SerialModel::runService() Script not found '$script' attributes=$attributes");
-            return array('success' => false, 'message' => "File not found '$script'");
-        }
         if ($this->redis) {
-            $this->redis->rpush("service-runner", "$script $attributes");
-            $this->log->info("SerialModel::runService() service-runner trigger sent for '$script $attributes'");
-            return array('success' => true, 'message' => "service-runner trigger sent for '$script $attributes'");
+            $payload = json_encode(['run' => $action, 'args' => $args, 'log' => $log]);
+            $this->redis->rpush("service-runner", $payload);
+            $this->log->info("SerialModel::pushAction() service-runner trigger sent for action '$action'");
+            return array('success' => true, 'message' => "service-runner trigger sent for action '$action'");
         } else {
-            $this->log->error("SerialModel::runService() Redis not enabled. Cannot execute '$script $attributes' safely.");
+            $this->log->error("SerialModel::pushAction() Redis not enabled. Cannot execute action '$action' safely.");
             return array('success' => false, 'message' => "Redis is required to run service commands");
         }
     }

--- a/Modules/admin/update/UpdateModel.php
+++ b/Modules/admin/update/UpdateModel.php
@@ -89,18 +89,11 @@ class UpdateModel
             return array('success' => false, 'message' => "Invalid firmware");
         }
 
-        if (file_exists($this->settings['openenergymonitor_dir'] . "/EmonScripts")) {
-            $script = $this->settings['openenergymonitor_dir'] . "/EmonScripts/update/service-runner-update.sh";
-        } else {
-            $script = $this->settings['openenergymonitor_dir'] . "/emonpi/service-runner-update.sh";
-        }
+        $action = file_exists($this->settings['openenergymonitor_dir'] . "/EmonScripts")
+            ? "emoncms-update"
+            : "emoncms-update-legacy";
 
-        return $this->runService($script,
-            escapeshellarg($type) . " " .
-            escapeshellarg($firmware_key) . " " .
-            escapeshellarg($serial_port) . ">" .
-            $this->update_logfile
-        );
+        return $this->pushAction($action, [$type, $firmware_key, $serial_port], "update");
     }
 
     public function update_firmware($serial_port, $firmware_key)
@@ -113,12 +106,7 @@ class UpdateModel
             return array('success' => false, 'message' => "Invalid firmware");
         }
 
-        $script = $this->settings['openenergymonitor_dir'] . "/EmonScripts/update/atmega_firmware_upload.sh";
-        return $this->runService($script,
-            escapeshellarg($serial_port) . " " .
-            escapeshellarg($firmware_key) . ">" .
-            $this->update_logfile
-        );
+        return $this->pushAction("firmware-upload", [$serial_port, $firmware_key], "update");
     }
 
     public function upload_custom_firmware($port, $baud_rate, $core, $autoreset, $file)
@@ -159,15 +147,7 @@ class UpdateModel
             return array('success' => false, 'message' => "Failed to save uploaded firmware file");
         }
 
-        $script = $this->settings['openenergymonitor_dir'] . "/EmonScripts/update/atmega_firmware_upload.sh";
-        return $this->runService($script,
-            escapeshellarg($port) . " custom " .
-            escapeshellarg($safe_filename) . " " .
-            escapeshellarg($baud_rate) . " " .
-            escapeshellarg($core) . " " .
-            escapeshellarg($autoreset) . ">" .
-            $this->update_logfile
-        );
+        return $this->pushAction("firmware-upload", [$port, "custom", $safe_filename, (string)$baud_rate, $core, $autoreset], "update");
     }
 
     // -------------------------------------------------------------------------
@@ -220,18 +200,15 @@ class UpdateModel
     // Private helpers
     // -------------------------------------------------------------------------
 
-    private function runService($script, $attributes)
+    private function pushAction(string $action, array $args, ?string $log = null): array
     {
-        if (!file_exists($script)) {
-            $this->log->error("UpdateModel::runService() Script not found '$script' attributes=$attributes");
-            return array('success' => false, 'message' => "File not found '$script'");
-        }
         if ($this->redis) {
-            $this->redis->rpush("service-runner", "$script $attributes");
-            $this->log->info("UpdateModel::runService() service-runner trigger sent for '$script $attributes'");
-            return array('success' => true, 'message' => "service-runner trigger sent for '$script $attributes'");
+            $payload = json_encode(['run' => $action, 'args' => $args, 'log' => $log]);
+            $this->redis->rpush("service-runner", $payload);
+            $this->log->info("UpdateModel::pushAction() service-runner trigger sent for action '$action'");
+            return array('success' => true, 'message' => "service-runner trigger sent for action '$action'");
         } else {
-            $this->log->error("UpdateModel::runService() Redis not enabled. Cannot execute '$script $attributes' safely.");
+            $this->log->error("UpdateModel::pushAction() Redis not enabled. Cannot execute action '$action' safely.");
             return array('success' => false, 'message' => "Redis is required to run service commands");
         }
     }

--- a/scripts/services/service-runner/service-runner.py
+++ b/scripts/services/service-runner/service-runner.py
@@ -33,11 +33,15 @@ SCRIPT_WHITELIST = {
     "components-update":     f"{_EMON_DIR}/EmonScripts/update/update_all_components.sh",
     "service-action":        f"{_EMONCMS_DIR}/scripts/service-action.sh",
     "serialmonitor-start":   f"{_EMONCMS_DIR}/scripts/serialmonitor/start.sh",
+    "sync-run":              "/opt/emoncms/modules/sync/emoncms-sync.sh",
+    "postprocess-run":       "/opt/emoncms/modules/postprocess/postprocess.sh",
 }
 
 # Hardcoded whitelist: log name -> absolute log file path.
 LOG_WHITELIST = {
     "update": f"{_LOG_DIR}/update.log",
+    "sync":        f"{_LOG_DIR}/sync.log",
+    "postprocess": f"{_LOG_DIR}/postprocess.log",
 }
 
 _EXPECTED_ARG_COUNT = {
@@ -49,6 +53,8 @@ _EXPECTED_ARG_COUNT = {
     "components-update":     1,    # e.g. ["stable"]
     "service-action":        2,    # e.g. ["emonhub.service", "restart"]
     "serialmonitor-start":   2,    # e.g. ["115200", "/dev/ttyUSB0"]
+    "sync-run":              0,    # no args
+    "postprocess-run":       0,    # no args
 }
 
 def _validate_args(action: str, args: list) -> bool:

--- a/scripts/services/service-runner/service-runner.py
+++ b/scripts/services/service-runner/service-runner.py
@@ -1,21 +1,67 @@
 #!/usr/bin/env python3
 
-## Used to run arbitrary commands from the EmonCMS web interface
-# EmonCMS submits commands to redis where this service picks them up
+## Used to run allowed commands from the EmonCMS web interface via a hardcoded whitelist.
+# EmonCMS submits action codes (JSON) to redis where this service picks them up
+# and maps them to pre-approved scripts. No arbitrary script execution is permitted.
 # Used in conjunction with:
 # - Admin module to run service-runner-update.sh
-# - Backup module
-# - Others??
+# - Serial monitor
+# - Others
 
 # Patched in emoncms-docker: default redis.Redis() uses localhost; Docker Compose uses hostname `redis`.
 
+import json
 import os
 import subprocess
 import time
-import shlex
 import redis
 
 KEYS = ["service-runner", "emoncms:service-runner"]
+
+# Base directories — override via environment variables when needed
+_EMON_DIR    = os.environ.get("OPENENERGYMONITOR_DIR", "/opt/openenergymonitor")
+_EMONCMS_DIR = os.environ.get("EMONCMS_DIR", "/var/www/emoncms")
+_LOG_DIR     = os.environ.get("EMONCMS_LOG_DIR", "/var/log/emoncms")
+
+# Hardcoded whitelist: action code -> absolute script path.
+# Only actions listed here can be executed; any unknown action is rejected.
+SCRIPT_WHITELIST = {
+    "emoncms-update":        f"{_EMON_DIR}/EmonScripts/update/service-runner-update.sh",
+    "emoncms-update-legacy": f"{_EMON_DIR}/emonpi/service-runner-update.sh",
+    "firmware-upload":       f"{_EMON_DIR}/EmonScripts/update/atmega_firmware_upload.sh",
+    "component-update":      f"{_EMON_DIR}/EmonScripts/update/update_component.sh",
+    "components-update":     f"{_EMON_DIR}/EmonScripts/update/update_all_components.sh",
+    "service-action":        f"{_EMONCMS_DIR}/scripts/service-action.sh",
+    "serialmonitor-start":   f"{_EMONCMS_DIR}/scripts/serialmonitor/start.sh",
+}
+
+# Hardcoded whitelist: log name -> absolute log file path.
+LOG_WHITELIST = {
+    "update": f"{_LOG_DIR}/update.log",
+}
+
+_EXPECTED_ARG_COUNT = {
+    "emoncms-update":        3,    # e.g. ["all", "emonpi-2022", "/dev/ttyUSB0"]
+    "emoncms-update-legacy": 3,    # e.g. ["emoncms", "none", "/dev/ttyAMA0"]
+    "firmware-upload":       None, # e.g. ["/dev/ttyUSB0", "emonpi-2022"]
+                                   #   or ["/dev/ttyUSB0", "custom", "firmware_abc.hex", "115200", "avr", "autoreset"]
+    "component-update":      2,    # e.g. ["/opt/openenergymonitor/EmonScripts", "master"]
+    "components-update":     1,    # e.g. ["stable"]
+    "service-action":        2,    # e.g. ["emonhub.service", "restart"]
+    "serialmonitor-start":   2,    # e.g. ["115200", "/dev/ttyUSB0"]
+}
+
+def _validate_args(action: str, args: list) -> bool:
+    """Check structural constraints only — content validation is left to the scripts."""
+    # Reject any arg containing a null byte
+    if any("\x00" in a for a in args):
+        return False
+    if action == "firmware-upload":
+        return len(args) in (2, 6)
+    expected = _EXPECTED_ARG_COUNT.get(action)
+    if expected is None:
+        return False
+    return len(args) == expected
 
 
 def _redis_client():
@@ -42,39 +88,68 @@ def main():
     server = connect_redis()
     while True:
         try:
-            # Get the next item from the 'service-runner' list, blocking until one exists
+            # Get the next item from the queue, blocking until one exists
             packed = server.blpop(KEYS)
             if not packed:
                 continue
-            flag = packed[1].decode()
+            raw = packed[1].decode()
         except redis.exceptions.ConnectionError:
             print("Connection to redis server lost, attempting to reconnect", flush=True)
             server = connect_redis()
             continue
 
-        print("Got flag:", flag, flush=True)
-        if ">" in flag:
-            script, logfile = flag.split(">")
-            print("STARTING:", script, '&>', logfile, flush=True)
-            # Got a cmdline, now run it.
-            with open(logfile, "w") as f:
-                try:
-                    subprocess.call(shlex.split(script), stdout=f, stderr=f)
-                except Exception as exc:
-                    # If an error occurs running the subprocess, add the error to
-                    # the specified logfile
-                    f.write("Error running [%s]" % script)
-                    f.write("Exception occurred: %s" % exc)
-                    continue
-        else:
-            script = flag
-            print("STARTING:", script, flush=True)
+        print("Got message:", raw, flush=True)
+
+        try:
+            payload  = json.loads(raw)
+            action   = payload.get("run")
+            args     = payload.get("args", [])
+            log_name = payload.get("log")
+        except (json.JSONDecodeError, AttributeError) as exc:
+            print(f"REJECTED: invalid JSON payload - {exc}", flush=True)
+            continue
+
+        if not isinstance(action, str) or action not in SCRIPT_WHITELIST:
+            print(f"REJECTED: unknown action '{action}'", flush=True)
+            continue
+
+        if not isinstance(args, list) or not all(isinstance(a, str) for a in args):
+            print("REJECTED: args must be a list of strings", flush=True)
+            continue
+
+        if not _validate_args(action, args):
+            print(f"REJECTED: invalid args for action '{action}': {args}", flush=True)
+            continue
+
+        script = SCRIPT_WHITELIST[action]
+        cmd = [script] + args
+
+        print(f"STARTING: {action} -> {script} {args}", flush=True)
+
+        if log_name is not None:
+            if log_name not in LOG_WHITELIST:
+                print(f"REJECTED: unknown log name '{log_name}'", flush=True)
+                continue
+            logfile = LOG_WHITELIST[log_name]
             try:
-                subprocess.call(shlex.split(script), stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+                with open(logfile, "w") as f:
+                    subprocess.call(cmd, stdout=f, stderr=f)
             except Exception as exc:
+                print(f"Error running action '{action}': {exc}", flush=True)
+                try:
+                    with open(logfile, "a") as f:
+                        f.write(f"Error running action '{action}': {exc}\n")
+                except Exception:
+                    pass
+                continue
+        else:
+            try:
+                subprocess.call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+            except Exception as exc:
+                print(f"Error running action '{action}': {exc}", flush=True)
                 continue
 
-        print("COMPLETE:", script, flush=True)
+        print(f"COMPLETE: {action}", flush=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR proposes replacing the free-form string protocol with a structured JSON payload and a server-side whitelist:

```json
{"run": "emoncms-update", "args": ["all", "none", "/dev/ttyUSB0"], "log": "update"}
```

- The daemon maps symbolic action codes to hardcoded absolute script paths — no script path crosses the Redis boundary
- Log destinations are resolved from a hardcoded `LOG_WHITELIST` — no longer caller-controlled
- Unknown actions, unknown log names, wrong arg counts, and non-string args are hard-rejected
- The four PHP models (`UpdateModel`, `ComponentsModel`, `ServiceModel`, `SerialModel`) are updated to push JSON action codes instead of constructing script path strings